### PR TITLE
build: bump SUI version in test.yml to 1.66.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ permissions:
   pull-requests: write
 
 env:
-  SUI_VERSION: "1.65.2"
+  SUI_VERSION: "1.66.2"
 
 jobs:
   setup:


### PR DESCRIPTION
This is what's used in [Published.toml](https://github.com/OpenZeppelin/contracts-sui/blob/634348fbf9c43497866e9a7905aaba773e44dbef/math/core/Published.toml)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI testing environment version for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->