### PR TITLE
fix: add EDivideByZero guard to fixed-point div/mod

### DIFF
--- a/math/fixed_point/sources/sd29x9/sd29x9_base.move
+++ b/math/fixed_point/sources/sd29x9/sd29x9_base.move
@@ -23,6 +23,10 @@ const EOverflow: vector<u8> = "Value overflows SD29x9 (must fit in 2^127 signed 
 #[error(code = 1)]
 const ECannotBeConvertedToUD30x9: vector<u8> = "Value cannot be converted to UD30x9";
 
+/// Divisor must be non-zero
+#[error(code = 2)]
+const EDivideByZero: vector<u8> = "Divisor must be non-zero";
+
 // === Conversion ===
 
 /// Converts a `SD29x9` value to a `UD30x9` value.
@@ -269,8 +273,9 @@ public fun lte(x: SD29x9, y: SD29x9): bool {
 /// - Returns `0` when `x` is an exact multiple of `y`.
 ///
 /// #### Aborts
-/// - Aborts if `y` is zero.
+/// - `EDivideByZero` if `y` is zero.
 public fun mod(x: SD29x9, y: SD29x9): SD29x9 {
+    assert!(y.unwrap() != 0, EDivideByZero);
     let x = decompose(x.unwrap());
     let y = decompose(y.unwrap());
     let remainder = x.mag % y.mag;
@@ -307,9 +312,10 @@ public fun mul(x: SD29x9, y: SD29x9): SD29x9 {
 /// - The division result `x / y`.
 ///
 /// #### Aborts
-/// - Aborts if `y` is zero.
+/// - `EDivideByZero` if `y` is zero.
 /// - Aborts if the resulting magnitude exceeds the representable `SD29x9` range.
 public fun div(x: SD29x9, y: SD29x9): SD29x9 {
+    assert!(y.unwrap() != 0, EDivideByZero);
     let x = decompose(x.unwrap());
     let y = decompose(y.unwrap());
     let neg = x.neg != y.neg;

--- a/math/fixed_point/sources/ud30x9/ud30x9_base.move
+++ b/math/fixed_point/sources/ud30x9/ud30x9_base.move
@@ -20,6 +20,10 @@ const EOverflow: vector<u8> = "Value overflows UD30x9 (must fit in 2^128 unsigne
 #[error(code = 1)]
 const ECannotBeConvertedToSD29x9: vector<u8> = "Value cannot be converted to SD29x9";
 
+/// Divisor must be non-zero
+#[error(code = 2)]
+const EDivideByZero: vector<u8> = "Divisor must be non-zero";
+
 // === Conversion ===
 
 /// Converts a `UD30x9` value to a `SD29x9` value.
@@ -244,8 +248,9 @@ public fun lte(x: UD30x9, y: UD30x9): bool {
 /// - The remainder of `x` divided by `y`.
 ///
 /// #### Aborts
-/// - Aborts if `y` is zero.
+/// - `EDivideByZero` if `y` is zero.
 public fun mod(x: UD30x9, y: UD30x9): UD30x9 {
+    assert!(y.unwrap() != 0, EDivideByZero);
     wrap(x.unwrap() % y.unwrap())
 }
 
@@ -282,9 +287,10 @@ public fun mul(x: UD30x9, y: UD30x9): UD30x9 {
 /// - The quotient `x / y`, rounded down to the nearest representable `UD30x9` value.
 ///
 /// #### Aborts
-/// - Aborts if `y` is zero.
+/// - `EDivideByZero` if `y` is zero.
 /// - Aborts if the resulting value exceeds the representable `UD30x9` range.
 public fun div(x: UD30x9, y: UD30x9): UD30x9 {
+    assert!(y.unwrap() != 0, EDivideByZero);
     let (x, y) = (x.unwrap() as u256, y.unwrap() as u256);
     let numerator = x * SCALE_U256;
     wrap_u256(numerator / y)

--- a/math/fixed_point/tests/sd29x9_tests/div_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/div_tests.move
@@ -41,7 +41,7 @@ fun div_handles_min_over_one() {
     expect(sd29x9::min().div(pos(SCALE)), sd29x9::min());
 }
 
-#[test, expected_failure(arithmetic_error, location = openzeppelin_fp_math::sd29x9_base)]
+#[test, expected_failure(abort_code = sd29x9_base::EDivideByZero)]
 fun div_by_zero_aborts() {
     pos(10 * SCALE).div(sd29x9::zero());
 }

--- a/math/fixed_point/tests/sd29x9_tests/mod_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/mod_tests.move
@@ -2,6 +2,7 @@
 module openzeppelin_fp_math::sd29x9_mod_tests;
 
 use openzeppelin_fp_math::sd29x9;
+use openzeppelin_fp_math::sd29x9_base;
 use openzeppelin_fp_math::sd29x9_test_helpers::{pos, neg, expect};
 
 const SCALE: u128 = 1_000_000_000;
@@ -13,7 +14,7 @@ fun mod_tracks_dividend_sign() {
     expect(pos(42 * SCALE).mod(neg(21 * SCALE)), sd29x9::zero());
 }
 
-#[test, expected_failure(arithmetic_error, location = openzeppelin_fp_math::sd29x9_base)]
+#[test, expected_failure(abort_code = sd29x9_base::EDivideByZero)]
 fun mod_with_zero_modulus_aborts() {
     pos(10).mod(sd29x9::zero());
 }

--- a/math/fixed_point/tests/ud30x9_tests/arithmetic_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/arithmetic_tests.move
@@ -33,7 +33,7 @@ fun checked_sub_underflow_aborts_as_expected() {
     fixed(0).sub(fixed(1));
 }
 
-#[test, expected_failure(arithmetic_error, location = openzeppelin_fp_math::ud30x9_base)]
+#[test, expected_failure(abort_code = ud30x9_base::EDivideByZero)]
 fun modulo_with_zero_divisor_aborts() {
     fixed(10).mod(fixed(0));
 }

--- a/math/fixed_point/tests/ud30x9_tests/div_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/div_tests.move
@@ -44,7 +44,7 @@ fun div_handles_extreme_but_valid_inputs() {
     expect(ud30x9::max().div(ud30x9::max()), fixed(SCALE));
 }
 
-#[test, expected_failure(arithmetic_error, location = openzeppelin_fp_math::ud30x9_base)]
+#[test, expected_failure(abort_code = ud30x9_base::EDivideByZero)]
 fun div_by_zero_aborts() {
     fixed(10 * SCALE).div(fixed(0));
 }


### PR DESCRIPTION
Resolves #262

## Description

The `div()` and `mod()` functions in `ud30x9_base` and `sd29x9_base` relied on the Move VM's opaque arithmetic abort for division by zero. The core math module (`macros.move`, `u512.move`) consistently uses explicit `assert!(denominator != 0, EDivideByZero)` with the descriptive message `"Divisor must be non-zero"`.

This PR adds the same pattern to the fixed-point modules for consistency and better debuggability for integrators.

### Changes

**Source (4 functions across 2 files):**
- `ud30x9_base.move`: Add `EDivideByZero` error constant and assert guard to `div()` and `mod()`
- `sd29x9_base.move`: Add `EDivideByZero` error constant and assert guard to `div()` and `mod()`

**Tests (4 tests across 4 files):**
- Update `expected_failure` annotations from `arithmetic_error` to `abort_code = *_base::EDivideByZero`
- Add missing `sd29x9_base` import to `mod_tests.move`

**Docs:**
- Update `#### Aborts` sections to reference `EDivideByZero` by name, matching core math module style

## PR Checklist

- [x] Tests
- [x] Documentation
- [ ] Changelog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in fixed-point arithmetic operations with explicit zero divisor checks that now abort with a specific error code, preventing undefined behavior and providing clearer feedback when attempting division or modulo by zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->