### PR TITLE
test: change expect helper function into macro

### DIFF
--- a/math/fixed_point/tests/sd29x9_tests/abs_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/abs_tests.move
@@ -11,53 +11,53 @@ const SCALE: u128 = 1_000_000_000;
 #[test]
 fun abs_preserves_positive_values() {
     // 5.0 -> 5.0
-    expect(pos(5 * SCALE).abs(), pos(5 * SCALE));
+    expect!(pos(5 * SCALE).abs(), pos(5 * SCALE));
     // 5.5 -> 5.5
-    expect(pos(5 * SCALE + 500_000_000).abs(), pos(5 * SCALE + 500_000_000));
+    expect!(pos(5 * SCALE + 500_000_000).abs(), pos(5 * SCALE + 500_000_000));
     // 0.1 -> 0.1
-    expect(pos(100_000_000).abs(), pos(100_000_000));
+    expect!(pos(100_000_000).abs(), pos(100_000_000));
 }
 
 #[test]
 fun abs_converts_negative_to_positive() {
     // -5.0 -> 5.0
-    expect(neg(5 * SCALE).abs(), pos(5 * SCALE));
+    expect!(neg(5 * SCALE).abs(), pos(5 * SCALE));
     // -5.5 -> 5.5
-    expect(neg(5 * SCALE + 500_000_000).abs(), pos(5 * SCALE + 500_000_000));
+    expect!(neg(5 * SCALE + 500_000_000).abs(), pos(5 * SCALE + 500_000_000));
     // -0.1 -> 0.1
-    expect(neg(100_000_000).abs(), pos(100_000_000));
+    expect!(neg(100_000_000).abs(), pos(100_000_000));
     // -1.0 -> 1.0
-    expect(neg(SCALE).abs(), pos(SCALE));
+    expect!(neg(SCALE).abs(), pos(SCALE));
 }
 
 #[test]
 fun abs_handles_zero() {
     // 0.0 -> 0.0
-    expect(sd29x9::zero().abs(), sd29x9::zero());
+    expect!(sd29x9::zero().abs(), sd29x9::zero());
 }
 
 #[test]
 fun abs_handles_edge_cases() {
     // Very small positive: 0.000000001 -> 0.000000001
-    expect(pos(1).abs(), pos(1));
+    expect!(pos(1).abs(), pos(1));
 
     // Very small negative: -0.000000001 -> 0.000000001
-    expect(neg(1).abs(), pos(1));
+    expect!(neg(1).abs(), pos(1));
 
     // Large positive value: 1000000000.5 -> 1000000000.5
-    expect(
+    expect!(
         pos(1_000_000_000 * SCALE + 500_000_000).abs(),
         pos(1_000_000_000 * SCALE + 500_000_000),
     );
 
     // Large negative value: -1000000000.5 -> 1000000000.5
-    expect(
+    expect!(
         neg(1_000_000_000 * SCALE + 500_000_000).abs(),
         pos(1_000_000_000 * SCALE + 500_000_000),
     );
 
     // Max positive value remains unchanged
-    expect(sd29x9::max().abs(), sd29x9::max());
+    expect!(sd29x9::max().abs(), sd29x9::max());
 }
 
 #[test, expected_failure(abort_code = sd29x9_base::EOverflow)]
@@ -67,11 +67,11 @@ fun abs_fails_for_min() {
 
 #[test]
 fun abs_of_max_minus_one() {
-    expect(pos(MAX_POSITIVE_VALUE - 1).abs(), pos(MAX_POSITIVE_VALUE - 1));
+    expect!(pos(MAX_POSITIVE_VALUE - 1).abs(), pos(MAX_POSITIVE_VALUE - 1));
 }
 
 #[test]
 fun abs_double_application() {
     // abs is idempotent on result
-    expect(neg(42 * SCALE).abs().abs(), pos(42 * SCALE));
+    expect!(neg(42 * SCALE).abs().abs(), pos(42 * SCALE));
 }

--- a/math/fixed_point/tests/sd29x9_tests/abs_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/abs_tests.move
@@ -3,7 +3,8 @@ module openzeppelin_fp_math::sd29x9_abs_tests;
 
 use openzeppelin_fp_math::sd29x9;
 use openzeppelin_fp_math::sd29x9_base;
-use openzeppelin_fp_math::sd29x9_test_helpers::{pos, neg, expect};
+use openzeppelin_fp_math::sd29x9_test_helpers::{pos, neg};
+use std::unit_test::assert_eq;
 
 const MAX_POSITIVE_VALUE: u128 = 0x7FFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF;
 const SCALE: u128 = 1_000_000_000;
@@ -11,53 +12,53 @@ const SCALE: u128 = 1_000_000_000;
 #[test]
 fun abs_preserves_positive_values() {
     // 5.0 -> 5.0
-    expect!(pos(5 * SCALE).abs(), pos(5 * SCALE));
+    assert_eq!(pos(5 * SCALE).abs(), pos(5 * SCALE));
     // 5.5 -> 5.5
-    expect!(pos(5 * SCALE + 500_000_000).abs(), pos(5 * SCALE + 500_000_000));
+    assert_eq!(pos(5 * SCALE + 500_000_000).abs(), pos(5 * SCALE + 500_000_000));
     // 0.1 -> 0.1
-    expect!(pos(100_000_000).abs(), pos(100_000_000));
+    assert_eq!(pos(100_000_000).abs(), pos(100_000_000));
 }
 
 #[test]
 fun abs_converts_negative_to_positive() {
     // -5.0 -> 5.0
-    expect!(neg(5 * SCALE).abs(), pos(5 * SCALE));
+    assert_eq!(neg(5 * SCALE).abs(), pos(5 * SCALE));
     // -5.5 -> 5.5
-    expect!(neg(5 * SCALE + 500_000_000).abs(), pos(5 * SCALE + 500_000_000));
+    assert_eq!(neg(5 * SCALE + 500_000_000).abs(), pos(5 * SCALE + 500_000_000));
     // -0.1 -> 0.1
-    expect!(neg(100_000_000).abs(), pos(100_000_000));
+    assert_eq!(neg(100_000_000).abs(), pos(100_000_000));
     // -1.0 -> 1.0
-    expect!(neg(SCALE).abs(), pos(SCALE));
+    assert_eq!(neg(SCALE).abs(), pos(SCALE));
 }
 
 #[test]
 fun abs_handles_zero() {
     // 0.0 -> 0.0
-    expect!(sd29x9::zero().abs(), sd29x9::zero());
+    assert_eq!(sd29x9::zero().abs(), sd29x9::zero());
 }
 
 #[test]
 fun abs_handles_edge_cases() {
     // Very small positive: 0.000000001 -> 0.000000001
-    expect!(pos(1).abs(), pos(1));
+    assert_eq!(pos(1).abs(), pos(1));
 
     // Very small negative: -0.000000001 -> 0.000000001
-    expect!(neg(1).abs(), pos(1));
+    assert_eq!(neg(1).abs(), pos(1));
 
     // Large positive value: 1000000000.5 -> 1000000000.5
-    expect!(
+    assert_eq!(
         pos(1_000_000_000 * SCALE + 500_000_000).abs(),
         pos(1_000_000_000 * SCALE + 500_000_000),
     );
 
     // Large negative value: -1000000000.5 -> 1000000000.5
-    expect!(
+    assert_eq!(
         neg(1_000_000_000 * SCALE + 500_000_000).abs(),
         pos(1_000_000_000 * SCALE + 500_000_000),
     );
 
     // Max positive value remains unchanged
-    expect!(sd29x9::max().abs(), sd29x9::max());
+    assert_eq!(sd29x9::max().abs(), sd29x9::max());
 }
 
 #[test, expected_failure(abort_code = sd29x9_base::EOverflow)]
@@ -67,11 +68,11 @@ fun abs_fails_for_min() {
 
 #[test]
 fun abs_of_max_minus_one() {
-    expect!(pos(MAX_POSITIVE_VALUE - 1).abs(), pos(MAX_POSITIVE_VALUE - 1));
+    assert_eq!(pos(MAX_POSITIVE_VALUE - 1).abs(), pos(MAX_POSITIVE_VALUE - 1));
 }
 
 #[test]
 fun abs_double_application() {
     // abs is idempotent on result
-    expect!(neg(42 * SCALE).abs().abs(), pos(42 * SCALE));
+    assert_eq!(neg(42 * SCALE).abs().abs(), pos(42 * SCALE));
 }

--- a/math/fixed_point/tests/sd29x9_tests/arithmetic_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/arithmetic_tests.move
@@ -10,27 +10,27 @@ const SCALE: u128 = 1_000_000_000;
 
 #[test]
 fun addition_and_subtraction_cover_signs() {
-    expect(pos(10 * SCALE).add(neg(5 * SCALE)), pos(5 * SCALE));
-    expect(neg(10 * SCALE).add(pos(5 * SCALE)), neg(5 * SCALE));
-    expect(neg(7 * SCALE).add(neg(9 * SCALE)), neg(16 * SCALE));
+    expect!(pos(10 * SCALE).add(neg(5 * SCALE)), pos(5 * SCALE));
+    expect!(neg(10 * SCALE).add(pos(5 * SCALE)), neg(5 * SCALE));
+    expect!(neg(7 * SCALE).add(neg(9 * SCALE)), neg(16 * SCALE));
 
-    expect(pos(20 * SCALE).sub(pos(7 * SCALE)), pos(13 * SCALE));
-    expect(pos(7 * SCALE).sub(pos(20 * SCALE)), neg(13 * SCALE));
-    expect(neg(9 * SCALE).sub(neg(4 * SCALE)), neg(5 * SCALE));
+    expect!(pos(20 * SCALE).sub(pos(7 * SCALE)), pos(13 * SCALE));
+    expect!(pos(7 * SCALE).sub(pos(20 * SCALE)), neg(13 * SCALE));
+    expect!(neg(9 * SCALE).sub(neg(4 * SCALE)), neg(5 * SCALE));
 }
 
 #[test]
 fun sum_handles_edge_cases() {
     let (min, max, zero) = (sd29x9::min(), sd29x9::max(), sd29x9::zero());
-    expect(min.add(zero), min);
-    expect(max.add(zero), max);
-    expect(zero.add(min), min);
-    expect(zero.add(max), max);
+    expect!(min.add(zero), min);
+    expect!(max.add(zero), max);
+    expect!(zero.add(min), min);
+    expect!(zero.add(max), max);
 
     let epsilon = pos(1);
-    expect(max.negate().add(epsilon.negate()), min);
-    expect(max.sub(epsilon).add(epsilon), max);
-    expect(min.add(epsilon).add(epsilon).negate().add(epsilon), max);
+    expect!(max.negate().add(epsilon.negate()), min);
+    expect!(max.sub(epsilon).add(epsilon), max);
+    expect!(min.add(epsilon).add(epsilon).negate().add(epsilon), max);
 }
 
 #[test]
@@ -40,24 +40,24 @@ fun sum_can_reach_minimum_value() {
     let min_plus_epsilon = min.add(epsilon);
     let zero = sd29x9::zero();
 
-    expect(zero.add(min), min);
-    expect(min_plus_epsilon.add(neg(1)), min);
+    expect!(zero.add(min), min);
+    expect!(min_plus_epsilon.add(neg(1)), min);
 }
 
 #[test]
 fun sub_handles_edge_cases() {
     let (min, max, zero) = (sd29x9::min(), sd29x9::max(), sd29x9::zero());
-    expect(min.sub(zero), min);
-    expect(max.sub(zero), max);
+    expect!(min.sub(zero), min);
+    expect!(max.sub(zero), max);
 
     let epsilon = pos(1);
     let min_plus_epsilon = min.add(epsilon);
-    expect(zero.sub(min_plus_epsilon), max);
-    expect(zero.sub(max), min_plus_epsilon);
+    expect!(zero.sub(min_plus_epsilon), max);
+    expect!(zero.sub(max), min_plus_epsilon);
 
-    expect(max.negate().sub(epsilon), min);
-    expect(max.sub(epsilon).sub(epsilon.negate()), max);
-    expect(min.add(epsilon).add(epsilon).negate().sub(epsilon.negate()), max);
+    expect!(max.negate().sub(epsilon), min);
+    expect!(max.sub(epsilon).sub(epsilon.negate()), max);
+    expect!(min.add(epsilon).add(epsilon).negate().sub(epsilon.negate()), max);
 }
 
 #[test, expected_failure(abort_code = sd29x9_base::EOverflow)]
@@ -80,20 +80,20 @@ fun add_zero_is_identity() {
     let x_pos = pos(12_345_678_901);
     let x_neg = neg(9_876_543_210);
 
-    expect(x_pos.add(zero), x_pos);
-    expect(zero.add(x_pos), x_pos);
-    expect(x_neg.add(zero), x_neg);
-    expect(zero.add(x_neg), x_neg);
-    expect(zero.add(zero), zero);
+    expect!(x_pos.add(zero), x_pos);
+    expect!(zero.add(x_pos), x_pos);
+    expect!(x_neg.add(zero), x_neg);
+    expect!(zero.add(x_neg), x_neg);
+    expect!(zero.add(zero), zero);
 }
 
 #[test]
 fun sub_self_is_zero() {
     let zero = sd29x9::zero();
-    expect(sd29x9::one().sub(sd29x9::one()), zero);
-    expect(neg(42 * SCALE).sub(neg(42 * SCALE)), zero);
-    expect(pos(999_999_999).sub(pos(999_999_999)), zero);
-    expect(sd29x9::max().sub(sd29x9::max()), zero);
+    expect!(sd29x9::one().sub(sd29x9::one()), zero);
+    expect!(neg(42 * SCALE).sub(neg(42 * SCALE)), zero);
+    expect!(pos(999_999_999).sub(pos(999_999_999)), zero);
+    expect!(sd29x9::max().sub(sd29x9::max()), zero);
 }
 
 #[test]
@@ -120,6 +120,6 @@ fun sub_negation_equivalence() {
     ];
     pairs.destroy!(|p| {
         let (a, b) = p.unpack();
-        expect(a.sub(b), a.add(b.negate()));
+        expect!(a.sub(b), a.add(b.negate()));
     });
 }

--- a/math/fixed_point/tests/sd29x9_tests/arithmetic_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/arithmetic_tests.move
@@ -3,34 +3,34 @@ module openzeppelin_fp_math::sd29x9_arithmetic_tests;
 
 use openzeppelin_fp_math::sd29x9;
 use openzeppelin_fp_math::sd29x9_base;
-use openzeppelin_fp_math::sd29x9_test_helpers::{pos, neg, expect, pair, unpack};
+use openzeppelin_fp_math::sd29x9_test_helpers::{pos, neg, pair, unpack};
 use std::unit_test::assert_eq;
 
 const SCALE: u128 = 1_000_000_000;
 
 #[test]
 fun addition_and_subtraction_cover_signs() {
-    expect!(pos(10 * SCALE).add(neg(5 * SCALE)), pos(5 * SCALE));
-    expect!(neg(10 * SCALE).add(pos(5 * SCALE)), neg(5 * SCALE));
-    expect!(neg(7 * SCALE).add(neg(9 * SCALE)), neg(16 * SCALE));
+    assert_eq!(pos(10 * SCALE).add(neg(5 * SCALE)), pos(5 * SCALE));
+    assert_eq!(neg(10 * SCALE).add(pos(5 * SCALE)), neg(5 * SCALE));
+    assert_eq!(neg(7 * SCALE).add(neg(9 * SCALE)), neg(16 * SCALE));
 
-    expect!(pos(20 * SCALE).sub(pos(7 * SCALE)), pos(13 * SCALE));
-    expect!(pos(7 * SCALE).sub(pos(20 * SCALE)), neg(13 * SCALE));
-    expect!(neg(9 * SCALE).sub(neg(4 * SCALE)), neg(5 * SCALE));
+    assert_eq!(pos(20 * SCALE).sub(pos(7 * SCALE)), pos(13 * SCALE));
+    assert_eq!(pos(7 * SCALE).sub(pos(20 * SCALE)), neg(13 * SCALE));
+    assert_eq!(neg(9 * SCALE).sub(neg(4 * SCALE)), neg(5 * SCALE));
 }
 
 #[test]
 fun sum_handles_edge_cases() {
     let (min, max, zero) = (sd29x9::min(), sd29x9::max(), sd29x9::zero());
-    expect!(min.add(zero), min);
-    expect!(max.add(zero), max);
-    expect!(zero.add(min), min);
-    expect!(zero.add(max), max);
+    assert_eq!(min.add(zero), min);
+    assert_eq!(max.add(zero), max);
+    assert_eq!(zero.add(min), min);
+    assert_eq!(zero.add(max), max);
 
     let epsilon = pos(1);
-    expect!(max.negate().add(epsilon.negate()), min);
-    expect!(max.sub(epsilon).add(epsilon), max);
-    expect!(min.add(epsilon).add(epsilon).negate().add(epsilon), max);
+    assert_eq!(max.negate().add(epsilon.negate()), min);
+    assert_eq!(max.sub(epsilon).add(epsilon), max);
+    assert_eq!(min.add(epsilon).add(epsilon).negate().add(epsilon), max);
 }
 
 #[test]
@@ -40,24 +40,24 @@ fun sum_can_reach_minimum_value() {
     let min_plus_epsilon = min.add(epsilon);
     let zero = sd29x9::zero();
 
-    expect!(zero.add(min), min);
-    expect!(min_plus_epsilon.add(neg(1)), min);
+    assert_eq!(zero.add(min), min);
+    assert_eq!(min_plus_epsilon.add(neg(1)), min);
 }
 
 #[test]
 fun sub_handles_edge_cases() {
     let (min, max, zero) = (sd29x9::min(), sd29x9::max(), sd29x9::zero());
-    expect!(min.sub(zero), min);
-    expect!(max.sub(zero), max);
+    assert_eq!(min.sub(zero), min);
+    assert_eq!(max.sub(zero), max);
 
     let epsilon = pos(1);
     let min_plus_epsilon = min.add(epsilon);
-    expect!(zero.sub(min_plus_epsilon), max);
-    expect!(zero.sub(max), min_plus_epsilon);
+    assert_eq!(zero.sub(min_plus_epsilon), max);
+    assert_eq!(zero.sub(max), min_plus_epsilon);
 
-    expect!(max.negate().sub(epsilon), min);
-    expect!(max.sub(epsilon).sub(epsilon.negate()), max);
-    expect!(min.add(epsilon).add(epsilon).negate().sub(epsilon.negate()), max);
+    assert_eq!(max.negate().sub(epsilon), min);
+    assert_eq!(max.sub(epsilon).sub(epsilon.negate()), max);
+    assert_eq!(min.add(epsilon).add(epsilon).negate().sub(epsilon.negate()), max);
 }
 
 #[test, expected_failure(abort_code = sd29x9_base::EOverflow)]
@@ -80,20 +80,20 @@ fun add_zero_is_identity() {
     let x_pos = pos(12_345_678_901);
     let x_neg = neg(9_876_543_210);
 
-    expect!(x_pos.add(zero), x_pos);
-    expect!(zero.add(x_pos), x_pos);
-    expect!(x_neg.add(zero), x_neg);
-    expect!(zero.add(x_neg), x_neg);
-    expect!(zero.add(zero), zero);
+    assert_eq!(x_pos.add(zero), x_pos);
+    assert_eq!(zero.add(x_pos), x_pos);
+    assert_eq!(x_neg.add(zero), x_neg);
+    assert_eq!(zero.add(x_neg), x_neg);
+    assert_eq!(zero.add(zero), zero);
 }
 
 #[test]
 fun sub_self_is_zero() {
     let zero = sd29x9::zero();
-    expect!(sd29x9::one().sub(sd29x9::one()), zero);
-    expect!(neg(42 * SCALE).sub(neg(42 * SCALE)), zero);
-    expect!(pos(999_999_999).sub(pos(999_999_999)), zero);
-    expect!(sd29x9::max().sub(sd29x9::max()), zero);
+    assert_eq!(sd29x9::one().sub(sd29x9::one()), zero);
+    assert_eq!(neg(42 * SCALE).sub(neg(42 * SCALE)), zero);
+    assert_eq!(pos(999_999_999).sub(pos(999_999_999)), zero);
+    assert_eq!(sd29x9::max().sub(sd29x9::max()), zero);
 }
 
 #[test]
@@ -120,6 +120,6 @@ fun sub_negation_equivalence() {
     ];
     pairs.destroy!(|p| {
         let (a, b) = p.unpack();
-        expect!(a.sub(b), a.add(b.negate()));
+        assert_eq!(a.sub(b), a.add(b.negate()));
     });
 }

--- a/math/fixed_point/tests/sd29x9_tests/bitwise_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/bitwise_tests.move
@@ -25,21 +25,21 @@ fun shifts_cover_positive_negative_and_large_offsets() {
     let neg_value = neg(8);
     let pos_value = pos(4);
 
-    expect(pos_value.lshift(0), pos_value);
-    expect(pos_value.lshift(1), pos(8));
-    expect(neg_value.lshift(1), neg(16));
+    expect!(pos_value.lshift(0), pos_value);
+    expect!(pos_value.lshift(1), pos(8));
+    expect!(neg_value.lshift(1), neg(16));
     assert!(pos_value.lshift(128).is_zero());
     assert!(pos_value.lshift(129).is_zero());
 
-    expect(pos_value.rshift(0), pos_value);
-    expect(pos_value.rshift(1), pos(2));
-    expect(neg_value.rshift(1), neg(4));
-    expect(neg_value.rshift(0), neg_value);
+    expect!(pos_value.rshift(0), pos_value);
+    expect!(pos_value.rshift(1), pos(2));
+    expect!(neg_value.rshift(1), neg(4));
+    expect!(neg_value.rshift(0), neg_value);
 
     let neg_one = neg(1);
-    expect(neg_one.rshift(127), neg_one);
-    expect(pos_value.rshift(128), sd29x9::zero());
-    expect(
+    expect!(neg_one.rshift(127), neg_one);
+    expect!(pos_value.rshift(128), sd29x9::zero());
+    expect!(
         neg_one.rshift(128),
         from_bits(0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF),
     );
@@ -85,16 +85,16 @@ fun or_combines_bits() {
 
 #[test]
 fun lshift_by_1_doubles_magnitude() {
-    expect(pos(4).lshift(1), pos(8));
+    expect!(pos(4).lshift(1), pos(8));
 }
 
 #[test]
 fun rshift_by_1_halves_magnitude() {
-    expect(pos(8).rshift(1), pos(4));
+    expect!(pos(8).rshift(1), pos(4));
 }
 
 #[test]
 fun rshift_preserves_negative_sign_for_large_shift() {
     // neg(1) in two's complement is all ones; arithmetic right shift keeps it all ones
-    expect(neg(1).rshift(127), neg(1));
+    expect!(neg(1).rshift(127), neg(1));
 }

--- a/math/fixed_point/tests/sd29x9_tests/bitwise_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/bitwise_tests.move
@@ -2,7 +2,7 @@
 module openzeppelin_fp_math::sd29x9_bitwise_tests;
 
 use openzeppelin_fp_math::sd29x9::{Self, from_bits};
-use openzeppelin_fp_math::sd29x9_test_helpers::{pos, neg, expect};
+use openzeppelin_fp_math::sd29x9_test_helpers::{pos, neg};
 use std::unit_test::assert_eq;
 
 const ALL_ONES: u128 = 0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF;
@@ -25,21 +25,21 @@ fun shifts_cover_positive_negative_and_large_offsets() {
     let neg_value = neg(8);
     let pos_value = pos(4);
 
-    expect!(pos_value.lshift(0), pos_value);
-    expect!(pos_value.lshift(1), pos(8));
-    expect!(neg_value.lshift(1), neg(16));
+    assert_eq!(pos_value.lshift(0), pos_value);
+    assert_eq!(pos_value.lshift(1), pos(8));
+    assert_eq!(neg_value.lshift(1), neg(16));
     assert!(pos_value.lshift(128).is_zero());
     assert!(pos_value.lshift(129).is_zero());
 
-    expect!(pos_value.rshift(0), pos_value);
-    expect!(pos_value.rshift(1), pos(2));
-    expect!(neg_value.rshift(1), neg(4));
-    expect!(neg_value.rshift(0), neg_value);
+    assert_eq!(pos_value.rshift(0), pos_value);
+    assert_eq!(pos_value.rshift(1), pos(2));
+    assert_eq!(neg_value.rshift(1), neg(4));
+    assert_eq!(neg_value.rshift(0), neg_value);
 
     let neg_one = neg(1);
-    expect!(neg_one.rshift(127), neg_one);
-    expect!(pos_value.rshift(128), sd29x9::zero());
-    expect!(neg_one.rshift(128), from_bits(0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF));
+    assert_eq!(neg_one.rshift(127), neg_one);
+    assert_eq!(pos_value.rshift(128), sd29x9::zero());
+    assert_eq!(neg_one.rshift(128), from_bits(0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF));
 }
 
 #[test]
@@ -82,16 +82,16 @@ fun or_combines_bits() {
 
 #[test]
 fun lshift_by_1_doubles_magnitude() {
-    expect!(pos(4).lshift(1), pos(8));
+    assert_eq!(pos(4).lshift(1), pos(8));
 }
 
 #[test]
 fun rshift_by_1_halves_magnitude() {
-    expect!(pos(8).rshift(1), pos(4));
+    assert_eq!(pos(8).rshift(1), pos(4));
 }
 
 #[test]
 fun rshift_preserves_negative_sign_for_large_shift() {
     // neg(1) in two's complement is all ones; arithmetic right shift keeps it all ones
-    expect!(neg(1).rshift(127), neg(1));
+    assert_eq!(neg(1).rshift(127), neg(1));
 }

--- a/math/fixed_point/tests/sd29x9_tests/bitwise_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/bitwise_tests.move
@@ -39,10 +39,7 @@ fun shifts_cover_positive_negative_and_large_offsets() {
     let neg_one = neg(1);
     expect!(neg_one.rshift(127), neg_one);
     expect!(pos_value.rshift(128), sd29x9::zero());
-    expect!(
-        neg_one.rshift(128),
-        from_bits(0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF),
-    );
+    expect!(neg_one.rshift(128), from_bits(0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF));
 }
 
 #[test]

--- a/math/fixed_point/tests/sd29x9_tests/casting_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/casting_tests.move
@@ -15,7 +15,7 @@ fun into_ud30x9_converts_zero() {
     let zero = sd29x9::zero();
     let converted = zero.into_UD30x9();
     assert!(converted.is_zero());
-    assert!(converted.eq(ud30x9::zero()));
+    assert_eq!(converted, ud30x9::zero());
 }
 
 #[test]

--- a/math/fixed_point/tests/sd29x9_tests/ceil_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/ceil_tests.move
@@ -11,53 +11,53 @@ const SCALE: u128 = 1_000_000_000;
 #[test]
 fun ceil_rounds_up_positive_fractional_values() {
     // 5.3 -> 6.0
-    expect(pos(5 * SCALE + 300_000_000).ceil(), pos(6 * SCALE));
+    expect!(pos(5 * SCALE + 300_000_000).ceil(), pos(6 * SCALE));
     // 5.9 -> 6.0
-    expect(pos(5 * SCALE + 900_000_000).ceil(), pos(6 * SCALE));
+    expect!(pos(5 * SCALE + 900_000_000).ceil(), pos(6 * SCALE));
     // 1.1 -> 2.0
-    expect(pos(SCALE + 100_000_000).ceil(), pos(2 * SCALE));
+    expect!(pos(SCALE + 100_000_000).ceil(), pos(2 * SCALE));
     // 0.5 -> 1.0
-    expect(pos(500_000_000).ceil(), pos(SCALE));
+    expect!(pos(500_000_000).ceil(), pos(SCALE));
     // 0.1 -> 1.0
-    expect(pos(100_000_000).ceil(), pos(SCALE));
+    expect!(pos(100_000_000).ceil(), pos(SCALE));
 }
 
 #[test]
 fun ceil_truncates_negative_fractional_values() {
     // -5.3 -> -5.0
-    expect(neg(5 * SCALE + 300_000_000).ceil(), neg(5 * SCALE));
+    expect!(neg(5 * SCALE + 300_000_000).ceil(), neg(5 * SCALE));
     // -5.9 -> -5.0
-    expect(neg(5 * SCALE + 900_000_000).ceil(), neg(5 * SCALE));
+    expect!(neg(5 * SCALE + 900_000_000).ceil(), neg(5 * SCALE));
     // -1.1 -> -1.0
-    expect(neg(SCALE + 100_000_000).ceil(), neg(SCALE));
+    expect!(neg(SCALE + 100_000_000).ceil(), neg(SCALE));
     // -0.5 -> 0.0
-    expect(neg(500_000_000).ceil(), sd29x9::zero());
+    expect!(neg(500_000_000).ceil(), sd29x9::zero());
     // -0.1 -> 0.0
-    expect(neg(100_000_000).ceil(), sd29x9::zero());
+    expect!(neg(100_000_000).ceil(), sd29x9::zero());
 }
 
 #[test]
 fun ceil_preserves_integer_values() {
     // 5.0 -> 5.0
-    expect(pos(5 * SCALE).ceil(), pos(5 * SCALE));
+    expect!(pos(5 * SCALE).ceil(), pos(5 * SCALE));
     // -5.0 -> -5.0
-    expect(neg(5 * SCALE).ceil(), neg(5 * SCALE));
+    expect!(neg(5 * SCALE).ceil(), neg(5 * SCALE));
     // 0.0 -> 0.0
-    expect(sd29x9::zero().ceil(), sd29x9::zero());
+    expect!(sd29x9::zero().ceil(), sd29x9::zero());
     // 100.0 -> 100.0
-    expect(pos(100 * SCALE).ceil(), pos(100 * SCALE));
+    expect!(pos(100 * SCALE).ceil(), pos(100 * SCALE));
 }
 
 #[test]
 fun ceil_handles_edge_cases() {
     // Very small positive fractional: 0.000000001 -> ceil: 1.0
-    expect(pos(1).ceil(), pos(SCALE));
+    expect!(pos(1).ceil(), pos(SCALE));
 
     // Very small negative fractional: -0.000000001 -> ceil: 0.0
-    expect(neg(1).ceil(), sd29x9::zero());
+    expect!(neg(1).ceil(), sd29x9::zero());
 
     // Large value with fraction: 1000000000.5 -> ceil: 1000000001.0
-    expect(pos(1_000_000_000 * SCALE + 500_000_000).ceil(), pos(1_000_000_001 * SCALE));
+    expect!(pos(1_000_000_000 * SCALE + 500_000_000).ceil(), pos(1_000_000_001 * SCALE));
 }
 
 #[test, expected_failure(abort_code = sd29x9_base::EOverflow)]
@@ -69,27 +69,27 @@ fun ceil_fails_for_max() {
 fun ceil_handles_min() {
     let min = sd29x9::min();
     let expected = MIN_NEGATIVE_VALUE - MIN_NEGATIVE_VALUE % SCALE;
-    expect(min.ceil(), neg(expected));
+    expect!(min.ceil(), neg(expected));
 }
 
 #[test]
 fun ceil_of_zero() {
-    expect(sd29x9::zero().ceil(), sd29x9::zero());
+    expect!(sd29x9::zero().ceil(), sd29x9::zero());
 }
 
 #[test]
 fun ceil_of_negative_just_above_integer() {
     // -0.999999999 -> 0
-    expect(neg(999_999_999).ceil(), sd29x9::zero());
+    expect!(neg(999_999_999).ceil(), sd29x9::zero());
 }
 
 #[test]
 fun ceil_of_exact_negative_integer() {
-    expect(neg(5 * SCALE).ceil(), neg(5 * SCALE));
+    expect!(neg(5 * SCALE).ceil(), neg(5 * SCALE));
 }
 
 #[test]
 fun ceil_of_pos_just_above_integer() {
     // 1.000000001 -> 2
-    expect(pos(SCALE + 1).ceil(), pos(2 * SCALE));
+    expect!(pos(SCALE + 1).ceil(), pos(2 * SCALE));
 }

--- a/math/fixed_point/tests/sd29x9_tests/ceil_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/ceil_tests.move
@@ -3,7 +3,8 @@ module openzeppelin_fp_math::sd29x9_ceil_tests;
 
 use openzeppelin_fp_math::sd29x9;
 use openzeppelin_fp_math::sd29x9_base;
-use openzeppelin_fp_math::sd29x9_test_helpers::{pos, neg, expect};
+use openzeppelin_fp_math::sd29x9_test_helpers::{pos, neg};
+use std::unit_test::assert_eq;
 
 const MIN_NEGATIVE_VALUE: u128 = 0x8000_0000_0000_0000_0000_0000_0000_0000;
 const SCALE: u128 = 1_000_000_000;
@@ -11,53 +12,53 @@ const SCALE: u128 = 1_000_000_000;
 #[test]
 fun ceil_rounds_up_positive_fractional_values() {
     // 5.3 -> 6.0
-    expect!(pos(5 * SCALE + 300_000_000).ceil(), pos(6 * SCALE));
+    assert_eq!(pos(5 * SCALE + 300_000_000).ceil(), pos(6 * SCALE));
     // 5.9 -> 6.0
-    expect!(pos(5 * SCALE + 900_000_000).ceil(), pos(6 * SCALE));
+    assert_eq!(pos(5 * SCALE + 900_000_000).ceil(), pos(6 * SCALE));
     // 1.1 -> 2.0
-    expect!(pos(SCALE + 100_000_000).ceil(), pos(2 * SCALE));
+    assert_eq!(pos(SCALE + 100_000_000).ceil(), pos(2 * SCALE));
     // 0.5 -> 1.0
-    expect!(pos(500_000_000).ceil(), pos(SCALE));
+    assert_eq!(pos(500_000_000).ceil(), pos(SCALE));
     // 0.1 -> 1.0
-    expect!(pos(100_000_000).ceil(), pos(SCALE));
+    assert_eq!(pos(100_000_000).ceil(), pos(SCALE));
 }
 
 #[test]
 fun ceil_truncates_negative_fractional_values() {
     // -5.3 -> -5.0
-    expect!(neg(5 * SCALE + 300_000_000).ceil(), neg(5 * SCALE));
+    assert_eq!(neg(5 * SCALE + 300_000_000).ceil(), neg(5 * SCALE));
     // -5.9 -> -5.0
-    expect!(neg(5 * SCALE + 900_000_000).ceil(), neg(5 * SCALE));
+    assert_eq!(neg(5 * SCALE + 900_000_000).ceil(), neg(5 * SCALE));
     // -1.1 -> -1.0
-    expect!(neg(SCALE + 100_000_000).ceil(), neg(SCALE));
+    assert_eq!(neg(SCALE + 100_000_000).ceil(), neg(SCALE));
     // -0.5 -> 0.0
-    expect!(neg(500_000_000).ceil(), sd29x9::zero());
+    assert_eq!(neg(500_000_000).ceil(), sd29x9::zero());
     // -0.1 -> 0.0
-    expect!(neg(100_000_000).ceil(), sd29x9::zero());
+    assert_eq!(neg(100_000_000).ceil(), sd29x9::zero());
 }
 
 #[test]
 fun ceil_preserves_integer_values() {
     // 5.0 -> 5.0
-    expect!(pos(5 * SCALE).ceil(), pos(5 * SCALE));
+    assert_eq!(pos(5 * SCALE).ceil(), pos(5 * SCALE));
     // -5.0 -> -5.0
-    expect!(neg(5 * SCALE).ceil(), neg(5 * SCALE));
+    assert_eq!(neg(5 * SCALE).ceil(), neg(5 * SCALE));
     // 0.0 -> 0.0
-    expect!(sd29x9::zero().ceil(), sd29x9::zero());
+    assert_eq!(sd29x9::zero().ceil(), sd29x9::zero());
     // 100.0 -> 100.0
-    expect!(pos(100 * SCALE).ceil(), pos(100 * SCALE));
+    assert_eq!(pos(100 * SCALE).ceil(), pos(100 * SCALE));
 }
 
 #[test]
 fun ceil_handles_edge_cases() {
     // Very small positive fractional: 0.000000001 -> ceil: 1.0
-    expect!(pos(1).ceil(), pos(SCALE));
+    assert_eq!(pos(1).ceil(), pos(SCALE));
 
     // Very small negative fractional: -0.000000001 -> ceil: 0.0
-    expect!(neg(1).ceil(), sd29x9::zero());
+    assert_eq!(neg(1).ceil(), sd29x9::zero());
 
     // Large value with fraction: 1000000000.5 -> ceil: 1000000001.0
-    expect!(pos(1_000_000_000 * SCALE + 500_000_000).ceil(), pos(1_000_000_001 * SCALE));
+    assert_eq!(pos(1_000_000_000 * SCALE + 500_000_000).ceil(), pos(1_000_000_001 * SCALE));
 }
 
 #[test, expected_failure(abort_code = sd29x9_base::EOverflow)]
@@ -69,27 +70,27 @@ fun ceil_fails_for_max() {
 fun ceil_handles_min() {
     let min = sd29x9::min();
     let expected = MIN_NEGATIVE_VALUE - MIN_NEGATIVE_VALUE % SCALE;
-    expect!(min.ceil(), neg(expected));
+    assert_eq!(min.ceil(), neg(expected));
 }
 
 #[test]
 fun ceil_of_zero() {
-    expect!(sd29x9::zero().ceil(), sd29x9::zero());
+    assert_eq!(sd29x9::zero().ceil(), sd29x9::zero());
 }
 
 #[test]
 fun ceil_of_negative_just_above_integer() {
     // -0.999999999 -> 0
-    expect!(neg(999_999_999).ceil(), sd29x9::zero());
+    assert_eq!(neg(999_999_999).ceil(), sd29x9::zero());
 }
 
 #[test]
 fun ceil_of_exact_negative_integer() {
-    expect!(neg(5 * SCALE).ceil(), neg(5 * SCALE));
+    assert_eq!(neg(5 * SCALE).ceil(), neg(5 * SCALE));
 }
 
 #[test]
 fun ceil_of_pos_just_above_integer() {
     // 1.000000001 -> 2
-    expect!(pos(SCALE + 1).ceil(), pos(2 * SCALE));
+    assert_eq!(pos(SCALE + 1).ceil(), pos(2 * SCALE));
 }

--- a/math/fixed_point/tests/sd29x9_tests/comparison_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/comparison_tests.move
@@ -3,6 +3,7 @@ module openzeppelin_fp_math::sd29x9_comparison_tests;
 
 use openzeppelin_fp_math::sd29x9;
 use openzeppelin_fp_math::sd29x9_test_helpers::{pos, neg};
+use std::unit_test::assert_eq;
 
 const MAX_POSITIVE_VALUE: u128 = 0x7FFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF;
 const SCALE: u128 = 1_000_000_000;
@@ -25,7 +26,7 @@ fun comparison_helpers_handle_all_cases() {
     assert!(neg_four.lte(neg_two));
     assert!(!pos_two.lte(neg_two));
 
-    assert!(pos_two.eq(pos_two));
+    assert_eq!(pos_two, pos_two);
     assert!(neg_two.neq(pos_two));
 }
 
@@ -59,8 +60,8 @@ fun compare_min_and_max() {
 
 #[test]
 fun compare_equal_values() {
-    assert!(pos(42 * SCALE).eq(pos(42 * SCALE)));
-    assert!(neg(7 * SCALE).eq(neg(7 * SCALE)));
+    assert_eq!(pos(42 * SCALE), pos(42 * SCALE));
+    assert_eq!(neg(7 * SCALE), neg(7 * SCALE));
     assert!(!pos(42 * SCALE).neq(pos(42 * SCALE)));
 }
 
@@ -88,7 +89,7 @@ fun eq_reflexivity() {
         sd29x9::min(),
     ];
     values.destroy!(|x| {
-        assert!(x.eq(x));
+        assert_eq!(x, x);
     });
 }
 

--- a/math/fixed_point/tests/sd29x9_tests/div_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/div_tests.move
@@ -68,10 +68,7 @@ fun div_self_is_one() {
 #[test]
 fun div_positive_fractions() {
     // 5 / 2 = 2.5
-    expect!(
-        pos(5 * SCALE).div(pos(2 * SCALE)),
-        pos(2 * SCALE + 500_000_000),
-    );
+    expect!(pos(5 * SCALE).div(pos(2 * SCALE)), pos(2 * SCALE + 500_000_000));
 }
 
 #[test]

--- a/math/fixed_point/tests/sd29x9_tests/div_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/div_tests.move
@@ -14,9 +14,9 @@ fun div_handles_zero_sign_and_identity_cases() {
     let neg_one = neg(SCALE);
     let value = pos(7 * SCALE + 500_000_000); // 7.5
 
-    expect(zero.div(value), zero);
-    expect(value.div(one), value);
-    expect(value.div(neg_one), value.negate());
+    expect!(zero.div(value), zero);
+    expect!(value.div(one), value);
+    expect!(value.div(neg_one), value.negate());
 }
 
 #[test]
@@ -24,21 +24,21 @@ fun div_handles_signs_and_exact_fractional_results() {
     // 7.5 / 2.5 = 3.0
     let numerator = pos(7 * SCALE + 500_000_000);
     let denominator = pos(2 * SCALE + 500_000_000);
-    expect(numerator.div(denominator), pos(3 * SCALE));
-    expect(numerator.div(denominator.negate()), neg(3 * SCALE));
-    expect(numerator.negate().div(denominator.negate()), pos(3 * SCALE));
+    expect!(numerator.div(denominator), pos(3 * SCALE));
+    expect!(numerator.div(denominator.negate()), neg(3 * SCALE));
+    expect!(numerator.negate().div(denominator.negate()), pos(3 * SCALE));
 }
 
 #[test]
 fun div_truncates_towards_zero() {
     // 1.0 / 3.0 = 0.333333333...
-    expect(pos(SCALE).div(pos(3 * SCALE)), pos(333_333_333));
-    expect(neg(SCALE).div(pos(3 * SCALE)), neg(333_333_333));
+    expect!(pos(SCALE).div(pos(3 * SCALE)), pos(333_333_333));
+    expect!(neg(SCALE).div(pos(3 * SCALE)), neg(333_333_333));
 }
 
 #[test]
 fun div_handles_min_over_one() {
-    expect(sd29x9::min().div(pos(SCALE)), sd29x9::min());
+    expect!(sd29x9::min().div(pos(SCALE)), sd29x9::min());
 }
 
 #[test, expected_failure(arithmetic_error, location = openzeppelin_fp_math::sd29x9_base)]
@@ -61,14 +61,14 @@ fun div_self_is_one() {
         pos(1_000_000_000_000),
     ];
     values.destroy!(|x| {
-        expect(x.div(x), one);
+        expect!(x.div(x), one);
     });
 }
 
 #[test]
 fun div_positive_fractions() {
     // 5 / 2 = 2.5
-    expect(
+    expect!(
         pos(5 * SCALE).div(pos(2 * SCALE)),
         pos(2 * SCALE + 500_000_000),
     );
@@ -77,7 +77,7 @@ fun div_positive_fractions() {
 #[test]
 fun div_small_by_large() {
     // 1 / 10 = 0.1
-    expect(pos(SCALE).div(pos(10 * SCALE)), pos(100_000_000));
+    expect!(pos(SCALE).div(pos(10 * SCALE)), pos(100_000_000));
 }
 
 #[test]
@@ -87,8 +87,8 @@ fun div_sign_parity() {
     let two = pos(2 * SCALE);
     let three = pos(3 * SCALE);
 
-    expect(six.div(two), three);
-    expect(six.negate().div(two), three.negate());
-    expect(six.div(two.negate()), three.negate());
-    expect(six.negate().div(two.negate()), three);
+    expect!(six.div(two), three);
+    expect!(six.negate().div(two), three.negate());
+    expect!(six.div(two.negate()), three.negate());
+    expect!(six.negate().div(two.negate()), three);
 }

--- a/math/fixed_point/tests/sd29x9_tests/div_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/div_tests.move
@@ -3,7 +3,8 @@ module openzeppelin_fp_math::sd29x9_div_tests;
 
 use openzeppelin_fp_math::sd29x9;
 use openzeppelin_fp_math::sd29x9_base;
-use openzeppelin_fp_math::sd29x9_test_helpers::{pos, neg, expect};
+use openzeppelin_fp_math::sd29x9_test_helpers::{pos, neg};
+use std::unit_test::assert_eq;
 
 const SCALE: u128 = 1_000_000_000;
 
@@ -14,9 +15,9 @@ fun div_handles_zero_sign_and_identity_cases() {
     let neg_one = neg(SCALE);
     let value = pos(7 * SCALE + 500_000_000); // 7.5
 
-    expect!(zero.div(value), zero);
-    expect!(value.div(one), value);
-    expect!(value.div(neg_one), value.negate());
+    assert_eq!(zero.div(value), zero);
+    assert_eq!(value.div(one), value);
+    assert_eq!(value.div(neg_one), value.negate());
 }
 
 #[test]
@@ -24,21 +25,21 @@ fun div_handles_signs_and_exact_fractional_results() {
     // 7.5 / 2.5 = 3.0
     let numerator = pos(7 * SCALE + 500_000_000);
     let denominator = pos(2 * SCALE + 500_000_000);
-    expect!(numerator.div(denominator), pos(3 * SCALE));
-    expect!(numerator.div(denominator.negate()), neg(3 * SCALE));
-    expect!(numerator.negate().div(denominator.negate()), pos(3 * SCALE));
+    assert_eq!(numerator.div(denominator), pos(3 * SCALE));
+    assert_eq!(numerator.div(denominator.negate()), neg(3 * SCALE));
+    assert_eq!(numerator.negate().div(denominator.negate()), pos(3 * SCALE));
 }
 
 #[test]
 fun div_truncates_towards_zero() {
     // 1.0 / 3.0 = 0.333333333...
-    expect!(pos(SCALE).div(pos(3 * SCALE)), pos(333_333_333));
-    expect!(neg(SCALE).div(pos(3 * SCALE)), neg(333_333_333));
+    assert_eq!(pos(SCALE).div(pos(3 * SCALE)), pos(333_333_333));
+    assert_eq!(neg(SCALE).div(pos(3 * SCALE)), neg(333_333_333));
 }
 
 #[test]
 fun div_handles_min_over_one() {
-    expect!(sd29x9::min().div(pos(SCALE)), sd29x9::min());
+    assert_eq!(sd29x9::min().div(pos(SCALE)), sd29x9::min());
 }
 
 #[test, expected_failure(arithmetic_error, location = openzeppelin_fp_math::sd29x9_base)]
@@ -61,20 +62,20 @@ fun div_self_is_one() {
         pos(1_000_000_000_000),
     ];
     values.destroy!(|x| {
-        expect!(x.div(x), one);
+        assert_eq!(x.div(x), one);
     });
 }
 
 #[test]
 fun div_positive_fractions() {
     // 5 / 2 = 2.5
-    expect!(pos(5 * SCALE).div(pos(2 * SCALE)), pos(2 * SCALE + 500_000_000));
+    assert_eq!(pos(5 * SCALE).div(pos(2 * SCALE)), pos(2 * SCALE + 500_000_000));
 }
 
 #[test]
 fun div_small_by_large() {
     // 1 / 10 = 0.1
-    expect!(pos(SCALE).div(pos(10 * SCALE)), pos(100_000_000));
+    assert_eq!(pos(SCALE).div(pos(10 * SCALE)), pos(100_000_000));
 }
 
 #[test]
@@ -84,8 +85,8 @@ fun div_sign_parity() {
     let two = pos(2 * SCALE);
     let three = pos(3 * SCALE);
 
-    expect!(six.div(two), three);
-    expect!(six.negate().div(two), three.negate());
-    expect!(six.div(two.negate()), three.negate());
-    expect!(six.negate().div(two.negate()), three);
+    assert_eq!(six.div(two), three);
+    assert_eq!(six.negate().div(two), three.negate());
+    assert_eq!(six.div(two.negate()), three.negate());
+    assert_eq!(six.negate().div(two.negate()), three);
 }

--- a/math/fixed_point/tests/sd29x9_tests/floor_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/floor_tests.move
@@ -11,60 +11,60 @@ const SCALE: u128 = 1_000_000_000;
 #[test]
 fun floor_truncates_positive_fractional_values() {
     // 5.3 -> 5.0
-    expect(pos(5 * SCALE + 300_000_000).floor(), pos(5 * SCALE));
+    expect!(pos(5 * SCALE + 300_000_000).floor(), pos(5 * SCALE));
     // 5.9 -> 5.0
-    expect(pos(5 * SCALE + 900_000_000).floor(), pos(5 * SCALE));
+    expect!(pos(5 * SCALE + 900_000_000).floor(), pos(5 * SCALE));
     // 1.1 -> 1.0
-    expect(pos(SCALE + 100_000_000).floor(), pos(SCALE));
+    expect!(pos(SCALE + 100_000_000).floor(), pos(SCALE));
     // 0.5 -> 0.0
-    expect(pos(500_000_000).floor(), sd29x9::zero());
+    expect!(pos(500_000_000).floor(), sd29x9::zero());
     // 0.1 -> 0.0
-    expect(pos(100_000_000).floor(), sd29x9::zero());
+    expect!(pos(100_000_000).floor(), sd29x9::zero());
 }
 
 #[test]
 fun floor_rounds_down_negative_fractional_values() {
     // -5.3 -> -6.0
-    expect(neg(5 * SCALE + 300_000_000).floor(), neg(6 * SCALE));
+    expect!(neg(5 * SCALE + 300_000_000).floor(), neg(6 * SCALE));
     // -5.9 -> -6.0
-    expect(neg(5 * SCALE + 900_000_000).floor(), neg(6 * SCALE));
+    expect!(neg(5 * SCALE + 900_000_000).floor(), neg(6 * SCALE));
     // -1.1 -> -2.0
-    expect(neg(SCALE + 100_000_000).floor(), neg(2 * SCALE));
+    expect!(neg(SCALE + 100_000_000).floor(), neg(2 * SCALE));
     // -0.5 -> -1.0
-    expect(neg(500_000_000).floor(), neg(SCALE));
+    expect!(neg(500_000_000).floor(), neg(SCALE));
     // -0.1 -> -1.0
-    expect(neg(100_000_000).floor(), neg(SCALE));
+    expect!(neg(100_000_000).floor(), neg(SCALE));
 }
 
 #[test]
 fun floor_preserves_integer_values() {
     // 5.0 -> 5.0
-    expect(pos(5 * SCALE).floor(), pos(5 * SCALE));
+    expect!(pos(5 * SCALE).floor(), pos(5 * SCALE));
     // -5.0 -> -5.0
-    expect(neg(5 * SCALE).floor(), neg(5 * SCALE));
+    expect!(neg(5 * SCALE).floor(), neg(5 * SCALE));
     // 0.0 -> 0.0
-    expect(sd29x9::zero().floor(), sd29x9::zero());
+    expect!(sd29x9::zero().floor(), sd29x9::zero());
     // 100.0 -> 100.0
-    expect(pos(100 * SCALE).floor(), pos(100 * SCALE));
+    expect!(pos(100 * SCALE).floor(), pos(100 * SCALE));
 }
 
 #[test]
 fun floor_handles_edge_cases() {
     // Very small positive fractional: 0.000000001 -> floor: 0.0
-    expect(pos(1).floor(), sd29x9::zero());
+    expect!(pos(1).floor(), sd29x9::zero());
 
     // Very small negative fractional: -0.000000001 -> floor: -1.0
-    expect(neg(1).floor(), neg(SCALE));
+    expect!(neg(1).floor(), neg(SCALE));
 
     // Large value with fraction: 1000000000.5 -> floor: 1000000000.0
-    expect(pos(1_000_000_000 * SCALE + 500_000_000).floor(), pos(1_000_000_000 * SCALE));
+    expect!(pos(1_000_000_000 * SCALE + 500_000_000).floor(), pos(1_000_000_000 * SCALE));
 }
 
 #[test]
 fun floor_handles_max() {
     let max = sd29x9::max();
     let expected = MAX_POSITIVE_VALUE - MAX_POSITIVE_VALUE % SCALE;
-    expect(max.floor(), pos(expected));
+    expect!(max.floor(), pos(expected));
 }
 
 #[test, expected_failure(abort_code = sd29x9_base::EOverflow)]
@@ -74,22 +74,22 @@ fun floor_fails_for_min() {
 
 #[test]
 fun floor_of_zero() {
-    expect(sd29x9::zero().floor(), sd29x9::zero());
+    expect!(sd29x9::zero().floor(), sd29x9::zero());
 }
 
 #[test]
 fun floor_of_positive_just_below_integer() {
     // 1.999999999 -> 1
-    expect(pos(2 * SCALE - 1).floor(), pos(SCALE));
+    expect!(pos(2 * SCALE - 1).floor(), pos(SCALE));
 }
 
 #[test]
 fun floor_of_negative_just_below_integer() {
     // -1.000000001 -> -2
-    expect(neg(SCALE + 1).floor(), neg(2 * SCALE));
+    expect!(neg(SCALE + 1).floor(), neg(2 * SCALE));
 }
 
 #[test]
 fun floor_of_exact_negative_integer() {
-    expect(neg(3 * SCALE).floor(), neg(3 * SCALE));
+    expect!(neg(3 * SCALE).floor(), neg(3 * SCALE));
 }

--- a/math/fixed_point/tests/sd29x9_tests/floor_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/floor_tests.move
@@ -3,7 +3,8 @@ module openzeppelin_fp_math::sd29x9_floor_tests;
 
 use openzeppelin_fp_math::sd29x9;
 use openzeppelin_fp_math::sd29x9_base;
-use openzeppelin_fp_math::sd29x9_test_helpers::{pos, neg, expect};
+use openzeppelin_fp_math::sd29x9_test_helpers::{pos, neg};
+use std::unit_test::assert_eq;
 
 const MAX_POSITIVE_VALUE: u128 = 0x7FFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF;
 const SCALE: u128 = 1_000_000_000;
@@ -11,60 +12,60 @@ const SCALE: u128 = 1_000_000_000;
 #[test]
 fun floor_truncates_positive_fractional_values() {
     // 5.3 -> 5.0
-    expect!(pos(5 * SCALE + 300_000_000).floor(), pos(5 * SCALE));
+    assert_eq!(pos(5 * SCALE + 300_000_000).floor(), pos(5 * SCALE));
     // 5.9 -> 5.0
-    expect!(pos(5 * SCALE + 900_000_000).floor(), pos(5 * SCALE));
+    assert_eq!(pos(5 * SCALE + 900_000_000).floor(), pos(5 * SCALE));
     // 1.1 -> 1.0
-    expect!(pos(SCALE + 100_000_000).floor(), pos(SCALE));
+    assert_eq!(pos(SCALE + 100_000_000).floor(), pos(SCALE));
     // 0.5 -> 0.0
-    expect!(pos(500_000_000).floor(), sd29x9::zero());
+    assert_eq!(pos(500_000_000).floor(), sd29x9::zero());
     // 0.1 -> 0.0
-    expect!(pos(100_000_000).floor(), sd29x9::zero());
+    assert_eq!(pos(100_000_000).floor(), sd29x9::zero());
 }
 
 #[test]
 fun floor_rounds_down_negative_fractional_values() {
     // -5.3 -> -6.0
-    expect!(neg(5 * SCALE + 300_000_000).floor(), neg(6 * SCALE));
+    assert_eq!(neg(5 * SCALE + 300_000_000).floor(), neg(6 * SCALE));
     // -5.9 -> -6.0
-    expect!(neg(5 * SCALE + 900_000_000).floor(), neg(6 * SCALE));
+    assert_eq!(neg(5 * SCALE + 900_000_000).floor(), neg(6 * SCALE));
     // -1.1 -> -2.0
-    expect!(neg(SCALE + 100_000_000).floor(), neg(2 * SCALE));
+    assert_eq!(neg(SCALE + 100_000_000).floor(), neg(2 * SCALE));
     // -0.5 -> -1.0
-    expect!(neg(500_000_000).floor(), neg(SCALE));
+    assert_eq!(neg(500_000_000).floor(), neg(SCALE));
     // -0.1 -> -1.0
-    expect!(neg(100_000_000).floor(), neg(SCALE));
+    assert_eq!(neg(100_000_000).floor(), neg(SCALE));
 }
 
 #[test]
 fun floor_preserves_integer_values() {
     // 5.0 -> 5.0
-    expect!(pos(5 * SCALE).floor(), pos(5 * SCALE));
+    assert_eq!(pos(5 * SCALE).floor(), pos(5 * SCALE));
     // -5.0 -> -5.0
-    expect!(neg(5 * SCALE).floor(), neg(5 * SCALE));
+    assert_eq!(neg(5 * SCALE).floor(), neg(5 * SCALE));
     // 0.0 -> 0.0
-    expect!(sd29x9::zero().floor(), sd29x9::zero());
+    assert_eq!(sd29x9::zero().floor(), sd29x9::zero());
     // 100.0 -> 100.0
-    expect!(pos(100 * SCALE).floor(), pos(100 * SCALE));
+    assert_eq!(pos(100 * SCALE).floor(), pos(100 * SCALE));
 }
 
 #[test]
 fun floor_handles_edge_cases() {
     // Very small positive fractional: 0.000000001 -> floor: 0.0
-    expect!(pos(1).floor(), sd29x9::zero());
+    assert_eq!(pos(1).floor(), sd29x9::zero());
 
     // Very small negative fractional: -0.000000001 -> floor: -1.0
-    expect!(neg(1).floor(), neg(SCALE));
+    assert_eq!(neg(1).floor(), neg(SCALE));
 
     // Large value with fraction: 1000000000.5 -> floor: 1000000000.0
-    expect!(pos(1_000_000_000 * SCALE + 500_000_000).floor(), pos(1_000_000_000 * SCALE));
+    assert_eq!(pos(1_000_000_000 * SCALE + 500_000_000).floor(), pos(1_000_000_000 * SCALE));
 }
 
 #[test]
 fun floor_handles_max() {
     let max = sd29x9::max();
     let expected = MAX_POSITIVE_VALUE - MAX_POSITIVE_VALUE % SCALE;
-    expect!(max.floor(), pos(expected));
+    assert_eq!(max.floor(), pos(expected));
 }
 
 #[test, expected_failure(abort_code = sd29x9_base::EOverflow)]
@@ -74,22 +75,22 @@ fun floor_fails_for_min() {
 
 #[test]
 fun floor_of_zero() {
-    expect!(sd29x9::zero().floor(), sd29x9::zero());
+    assert_eq!(sd29x9::zero().floor(), sd29x9::zero());
 }
 
 #[test]
 fun floor_of_positive_just_below_integer() {
     // 1.999999999 -> 1
-    expect!(pos(2 * SCALE - 1).floor(), pos(SCALE));
+    assert_eq!(pos(2 * SCALE - 1).floor(), pos(SCALE));
 }
 
 #[test]
 fun floor_of_negative_just_below_integer() {
     // -1.000000001 -> -2
-    expect!(neg(SCALE + 1).floor(), neg(2 * SCALE));
+    assert_eq!(neg(SCALE + 1).floor(), neg(2 * SCALE));
 }
 
 #[test]
 fun floor_of_exact_negative_integer() {
-    expect!(neg(3 * SCALE).floor(), neg(3 * SCALE));
+    assert_eq!(neg(3 * SCALE).floor(), neg(3 * SCALE));
 }

--- a/math/fixed_point/tests/sd29x9_tests/helpers.move
+++ b/math/fixed_point/tests/sd29x9_tests/helpers.move
@@ -24,6 +24,8 @@ public(package) fun neg(raw: u128): SD29x9 {
     sd29x9::wrap(raw, true)
 }
 
-public(package) fun expect(left: SD29x9, right: SD29x9) {
+public(package) macro fun expect($left: SD29x9, $right: SD29x9) {
+    let left = $left;
+    let right = $right;
     assert_eq!(left.unwrap(), right.unwrap());
 }

--- a/math/fixed_point/tests/sd29x9_tests/helpers.move
+++ b/math/fixed_point/tests/sd29x9_tests/helpers.move
@@ -2,7 +2,6 @@
 module openzeppelin_fp_math::sd29x9_test_helpers;
 
 use openzeppelin_fp_math::sd29x9::{Self, SD29x9};
-use std::unit_test::assert_eq;
 
 public struct Pair has drop {
     x: SD29x9,
@@ -22,10 +21,4 @@ public(package) fun pos(raw: u128): SD29x9 {
 
 public(package) fun neg(raw: u128): SD29x9 {
     sd29x9::wrap(raw, true)
-}
-
-public(package) macro fun expect($left: SD29x9, $right: SD29x9) {
-    let left = $left;
-    let right = $right;
-    assert_eq!(left.unwrap(), right.unwrap());
 }

--- a/math/fixed_point/tests/sd29x9_tests/mod_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/mod_tests.move
@@ -40,10 +40,7 @@ fun mod_dividend_less_than_divisor() {
 
 #[test]
 fun mod_large_fractional() {
-    expect!(
-        pos(100 * SCALE + 500_000_000).mod(pos(SCALE)),
-        pos(500_000_000),
-    );
+    expect!(pos(100 * SCALE + 500_000_000).mod(pos(SCALE)), pos(500_000_000));
 }
 
 #[test]

--- a/math/fixed_point/tests/sd29x9_tests/mod_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/mod_tests.move
@@ -8,9 +8,9 @@ const SCALE: u128 = 1_000_000_000;
 
 #[test]
 fun mod_tracks_dividend_sign() {
-    expect(pos(100 * SCALE).mod(pos(15 * SCALE)), pos(10 * SCALE));
-    expect(neg(100 * SCALE).mod(pos(15 * SCALE)), neg(10 * SCALE));
-    expect(pos(42 * SCALE).mod(neg(21 * SCALE)), sd29x9::zero());
+    expect!(pos(100 * SCALE).mod(pos(15 * SCALE)), pos(10 * SCALE));
+    expect!(neg(100 * SCALE).mod(pos(15 * SCALE)), neg(10 * SCALE));
+    expect!(pos(42 * SCALE).mod(neg(21 * SCALE)), sd29x9::zero());
 }
 
 #[test, expected_failure(arithmetic_error, location = openzeppelin_fp_math::sd29x9_base)]
@@ -20,27 +20,27 @@ fun mod_with_zero_modulus_aborts() {
 
 #[test]
 fun mod_positive_positive() {
-    expect(pos(10 * SCALE).mod(pos(3 * SCALE)), pos(SCALE));
+    expect!(pos(10 * SCALE).mod(pos(3 * SCALE)), pos(SCALE));
 }
 
 #[test]
 fun mod_exact_division() {
-    expect(pos(15 * SCALE).mod(pos(5 * SCALE)), sd29x9::zero());
+    expect!(pos(15 * SCALE).mod(pos(5 * SCALE)), sd29x9::zero());
 }
 
 #[test]
 fun mod_dividend_equals_divisor() {
-    expect(pos(7 * SCALE).mod(pos(7 * SCALE)), sd29x9::zero());
+    expect!(pos(7 * SCALE).mod(pos(7 * SCALE)), sd29x9::zero());
 }
 
 #[test]
 fun mod_dividend_less_than_divisor() {
-    expect(pos(3 * SCALE).mod(pos(10 * SCALE)), pos(3 * SCALE));
+    expect!(pos(3 * SCALE).mod(pos(10 * SCALE)), pos(3 * SCALE));
 }
 
 #[test]
 fun mod_large_fractional() {
-    expect(
+    expect!(
         pos(100 * SCALE + 500_000_000).mod(pos(SCALE)),
         pos(500_000_000),
     );
@@ -48,10 +48,10 @@ fun mod_large_fractional() {
 
 #[test]
 fun mod_negative_negative() {
-    expect(neg(13 * SCALE).mod(neg(5 * SCALE)), neg(3 * SCALE));
+    expect!(neg(13 * SCALE).mod(neg(5 * SCALE)), neg(3 * SCALE));
 }
 
 #[test]
 fun mod_negative_divisor_keeps_positive_dividend_sign() {
-    expect(pos(13 * SCALE).mod(neg(5 * SCALE)), pos(3 * SCALE));
+    expect!(pos(13 * SCALE).mod(neg(5 * SCALE)), pos(3 * SCALE));
 }

--- a/math/fixed_point/tests/sd29x9_tests/mod_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/mod_tests.move
@@ -2,15 +2,16 @@
 module openzeppelin_fp_math::sd29x9_mod_tests;
 
 use openzeppelin_fp_math::sd29x9;
-use openzeppelin_fp_math::sd29x9_test_helpers::{pos, neg, expect};
+use openzeppelin_fp_math::sd29x9_test_helpers::{pos, neg};
+use std::unit_test::assert_eq;
 
 const SCALE: u128 = 1_000_000_000;
 
 #[test]
 fun mod_tracks_dividend_sign() {
-    expect!(pos(100 * SCALE).mod(pos(15 * SCALE)), pos(10 * SCALE));
-    expect!(neg(100 * SCALE).mod(pos(15 * SCALE)), neg(10 * SCALE));
-    expect!(pos(42 * SCALE).mod(neg(21 * SCALE)), sd29x9::zero());
+    assert_eq!(pos(100 * SCALE).mod(pos(15 * SCALE)), pos(10 * SCALE));
+    assert_eq!(neg(100 * SCALE).mod(pos(15 * SCALE)), neg(10 * SCALE));
+    assert_eq!(pos(42 * SCALE).mod(neg(21 * SCALE)), sd29x9::zero());
 }
 
 #[test, expected_failure(arithmetic_error, location = openzeppelin_fp_math::sd29x9_base)]
@@ -20,35 +21,35 @@ fun mod_with_zero_modulus_aborts() {
 
 #[test]
 fun mod_positive_positive() {
-    expect!(pos(10 * SCALE).mod(pos(3 * SCALE)), pos(SCALE));
+    assert_eq!(pos(10 * SCALE).mod(pos(3 * SCALE)), pos(SCALE));
 }
 
 #[test]
 fun mod_exact_division() {
-    expect!(pos(15 * SCALE).mod(pos(5 * SCALE)), sd29x9::zero());
+    assert_eq!(pos(15 * SCALE).mod(pos(5 * SCALE)), sd29x9::zero());
 }
 
 #[test]
 fun mod_dividend_equals_divisor() {
-    expect!(pos(7 * SCALE).mod(pos(7 * SCALE)), sd29x9::zero());
+    assert_eq!(pos(7 * SCALE).mod(pos(7 * SCALE)), sd29x9::zero());
 }
 
 #[test]
 fun mod_dividend_less_than_divisor() {
-    expect!(pos(3 * SCALE).mod(pos(10 * SCALE)), pos(3 * SCALE));
+    assert_eq!(pos(3 * SCALE).mod(pos(10 * SCALE)), pos(3 * SCALE));
 }
 
 #[test]
 fun mod_large_fractional() {
-    expect!(pos(100 * SCALE + 500_000_000).mod(pos(SCALE)), pos(500_000_000));
+    assert_eq!(pos(100 * SCALE + 500_000_000).mod(pos(SCALE)), pos(500_000_000));
 }
 
 #[test]
 fun mod_negative_negative() {
-    expect!(neg(13 * SCALE).mod(neg(5 * SCALE)), neg(3 * SCALE));
+    assert_eq!(neg(13 * SCALE).mod(neg(5 * SCALE)), neg(3 * SCALE));
 }
 
 #[test]
 fun mod_negative_divisor_keeps_positive_dividend_sign() {
-    expect!(pos(13 * SCALE).mod(neg(5 * SCALE)), pos(3 * SCALE));
+    assert_eq!(pos(13 * SCALE).mod(neg(5 * SCALE)), pos(3 * SCALE));
 }

--- a/math/fixed_point/tests/sd29x9_tests/mul_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/mul_tests.move
@@ -3,7 +3,7 @@ module openzeppelin_fp_math::sd29x9_mul_tests;
 
 use openzeppelin_fp_math::sd29x9;
 use openzeppelin_fp_math::sd29x9_base;
-use openzeppelin_fp_math::sd29x9_test_helpers::{pos, neg, expect, pair, unpack};
+use openzeppelin_fp_math::sd29x9_test_helpers::{pos, neg, pair, unpack};
 use std::unit_test::assert_eq;
 
 const MAX_POSITIVE_VALUE: u128 = 0x7FFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF;
@@ -25,8 +25,8 @@ fun mul_handles_multiplication_by_zero() {
         sd29x9::min(),
     ];
     values.destroy!(|val| {
-        expect!(val.mul(zero), zero);
-        expect!(zero.mul(val), zero);
+        assert_eq!(val.mul(zero), zero);
+        assert_eq!(zero.mul(val), zero);
     });
 }
 
@@ -43,8 +43,8 @@ fun mul_handles_multiplication_by_one() {
         neg(500_000_000_000_000_000),
     ];
     values.destroy!(|val| {
-        expect!(val.mul(one), val);
-        expect!(one.mul(val), val);
+        assert_eq!(val.mul(one), val);
+        assert_eq!(one.mul(val), val);
     });
 }
 
@@ -61,8 +61,8 @@ fun mul_handles_multiplication_by_minus_one() {
         neg(500_000_000_000_000_000),
     ];
     values.destroy!(|val| {
-        expect!(val.mul(minus_one), val.negate());
-        expect!(minus_one.mul(val), val.negate());
+        assert_eq!(val.mul(minus_one), val.negate());
+        assert_eq!(minus_one.mul(val), val.negate());
     });
 }
 
@@ -76,16 +76,16 @@ fun mul_handles_signs_for_integers() {
     let minus_six = six.negate();
 
     // 1. Both positive
-    expect!(two.mul(three), six);
+    assert_eq!(two.mul(three), six);
 
     // 2. Left positive, right negative
-    expect!(two.mul(minus_three), minus_six);
+    assert_eq!(two.mul(minus_three), minus_six);
 
     // 3. Left negative, right positive
-    expect!(minus_two.mul(three), minus_six);
+    assert_eq!(minus_two.mul(three), minus_six);
 
     // 4. Both negative
-    expect!(minus_two.mul(minus_three), six);
+    assert_eq!(minus_two.mul(minus_three), six);
 }
 
 #[test]
@@ -96,34 +96,34 @@ fun mul_handles_signs_for_fractional() {
     let expected = pos(3_375_000_000);
 
     // 1. Both positive
-    expect!(left.mul(right), expected);
+    assert_eq!(left.mul(right), expected);
 
     // 2. Left positive, right negative
-    expect!(left.mul(right.negate()), expected.negate());
+    assert_eq!(left.mul(right.negate()), expected.negate());
 
     // 3. Left negative, right positive
-    expect!(left.negate().mul(right), expected.negate());
+    assert_eq!(left.negate().mul(right), expected.negate());
 
     // 4. Both negative
-    expect!(left.negate().mul(right.negate()), expected);
+    assert_eq!(left.negate().mul(right.negate()), expected);
 }
 
 #[test]
 fun mul_truncates_towards_zero_at_scale_boundary() {
     // 1.000000001 * 1.000000001 = 1.000000002000000001 -> 1.000000002
     let x = pos(SCALE + 1);
-    expect!(x.mul(x), pos(SCALE + 2));
+    assert_eq!(x.mul(x), pos(SCALE + 2));
 
     // 1.000000001 * 1.000000002 = 1.000000003000000002 -> 1.000000003
-    expect!(pos(SCALE + 1).mul(pos(SCALE + 2)), pos(SCALE + 3));
+    assert_eq!(pos(SCALE + 1).mul(pos(SCALE + 2)), pos(SCALE + 3));
 
     // 0.999999999 * 0.999999999 = 0.999999998000000001 -> 0.999999998
     let almost_one = pos(SCALE - 1);
-    expect!(almost_one.mul(almost_one), pos(SCALE - 2));
+    assert_eq!(almost_one.mul(almost_one), pos(SCALE - 2));
 
     // Sign checks near the truncation boundary
-    expect!(x.negate().mul(x), neg(SCALE + 2));
-    expect!(x.negate().mul(x.negate()), pos(SCALE + 2));
+    assert_eq!(x.negate().mul(x), neg(SCALE + 2));
+    assert_eq!(x.negate().mul(x.negate()), pos(SCALE + 2));
 }
 
 #[test]
@@ -131,19 +131,19 @@ fun mul_handles_difficult_fractional_magnitudes() {
     // (999999999.999999999)^2 = 999999999999999998.000000000000000001
     let value = pos(999_999_999_999_999_999);
     let expected_square = pos(999_999_999_999_999_998_000_000_000);
-    expect!(value.mul(value), pos(999_999_999_999_999_998_000_000_000));
-    expect!(value.negate().mul(value), expected_square.negate());
-    expect!(value.mul(value.negate()), expected_square.negate());
-    expect!(value.negate().mul(value.negate()), expected_square);
+    assert_eq!(value.mul(value), pos(999_999_999_999_999_998_000_000_000));
+    assert_eq!(value.negate().mul(value), expected_square.negate());
+    assert_eq!(value.mul(value.negate()), expected_square.negate());
+    assert_eq!(value.negate().mul(value.negate()), expected_square);
 
     // 123456789.123456789 * 987654321.987654321
     let left = pos(123_456_789_123_456_789);
     let right = pos(987_654_321_987_654_321);
     let expected_product = pos(121_932_631_356_500_531_347_203_169);
-    expect!(left.mul(right), expected_product);
-    expect!(left.negate().mul(right), expected_product.negate());
-    expect!(left.mul(right.negate()), expected_product.negate());
-    expect!(left.negate().mul(right.negate()), expected_product);
+    assert_eq!(left.mul(right), expected_product);
+    assert_eq!(left.negate().mul(right), expected_product.negate());
+    assert_eq!(left.mul(right.negate()), expected_product.negate());
+    assert_eq!(left.negate().mul(right.negate()), expected_product);
 }
 
 #[test]
@@ -154,25 +154,25 @@ fun mul_large_intermediate_product_does_not_overflow() {
     let max = sd29x9::max();
     let min = sd29x9::min();
 
-    expect!(max.mul(half), pos(MAX_POSITIVE_VALUE / 2));
-    expect!(half.mul(max), pos(MAX_POSITIVE_VALUE / 2));
+    assert_eq!(max.mul(half), pos(MAX_POSITIVE_VALUE / 2));
+    assert_eq!(half.mul(max), pos(MAX_POSITIVE_VALUE / 2));
 
-    expect!(min.mul(half), neg(MIN_NEGATIVE_VALUE / 2));
-    expect!(half.mul(min), neg(MIN_NEGATIVE_VALUE / 2));
+    assert_eq!(min.mul(half), neg(MIN_NEGATIVE_VALUE / 2));
+    assert_eq!(half.mul(min), neg(MIN_NEGATIVE_VALUE / 2));
 }
 
 #[test]
 fun mul_handles_min_times_one() {
     let min = sd29x9::min();
     let one = sd29x9::one();
-    expect!(min.mul(one), min);
+    assert_eq!(min.mul(one), min);
 }
 
 #[test]
 fun mul_handles_max_times_one() {
     let max = sd29x9::max();
     let one = sd29x9::one();
-    expect!(max.mul(one), max);
+    assert_eq!(max.mul(one), max);
 }
 
 #[test, expected_failure(abort_code = sd29x9_base::EOverflow)]

--- a/math/fixed_point/tests/sd29x9_tests/mul_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/mul_tests.move
@@ -25,8 +25,8 @@ fun mul_handles_multiplication_by_zero() {
         sd29x9::min(),
     ];
     values.destroy!(|val| {
-        expect(val.mul(zero), zero);
-        expect(zero.mul(val), zero);
+        expect!(val.mul(zero), zero);
+        expect!(zero.mul(val), zero);
     });
 }
 
@@ -43,8 +43,8 @@ fun mul_handles_multiplication_by_one() {
         neg(500_000_000_000_000_000),
     ];
     values.destroy!(|val| {
-        expect(val.mul(one), val);
-        expect(one.mul(val), val);
+        expect!(val.mul(one), val);
+        expect!(one.mul(val), val);
     });
 }
 
@@ -61,8 +61,8 @@ fun mul_handles_multiplication_by_minus_one() {
         neg(500_000_000_000_000_000),
     ];
     values.destroy!(|val| {
-        expect(val.mul(minus_one), val.negate());
-        expect(minus_one.mul(val), val.negate());
+        expect!(val.mul(minus_one), val.negate());
+        expect!(minus_one.mul(val), val.negate());
     });
 }
 
@@ -76,16 +76,16 @@ fun mul_handles_signs_for_integers() {
     let minus_six = six.negate();
 
     // 1. Both positive
-    expect(two.mul(three), six);
+    expect!(two.mul(three), six);
 
     // 2. Left positive, right negative
-    expect(two.mul(minus_three), minus_six);
+    expect!(two.mul(minus_three), minus_six);
 
     // 3. Left negative, right positive
-    expect(minus_two.mul(three), minus_six);
+    expect!(minus_two.mul(three), minus_six);
 
     // 4. Both negative
-    expect(minus_two.mul(minus_three), six);
+    expect!(minus_two.mul(minus_three), six);
 }
 
 #[test]
@@ -96,34 +96,34 @@ fun mul_handles_signs_for_fractional() {
     let expected = pos(3_375_000_000);
 
     // 1. Both positive
-    expect(left.mul(right), expected);
+    expect!(left.mul(right), expected);
 
     // 2. Left positive, right negative
-    expect(left.mul(right.negate()), expected.negate());
+    expect!(left.mul(right.negate()), expected.negate());
 
     // 3. Left negative, right positive
-    expect(left.negate().mul(right), expected.negate());
+    expect!(left.negate().mul(right), expected.negate());
 
     // 4. Both negative
-    expect(left.negate().mul(right.negate()), expected);
+    expect!(left.negate().mul(right.negate()), expected);
 }
 
 #[test]
 fun mul_truncates_towards_zero_at_scale_boundary() {
     // 1.000000001 * 1.000000001 = 1.000000002000000001 -> 1.000000002
     let x = pos(SCALE + 1);
-    expect(x.mul(x), pos(SCALE + 2));
+    expect!(x.mul(x), pos(SCALE + 2));
 
     // 1.000000001 * 1.000000002 = 1.000000003000000002 -> 1.000000003
-    expect(pos(SCALE + 1).mul(pos(SCALE + 2)), pos(SCALE + 3));
+    expect!(pos(SCALE + 1).mul(pos(SCALE + 2)), pos(SCALE + 3));
 
     // 0.999999999 * 0.999999999 = 0.999999998000000001 -> 0.999999998
     let almost_one = pos(SCALE - 1);
-    expect(almost_one.mul(almost_one), pos(SCALE - 2));
+    expect!(almost_one.mul(almost_one), pos(SCALE - 2));
 
     // Sign checks near the truncation boundary
-    expect(x.negate().mul(x), neg(SCALE + 2));
-    expect(x.negate().mul(x.negate()), pos(SCALE + 2));
+    expect!(x.negate().mul(x), neg(SCALE + 2));
+    expect!(x.negate().mul(x.negate()), pos(SCALE + 2));
 }
 
 #[test]
@@ -131,19 +131,19 @@ fun mul_handles_difficult_fractional_magnitudes() {
     // (999999999.999999999)^2 = 999999999999999998.000000000000000001
     let value = pos(999_999_999_999_999_999);
     let expected_square = pos(999_999_999_999_999_998_000_000_000);
-    expect(value.mul(value), pos(999_999_999_999_999_998_000_000_000));
-    expect(value.negate().mul(value), expected_square.negate());
-    expect(value.mul(value.negate()), expected_square.negate());
-    expect(value.negate().mul(value.negate()), expected_square);
+    expect!(value.mul(value), pos(999_999_999_999_999_998_000_000_000));
+    expect!(value.negate().mul(value), expected_square.negate());
+    expect!(value.mul(value.negate()), expected_square.negate());
+    expect!(value.negate().mul(value.negate()), expected_square);
 
     // 123456789.123456789 * 987654321.987654321
     let left = pos(123_456_789_123_456_789);
     let right = pos(987_654_321_987_654_321);
     let expected_product = pos(121_932_631_356_500_531_347_203_169);
-    expect(left.mul(right), expected_product);
-    expect(left.negate().mul(right), expected_product.negate());
-    expect(left.mul(right.negate()), expected_product.negate());
-    expect(left.negate().mul(right.negate()), expected_product);
+    expect!(left.mul(right), expected_product);
+    expect!(left.negate().mul(right), expected_product.negate());
+    expect!(left.mul(right.negate()), expected_product.negate());
+    expect!(left.negate().mul(right.negate()), expected_product);
 }
 
 #[test]
@@ -154,25 +154,25 @@ fun mul_large_intermediate_product_does_not_overflow() {
     let max = sd29x9::max();
     let min = sd29x9::min();
 
-    expect(max.mul(half), pos(MAX_POSITIVE_VALUE / 2));
-    expect(half.mul(max), pos(MAX_POSITIVE_VALUE / 2));
+    expect!(max.mul(half), pos(MAX_POSITIVE_VALUE / 2));
+    expect!(half.mul(max), pos(MAX_POSITIVE_VALUE / 2));
 
-    expect(min.mul(half), neg(MIN_NEGATIVE_VALUE / 2));
-    expect(half.mul(min), neg(MIN_NEGATIVE_VALUE / 2));
+    expect!(min.mul(half), neg(MIN_NEGATIVE_VALUE / 2));
+    expect!(half.mul(min), neg(MIN_NEGATIVE_VALUE / 2));
 }
 
 #[test]
 fun mul_handles_min_times_one() {
     let min = sd29x9::min();
     let one = sd29x9::one();
-    expect(min.mul(one), min);
+    expect!(min.mul(one), min);
 }
 
 #[test]
 fun mul_handles_max_times_one() {
     let max = sd29x9::max();
     let one = sd29x9::one();
-    expect(max.mul(one), max);
+    expect!(max.mul(one), max);
 }
 
 #[test, expected_failure(abort_code = sd29x9_base::EOverflow)]

--- a/math/fixed_point/tests/sd29x9_tests/negate_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/negate_tests.move
@@ -10,50 +10,50 @@ const SCALE: u128 = 1_000_000_000;
 
 #[test]
 fun negate_handles_zero() {
-    expect(sd29x9::zero().negate(), sd29x9::zero());
+    expect!(sd29x9::zero().negate(), sd29x9::zero());
 }
 
 #[test]
 fun negate_flips_positive_and_negative_values() {
-    expect(pos(1).negate(), neg(1));
-    expect(pos(SCALE).negate(), neg(SCALE));
-    expect(pos(5 * SCALE + 300_000_000).negate(), neg(5 * SCALE + 300_000_000));
+    expect!(pos(1).negate(), neg(1));
+    expect!(pos(SCALE).negate(), neg(SCALE));
+    expect!(pos(5 * SCALE + 300_000_000).negate(), neg(5 * SCALE + 300_000_000));
 
-    expect(neg(1).negate(), pos(1));
-    expect(neg(SCALE).negate(), pos(SCALE));
-    expect(neg(5 * SCALE + 300_000_000).negate(), pos(5 * SCALE + 300_000_000));
+    expect!(neg(1).negate(), pos(1));
+    expect!(neg(SCALE).negate(), pos(SCALE));
+    expect!(neg(5 * SCALE + 300_000_000).negate(), pos(5 * SCALE + 300_000_000));
 }
 
 #[test]
 fun negate_is_its_own_inverse() {
     let zero = sd29x9::zero();
-    expect(zero.negate().negate(), zero);
+    expect!(zero.negate().negate(), zero);
 
     let one = pos(1);
-    expect(one.negate().negate(), one);
+    expect!(one.negate().negate(), one);
 
     let minus_one = neg(1);
-    expect(minus_one.negate().negate(), minus_one);
+    expect!(minus_one.negate().negate(), minus_one);
 
     let large_positive = pos(500_000_000_000_000_000);
-    expect(large_positive.negate().negate(), large_positive);
+    expect!(large_positive.negate().negate(), large_positive);
 
     let large_negative = neg(500_000_000_000_000_000);
-    expect(large_negative.negate().negate(), large_negative);
+    expect!(large_negative.negate().negate(), large_negative);
 
     let pos_with_fraction = pos(42 * SCALE + 123_456_789);
-    expect(pos_with_fraction.negate().negate(), pos_with_fraction);
+    expect!(pos_with_fraction.negate().negate(), pos_with_fraction);
 
     let neg_with_fraction = neg(42 * SCALE + 123_456_789);
-    expect(neg_with_fraction.negate().negate(), neg_with_fraction);
+    expect!(neg_with_fraction.negate().negate(), neg_with_fraction);
 
     let max = sd29x9::max();
-    expect(max.negate().negate(), max);
+    expect!(max.negate().negate(), max);
 }
 
 #[test]
 fun negate_handles_max() {
-    expect(sd29x9::max().negate(), from_bits(MIN_NEGATIVE_VALUE + 1));
+    expect!(sd29x9::max().negate(), from_bits(MIN_NEGATIVE_VALUE + 1));
 }
 
 #[test, expected_failure(abort_code = sd29x9_base::EOverflow)]
@@ -64,18 +64,18 @@ fun negate_fails_for_min() {
 #[test]
 fun negate_handles_min_plus_smallest_step() {
     let min_plus_epsilon = neg(MIN_NEGATIVE_VALUE - 1);
-    expect(min_plus_epsilon.negate(), sd29x9::max());
+    expect!(min_plus_epsilon.negate(), sd29x9::max());
 }
 
 #[test]
 fun negate_one() {
-    expect(pos(SCALE).negate(), neg(SCALE));
-    expect(neg(SCALE).negate(), pos(SCALE));
+    expect!(pos(SCALE).negate(), neg(SCALE));
+    expect!(neg(SCALE).negate(), pos(SCALE));
 }
 
 #[test]
 fun negate_large_value() {
-    expect(neg(500_000_000_000).negate(), pos(500_000_000_000));
+    expect!(neg(500_000_000_000).negate(), pos(500_000_000_000));
 }
 
 #[test]

--- a/math/fixed_point/tests/sd29x9_tests/negate_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/negate_tests.move
@@ -3,57 +3,58 @@ module openzeppelin_fp_math::sd29x9_negate_tests;
 
 use openzeppelin_fp_math::sd29x9::{Self, from_bits};
 use openzeppelin_fp_math::sd29x9_base;
-use openzeppelin_fp_math::sd29x9_test_helpers::{pos, neg, expect};
+use openzeppelin_fp_math::sd29x9_test_helpers::{pos, neg};
+use std::unit_test::assert_eq;
 
 const MIN_NEGATIVE_VALUE: u128 = 0x8000_0000_0000_0000_0000_0000_0000_0000;
 const SCALE: u128 = 1_000_000_000;
 
 #[test]
 fun negate_handles_zero() {
-    expect!(sd29x9::zero().negate(), sd29x9::zero());
+    assert_eq!(sd29x9::zero().negate(), sd29x9::zero());
 }
 
 #[test]
 fun negate_flips_positive_and_negative_values() {
-    expect!(pos(1).negate(), neg(1));
-    expect!(pos(SCALE).negate(), neg(SCALE));
-    expect!(pos(5 * SCALE + 300_000_000).negate(), neg(5 * SCALE + 300_000_000));
+    assert_eq!(pos(1).negate(), neg(1));
+    assert_eq!(pos(SCALE).negate(), neg(SCALE));
+    assert_eq!(pos(5 * SCALE + 300_000_000).negate(), neg(5 * SCALE + 300_000_000));
 
-    expect!(neg(1).negate(), pos(1));
-    expect!(neg(SCALE).negate(), pos(SCALE));
-    expect!(neg(5 * SCALE + 300_000_000).negate(), pos(5 * SCALE + 300_000_000));
+    assert_eq!(neg(1).negate(), pos(1));
+    assert_eq!(neg(SCALE).negate(), pos(SCALE));
+    assert_eq!(neg(5 * SCALE + 300_000_000).negate(), pos(5 * SCALE + 300_000_000));
 }
 
 #[test]
 fun negate_is_its_own_inverse() {
     let zero = sd29x9::zero();
-    expect!(zero.negate().negate(), zero);
+    assert_eq!(zero.negate().negate(), zero);
 
     let one = pos(1);
-    expect!(one.negate().negate(), one);
+    assert_eq!(one.negate().negate(), one);
 
     let minus_one = neg(1);
-    expect!(minus_one.negate().negate(), minus_one);
+    assert_eq!(minus_one.negate().negate(), minus_one);
 
     let large_positive = pos(500_000_000_000_000_000);
-    expect!(large_positive.negate().negate(), large_positive);
+    assert_eq!(large_positive.negate().negate(), large_positive);
 
     let large_negative = neg(500_000_000_000_000_000);
-    expect!(large_negative.negate().negate(), large_negative);
+    assert_eq!(large_negative.negate().negate(), large_negative);
 
     let pos_with_fraction = pos(42 * SCALE + 123_456_789);
-    expect!(pos_with_fraction.negate().negate(), pos_with_fraction);
+    assert_eq!(pos_with_fraction.negate().negate(), pos_with_fraction);
 
     let neg_with_fraction = neg(42 * SCALE + 123_456_789);
-    expect!(neg_with_fraction.negate().negate(), neg_with_fraction);
+    assert_eq!(neg_with_fraction.negate().negate(), neg_with_fraction);
 
     let max = sd29x9::max();
-    expect!(max.negate().negate(), max);
+    assert_eq!(max.negate().negate(), max);
 }
 
 #[test]
 fun negate_handles_max() {
-    expect!(sd29x9::max().negate(), from_bits(MIN_NEGATIVE_VALUE + 1));
+    assert_eq!(sd29x9::max().negate(), from_bits(MIN_NEGATIVE_VALUE + 1));
 }
 
 #[test, expected_failure(abort_code = sd29x9_base::EOverflow)]
@@ -64,18 +65,18 @@ fun negate_fails_for_min() {
 #[test]
 fun negate_handles_min_plus_smallest_step() {
     let min_plus_epsilon = neg(MIN_NEGATIVE_VALUE - 1);
-    expect!(min_plus_epsilon.negate(), sd29x9::max());
+    assert_eq!(min_plus_epsilon.negate(), sd29x9::max());
 }
 
 #[test]
 fun negate_one() {
-    expect!(pos(SCALE).negate(), neg(SCALE));
-    expect!(neg(SCALE).negate(), pos(SCALE));
+    assert_eq!(pos(SCALE).negate(), neg(SCALE));
+    assert_eq!(neg(SCALE).negate(), pos(SCALE));
 }
 
 #[test]
 fun negate_large_value() {
-    expect!(neg(500_000_000_000).negate(), pos(500_000_000_000));
+    assert_eq!(neg(500_000_000_000).negate(), pos(500_000_000_000));
 }
 
 #[test]

--- a/math/fixed_point/tests/sd29x9_tests/pow_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/pow_tests.move
@@ -10,38 +10,38 @@ const SCALE: u128 = 1_000_000_000;
 #[test]
 fun pow_handles_zero_and_one_exponents() {
     let x = pos(12 * SCALE + 345_678_901);
-    expect(x.pow(0), sd29x9::one());
-    expect(x.pow(1), x);
-    expect(sd29x9::zero().pow(0), sd29x9::one());
+    expect!(x.pow(0), sd29x9::one());
+    expect!(x.pow(1), x);
+    expect!(sd29x9::zero().pow(0), sd29x9::one());
 }
 
 #[test]
 fun pow_handles_zero_base_and_sign_parity() {
     let zero = sd29x9::zero();
-    expect(zero.pow(5), zero);
+    expect!(zero.pow(5), zero);
 
     let neg_base = neg(2 * SCALE);
-    expect(neg_base.pow(2), pos(4 * SCALE));
-    expect(neg_base.pow(3), neg(8 * SCALE));
+    expect!(neg_base.pow(2), pos(4 * SCALE));
+    expect!(neg_base.pow(3), neg(8 * SCALE));
 }
 
 #[test]
 fun pow_handles_fractional_values_and_truncation() {
     // 1.5^2 = 2.25, 1.5^3 = 3.375
     let one_point_five = pos(1_500_000_000);
-    expect(one_point_five.pow(2), pos(2_250_000_000));
-    expect(one_point_five.pow(3), pos(3_375_000_000));
+    expect!(one_point_five.pow(2), pos(2_250_000_000));
+    expect!(one_point_five.pow(3), pos(3_375_000_000));
 
     // 1.000000001^2 = 1.000000002000000001 -> 1.000000002
     let epsilon = pos(SCALE + 1);
-    expect(epsilon.pow(2), pos(SCALE + 2));
+    expect!(epsilon.pow(2), pos(SCALE + 2));
 }
 
 #[test]
 fun pow_handles_negative_one_parity() {
     let neg_one = neg(SCALE);
-    expect(neg_one.pow(2), pos(SCALE));
-    expect(neg_one.pow(3), neg(SCALE));
+    expect!(neg_one.pow(2), pos(SCALE));
+    expect!(neg_one.pow(3), neg(SCALE));
 }
 
 #[test]
@@ -49,9 +49,9 @@ fun pow_supports_high_exponents() {
     let val = pos(SCALE + 250_000_000); // 1.25
     // Exact result for exp=16: sequential truncation of (res_mag * 1_250_000_000 / 1_000_000_000)
     // gives 35_527_136_770 (vs. exact 1.25^16 * 10^9 = 35_527_136_787 before flooring).
-    expect(val.pow(16), pos(35_527_136_770));
+    expect!(val.pow(16), pos(35_527_136_770));
     // Recurrence invariant for the maximum u8 exponent: pow(n) == pow(n-1).mul(base).
-    expect(val.pow(255), val.pow(254).mul(val));
+    expect!(val.pow(255), val.pow(254).mul(val));
 }
 
 #[test, expected_failure(abort_code = sd29x9_base::EOverflow)]
@@ -67,10 +67,10 @@ fun pow_overflow_aborts_for_large_exponent() {
 
 #[test]
 fun pow_two_squared() {
-    expect(pos(2 * SCALE).pow(2), pos(4 * SCALE));
+    expect!(pos(2 * SCALE).pow(2), pos(4 * SCALE));
 }
 
 #[test]
 fun pow_three_cubed() {
-    expect(pos(3 * SCALE).pow(3), pos(27 * SCALE));
+    expect!(pos(3 * SCALE).pow(3), pos(27 * SCALE));
 }

--- a/math/fixed_point/tests/sd29x9_tests/pow_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/pow_tests.move
@@ -3,45 +3,46 @@ module openzeppelin_fp_math::sd29x9_pow_tests;
 
 use openzeppelin_fp_math::sd29x9;
 use openzeppelin_fp_math::sd29x9_base;
-use openzeppelin_fp_math::sd29x9_test_helpers::{pos, neg, expect};
+use openzeppelin_fp_math::sd29x9_test_helpers::{pos, neg};
+use std::unit_test::assert_eq;
 
 const SCALE: u128 = 1_000_000_000;
 
 #[test]
 fun pow_handles_zero_and_one_exponents() {
     let x = pos(12 * SCALE + 345_678_901);
-    expect!(x.pow(0), sd29x9::one());
-    expect!(x.pow(1), x);
-    expect!(sd29x9::zero().pow(0), sd29x9::one());
+    assert_eq!(x.pow(0), sd29x9::one());
+    assert_eq!(x.pow(1), x);
+    assert_eq!(sd29x9::zero().pow(0), sd29x9::one());
 }
 
 #[test]
 fun pow_handles_zero_base_and_sign_parity() {
     let zero = sd29x9::zero();
-    expect!(zero.pow(5), zero);
+    assert_eq!(zero.pow(5), zero);
 
     let neg_base = neg(2 * SCALE);
-    expect!(neg_base.pow(2), pos(4 * SCALE));
-    expect!(neg_base.pow(3), neg(8 * SCALE));
+    assert_eq!(neg_base.pow(2), pos(4 * SCALE));
+    assert_eq!(neg_base.pow(3), neg(8 * SCALE));
 }
 
 #[test]
 fun pow_handles_fractional_values_and_truncation() {
     // 1.5^2 = 2.25, 1.5^3 = 3.375
     let one_point_five = pos(1_500_000_000);
-    expect!(one_point_five.pow(2), pos(2_250_000_000));
-    expect!(one_point_five.pow(3), pos(3_375_000_000));
+    assert_eq!(one_point_five.pow(2), pos(2_250_000_000));
+    assert_eq!(one_point_five.pow(3), pos(3_375_000_000));
 
     // 1.000000001^2 = 1.000000002000000001 -> 1.000000002
     let epsilon = pos(SCALE + 1);
-    expect!(epsilon.pow(2), pos(SCALE + 2));
+    assert_eq!(epsilon.pow(2), pos(SCALE + 2));
 }
 
 #[test]
 fun pow_handles_negative_one_parity() {
     let neg_one = neg(SCALE);
-    expect!(neg_one.pow(2), pos(SCALE));
-    expect!(neg_one.pow(3), neg(SCALE));
+    assert_eq!(neg_one.pow(2), pos(SCALE));
+    assert_eq!(neg_one.pow(3), neg(SCALE));
 }
 
 #[test]
@@ -49,9 +50,9 @@ fun pow_supports_high_exponents() {
     let val = pos(SCALE + 250_000_000); // 1.25
     // Exact result for exp=16: sequential truncation of (res_mag * 1_250_000_000 / 1_000_000_000)
     // gives 35_527_136_770 (vs. exact 1.25^16 * 10^9 = 35_527_136_787 before flooring).
-    expect!(val.pow(16), pos(35_527_136_770));
+    assert_eq!(val.pow(16), pos(35_527_136_770));
     // Recurrence invariant for the maximum u8 exponent: pow(n) == pow(n-1).mul(base).
-    expect!(val.pow(255), val.pow(254).mul(val));
+    assert_eq!(val.pow(255), val.pow(254).mul(val));
 }
 
 #[test, expected_failure(abort_code = sd29x9_base::EOverflow)]
@@ -67,10 +68,10 @@ fun pow_overflow_aborts_for_large_exponent() {
 
 #[test]
 fun pow_two_squared() {
-    expect!(pos(2 * SCALE).pow(2), pos(4 * SCALE));
+    assert_eq!(pos(2 * SCALE).pow(2), pos(4 * SCALE));
 }
 
 #[test]
 fun pow_three_cubed() {
-    expect!(pos(3 * SCALE).pow(3), pos(27 * SCALE));
+    assert_eq!(pos(3 * SCALE).pow(3), pos(27 * SCALE));
 }

--- a/math/fixed_point/tests/sd29x9_tests/unchecked_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/unchecked_tests.move
@@ -10,40 +10,40 @@ const SCALE: u128 = 1_000_000_000;
 fun unchecked_add_and_sub_wrap_around() {
     let max = sd29x9::max();
     let one = pos(1);
-    expect(max.unchecked_add(one), sd29x9::min());
+    expect!(max.unchecked_add(one), sd29x9::min());
 
     let min_val = sd29x9::min();
-    expect(min_val.unchecked_sub(one), max);
+    expect!(min_val.unchecked_sub(one), max);
 }
 
 #[test]
 fun unchecked_sub_zero_is_identity_for_positive() {
     let x = pos(123 * SCALE + 456_000_000);
-    expect(x.unchecked_sub(sd29x9::zero()), x);
+    expect!(x.unchecked_sub(sd29x9::zero()), x);
 }
 
 #[test]
 fun unchecked_sub_zero_is_identity_for_negative() {
     let x = neg(123 * SCALE + 456_000_000);
-    expect(x.unchecked_sub(sd29x9::zero()), x);
+    expect!(x.unchecked_sub(sd29x9::zero()), x);
 }
 
 #[test]
 fun unchecked_sub_zero_is_identity_for_max() {
     let max = sd29x9::max();
-    expect(max.unchecked_sub(sd29x9::zero()), max);
+    expect!(max.unchecked_sub(sd29x9::zero()), max);
 }
 
 #[test]
 fun unchecked_sub_zero_is_identity_for_min() {
     let min = sd29x9::min();
-    expect(min.unchecked_sub(sd29x9::zero()), min);
+    expect!(min.unchecked_sub(sd29x9::zero()), min);
 }
 
 #[test]
 fun unchecked_sub_zero_is_identity_for_zero() {
     let zero = sd29x9::zero();
-    expect(zero.unchecked_sub(zero), zero);
+    expect!(zero.unchecked_sub(zero), zero);
 }
 
 #[test]
@@ -51,16 +51,16 @@ fun unchecked_add_zero_is_identity() {
     let zero = sd29x9::zero();
     let values = vector[pos(1), neg(1), pos(SCALE), neg(SCALE), sd29x9::max(), sd29x9::min(), zero];
     values.destroy!(|x| {
-        expect(x.unchecked_add(zero), x);
+        expect!(x.unchecked_add(zero), x);
     });
 }
 
 #[test]
 fun unchecked_add_small_values() {
-    expect(pos(3).unchecked_add(pos(4)), pos(7));
+    expect!(pos(3).unchecked_add(pos(4)), pos(7));
 }
 
 #[test]
 fun unchecked_sub_small_values() {
-    expect(pos(10).unchecked_sub(pos(3)), pos(7));
+    expect!(pos(10).unchecked_sub(pos(3)), pos(7));
 }

--- a/math/fixed_point/tests/sd29x9_tests/unchecked_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/unchecked_tests.move
@@ -2,7 +2,8 @@
 module openzeppelin_fp_math::sd29x9_unchecked_tests;
 
 use openzeppelin_fp_math::sd29x9;
-use openzeppelin_fp_math::sd29x9_test_helpers::{pos, neg, expect};
+use openzeppelin_fp_math::sd29x9_test_helpers::{pos, neg};
+use std::unit_test::assert_eq;
 
 const SCALE: u128 = 1_000_000_000;
 
@@ -10,40 +11,40 @@ const SCALE: u128 = 1_000_000_000;
 fun unchecked_add_and_sub_wrap_around() {
     let max = sd29x9::max();
     let one = pos(1);
-    expect!(max.unchecked_add(one), sd29x9::min());
+    assert_eq!(max.unchecked_add(one), sd29x9::min());
 
     let min_val = sd29x9::min();
-    expect!(min_val.unchecked_sub(one), max);
+    assert_eq!(min_val.unchecked_sub(one), max);
 }
 
 #[test]
 fun unchecked_sub_zero_is_identity_for_positive() {
     let x = pos(123 * SCALE + 456_000_000);
-    expect!(x.unchecked_sub(sd29x9::zero()), x);
+    assert_eq!(x.unchecked_sub(sd29x9::zero()), x);
 }
 
 #[test]
 fun unchecked_sub_zero_is_identity_for_negative() {
     let x = neg(123 * SCALE + 456_000_000);
-    expect!(x.unchecked_sub(sd29x9::zero()), x);
+    assert_eq!(x.unchecked_sub(sd29x9::zero()), x);
 }
 
 #[test]
 fun unchecked_sub_zero_is_identity_for_max() {
     let max = sd29x9::max();
-    expect!(max.unchecked_sub(sd29x9::zero()), max);
+    assert_eq!(max.unchecked_sub(sd29x9::zero()), max);
 }
 
 #[test]
 fun unchecked_sub_zero_is_identity_for_min() {
     let min = sd29x9::min();
-    expect!(min.unchecked_sub(sd29x9::zero()), min);
+    assert_eq!(min.unchecked_sub(sd29x9::zero()), min);
 }
 
 #[test]
 fun unchecked_sub_zero_is_identity_for_zero() {
     let zero = sd29x9::zero();
-    expect!(zero.unchecked_sub(zero), zero);
+    assert_eq!(zero.unchecked_sub(zero), zero);
 }
 
 #[test]
@@ -51,16 +52,16 @@ fun unchecked_add_zero_is_identity() {
     let zero = sd29x9::zero();
     let values = vector[pos(1), neg(1), pos(SCALE), neg(SCALE), sd29x9::max(), sd29x9::min(), zero];
     values.destroy!(|x| {
-        expect!(x.unchecked_add(zero), x);
+        assert_eq!(x.unchecked_add(zero), x);
     });
 }
 
 #[test]
 fun unchecked_add_small_values() {
-    expect!(pos(3).unchecked_add(pos(4)), pos(7));
+    assert_eq!(pos(3).unchecked_add(pos(4)), pos(7));
 }
 
 #[test]
 fun unchecked_sub_small_values() {
-    expect!(pos(10).unchecked_sub(pos(3)), pos(7));
+    assert_eq!(pos(10).unchecked_sub(pos(3)), pos(7));
 }

--- a/math/fixed_point/tests/sd29x9_tests/wrap_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/wrap_tests.move
@@ -12,7 +12,7 @@ const MIN_NEGATIVE_VALUE: u128 = 0x8000_0000_0000_0000_0000_0000_0000_0000;
 #[test]
 fun wrap_max_positive() {
     let value = sd29x9::wrap(MAX_POSITIVE_VALUE, false);
-    expect(value, sd29x9::max());
+    expect!(value, sd29x9::max());
 }
 
 #[test]
@@ -27,7 +27,7 @@ fun wrap_negative_zero_is_zero() {
 
 #[test]
 fun wrap_min_value() {
-    expect(sd29x9::min(), from_bits(MIN_NEGATIVE_VALUE));
+    expect!(sd29x9::min(), from_bits(MIN_NEGATIVE_VALUE));
 }
 
 #[test, expected_failure(abort_code = sd29x9::EOverflow)]
@@ -58,15 +58,15 @@ fun from_bits_all_ones() {
 
 #[test]
 fun from_bits_max_positive() {
-    expect(from_bits(MAX_POSITIVE_VALUE), sd29x9::max());
+    expect!(from_bits(MAX_POSITIVE_VALUE), sd29x9::max());
 }
 
 #[test]
 fun from_bits_min_negative() {
-    expect(from_bits(MIN_NEGATIVE_VALUE), sd29x9::min());
+    expect!(from_bits(MIN_NEGATIVE_VALUE), sd29x9::min());
 }
 
 #[test]
 fun from_bits_one() {
-    expect(from_bits(1), pos(1));
+    expect!(from_bits(1), pos(1));
 }

--- a/math/fixed_point/tests/sd29x9_tests/wrap_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/wrap_tests.move
@@ -2,7 +2,7 @@
 module openzeppelin_fp_math::sd29x9_wrap_tests;
 
 use openzeppelin_fp_math::sd29x9::{Self, from_bits};
-use openzeppelin_fp_math::sd29x9_test_helpers::{pos, expect};
+use openzeppelin_fp_math::sd29x9_test_helpers::pos;
 use std::unit_test::assert_eq;
 
 const ALL_ONES: u128 = 0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF;
@@ -12,7 +12,7 @@ const MIN_NEGATIVE_VALUE: u128 = 0x8000_0000_0000_0000_0000_0000_0000_0000;
 #[test]
 fun wrap_max_positive() {
     let value = sd29x9::wrap(MAX_POSITIVE_VALUE, false);
-    expect!(value, sd29x9::max());
+    assert_eq!(value, sd29x9::max());
 }
 
 #[test]
@@ -27,7 +27,7 @@ fun wrap_negative_zero_is_zero() {
 
 #[test]
 fun wrap_min_value() {
-    expect!(sd29x9::min(), from_bits(MIN_NEGATIVE_VALUE));
+    assert_eq!(sd29x9::min(), from_bits(MIN_NEGATIVE_VALUE));
 }
 
 #[test, expected_failure(abort_code = sd29x9::EOverflow)]
@@ -58,15 +58,15 @@ fun from_bits_all_ones() {
 
 #[test]
 fun from_bits_max_positive() {
-    expect!(from_bits(MAX_POSITIVE_VALUE), sd29x9::max());
+    assert_eq!(from_bits(MAX_POSITIVE_VALUE), sd29x9::max());
 }
 
 #[test]
 fun from_bits_min_negative() {
-    expect!(from_bits(MIN_NEGATIVE_VALUE), sd29x9::min());
+    assert_eq!(from_bits(MIN_NEGATIVE_VALUE), sd29x9::min());
 }
 
 #[test]
 fun from_bits_one() {
-    expect!(from_bits(1), pos(1));
+    assert_eq!(from_bits(1), pos(1));
 }

--- a/math/fixed_point/tests/ud30x9_tests/abs_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/abs_tests.move
@@ -36,11 +36,11 @@ fun abs_handles_zero() {
 fun abs_handles_edge_cases() {
     // 0.000000001 -> 0.000000001
     let tiny = fixed(1);
-    expect(tiny.abs(), tiny);
+    expect!(tiny.abs(), tiny);
 
     // 1000000.5 -> 1000000.5
     let large = fixed(1000000 * SCALE + 500_000_000);
-    expect(large.abs(), large);
+    expect!(large.abs(), large);
 
     // Max value remains unchanged
     let max = ud30x9::max();
@@ -59,7 +59,7 @@ fun abs_of_scale_minus_one() {
 
 #[test]
 fun abs_of_max() {
-    expect(ud30x9::max().abs(), ud30x9::max());
+    expect!(ud30x9::max().abs(), ud30x9::max());
 }
 
 #[test]

--- a/math/fixed_point/tests/ud30x9_tests/abs_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/abs_tests.move
@@ -2,7 +2,7 @@
 module openzeppelin_fp_math::ud30x9_abs_tests;
 
 use openzeppelin_fp_math::ud30x9;
-use openzeppelin_fp_math::ud30x9_test_helpers::{fixed, expect};
+use openzeppelin_fp_math::ud30x9_test_helpers::fixed;
 use std::unit_test::assert_eq;
 
 const MAX_VALUE: u128 = 0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF;
@@ -36,11 +36,11 @@ fun abs_handles_zero() {
 fun abs_handles_edge_cases() {
     // 0.000000001 -> 0.000000001
     let tiny = fixed(1);
-    expect!(tiny.abs(), tiny);
+    assert_eq!(tiny.abs(), tiny);
 
     // 1000000.5 -> 1000000.5
     let large = fixed(1000000 * SCALE + 500_000_000);
-    expect!(large.abs(), large);
+    assert_eq!(large.abs(), large);
 
     // Max value remains unchanged
     let max = ud30x9::max();
@@ -59,7 +59,7 @@ fun abs_of_scale_minus_one() {
 
 #[test]
 fun abs_of_max() {
-    expect!(ud30x9::max().abs(), ud30x9::max());
+    assert_eq!(ud30x9::max().abs(), ud30x9::max());
 }
 
 #[test]

--- a/math/fixed_point/tests/ud30x9_tests/arithmetic_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/arithmetic_tests.move
@@ -2,7 +2,7 @@
 module openzeppelin_fp_math::ud30x9_arithmetic_tests;
 
 use openzeppelin_fp_math::ud30x9_base;
-use openzeppelin_fp_math::ud30x9_test_helpers::{fixed, expect, pair, unpack};
+use openzeppelin_fp_math::ud30x9_test_helpers::{fixed, pair, unpack};
 use std::unit_test::assert_eq;
 
 const MAX_VALUE: u128 = 0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF;
@@ -61,8 +61,8 @@ fun add_zero_is_identity() {
         fixed(1_000_000 * SCALE),
     ];
     cases.destroy!(|x| {
-        expect!(x.add(zero), x);
-        expect!(zero.add(x), x);
+        assert_eq!(x.add(zero), x);
+        assert_eq!(zero.add(x), x);
     });
 }
 

--- a/math/fixed_point/tests/ud30x9_tests/arithmetic_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/arithmetic_tests.move
@@ -61,8 +61,8 @@ fun add_zero_is_identity() {
         fixed(1_000_000 * SCALE),
     ];
     cases.destroy!(|x| {
-        expect(x.add(zero), x);
-        expect(zero.add(x), x);
+        expect!(x.add(zero), x);
+        expect!(zero.add(x), x);
     });
 }
 

--- a/math/fixed_point/tests/ud30x9_tests/bitwise_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/bitwise_tests.move
@@ -37,25 +37,25 @@ fun bitwise_and_shift_helpers_behave_like_u128() {
 #[test]
 fun lshift_by_128_returns_zero() {
     let x = fixed(1);
-    expect(x.lshift(128), fixed(0));
+    expect!(x.lshift(128), fixed(0));
 }
 
 #[test]
 fun rshift_by_128_returns_zero() {
     let x = fixed(1);
-    expect(x.rshift(128), fixed(0));
+    expect!(x.rshift(128), fixed(0));
 }
 
 #[test]
 fun lshift_by_255_returns_zero() {
     let x = fixed(1);
-    expect(x.lshift(255), fixed(0));
+    expect!(x.lshift(255), fixed(0));
 }
 
 #[test]
 fun rshift_by_255_returns_zero() {
     let x = fixed(1);
-    expect(x.rshift(255), fixed(0));
+    expect!(x.rshift(255), fixed(0));
 }
 
 #[test]

--- a/math/fixed_point/tests/ud30x9_tests/bitwise_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/bitwise_tests.move
@@ -1,7 +1,7 @@
 #[test_only]
 module openzeppelin_fp_math::ud30x9_bitwise_tests;
 
-use openzeppelin_fp_math::ud30x9_test_helpers::{fixed, expect, pair, unpack};
+use openzeppelin_fp_math::ud30x9_test_helpers::{fixed, pair, unpack};
 use std::unit_test::assert_eq;
 
 const MAX_VALUE: u128 = 0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF;
@@ -37,25 +37,25 @@ fun bitwise_and_shift_helpers_behave_like_u128() {
 #[test]
 fun lshift_by_128_returns_zero() {
     let x = fixed(1);
-    expect!(x.lshift(128), fixed(0));
+    assert_eq!(x.lshift(128), fixed(0));
 }
 
 #[test]
 fun rshift_by_128_returns_zero() {
     let x = fixed(1);
-    expect!(x.rshift(128), fixed(0));
+    assert_eq!(x.rshift(128), fixed(0));
 }
 
 #[test]
 fun lshift_by_255_returns_zero() {
     let x = fixed(1);
-    expect!(x.lshift(255), fixed(0));
+    assert_eq!(x.lshift(255), fixed(0));
 }
 
 #[test]
 fun rshift_by_255_returns_zero() {
     let x = fixed(1);
-    expect!(x.rshift(255), fixed(0));
+    assert_eq!(x.rshift(255), fixed(0));
 }
 
 #[test]

--- a/math/fixed_point/tests/ud30x9_tests/casting_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/casting_tests.move
@@ -17,7 +17,7 @@ fun into_sd29x9_converts_zero() {
     let zero = ud30x9::zero();
     let converted = zero.into_SD29x9();
     assert!(converted.is_zero());
-    assert!(converted.eq(sd29x9::zero()));
+    assert_eq!(converted, sd29x9::zero());
 }
 
 #[test]

--- a/math/fixed_point/tests/ud30x9_tests/ceil_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/ceil_tests.move
@@ -13,57 +13,57 @@ const SCALE: u128 = 1_000_000_000;
 fun ceil_rounds_up_fractional_values() {
     // 5.3 -> 6.0
     let value = fixed(5 * SCALE + 300_000_000);
-    expect(value.ceil(), fixed(6 * SCALE));
+    expect!(value.ceil(), fixed(6 * SCALE));
 
     // 5.9 -> 6.0
     let value = fixed(5 * SCALE + 900_000_000);
-    expect(value.ceil(), fixed(6 * SCALE));
+    expect!(value.ceil(), fixed(6 * SCALE));
 
     // 1.1 -> 2.0
     let value = fixed(SCALE + 100_000_000);
-    expect(value.ceil(), fixed(2 * SCALE));
+    expect!(value.ceil(), fixed(2 * SCALE));
 
     // 0.5 -> 1.0
     let value = fixed(500_000_000);
-    expect(value.ceil(), fixed(SCALE));
+    expect!(value.ceil(), fixed(SCALE));
 
     // 0.1 -> 1.0
     let value = fixed(100_000_000);
-    expect(value.ceil(), fixed(SCALE));
+    expect!(value.ceil(), fixed(SCALE));
 }
 
 #[test]
 fun ceil_preserves_integer_values() {
     // 5.0 -> 5.0
     let value = fixed(5 * SCALE);
-    expect(value.ceil(), fixed(5 * SCALE));
+    expect!(value.ceil(), fixed(5 * SCALE));
 
     // 0.0 -> 0.0
     let zero = fixed(0);
-    expect(zero.ceil(), fixed(0));
+    expect!(zero.ceil(), fixed(0));
 
     // 100.0 -> 100.0
     let value = fixed(100 * SCALE);
-    expect(value.ceil(), fixed(100 * SCALE));
+    expect!(value.ceil(), fixed(100 * SCALE));
 
     // 1.0 -> 1.0
     let value = fixed(SCALE);
-    expect(value.ceil(), fixed(SCALE));
+    expect!(value.ceil(), fixed(SCALE));
 }
 
 #[test]
 fun ceil_handles_edge_cases() {
     // 0.000000001 -> 1.0
     let tiny = fixed(1);
-    expect(tiny.ceil(), fixed(SCALE));
+    expect!(tiny.ceil(), fixed(SCALE));
 
     // 1000000000.5 -> 1000000001.0
     let large = fixed(1_000_000_000 * SCALE + 500_000_000);
-    expect(large.ceil(), fixed(1_000_000_001 * SCALE));
+    expect!(large.ceil(), fixed(1_000_000_001 * SCALE));
 
     // 5.999999999 -> 6.0
     let almost = fixed(6 * SCALE - 1);
-    expect(almost.ceil(), fixed(6 * SCALE));
+    expect!(almost.ceil(), fixed(6 * SCALE));
 }
 
 #[test, expected_failure(abort_code = ud30x9_base::EOverflow)]
@@ -73,29 +73,29 @@ fun ceil_fails_for_max() {
 
 #[test]
 fun ceil_of_zero() {
-    expect(fixed(0).ceil(), fixed(0));
+    expect!(fixed(0).ceil(), fixed(0));
 }
 
 #[test]
 fun ceil_of_just_above_integer() {
     // 1.000000001 -> 2.0
-    expect(fixed(SCALE + 1).ceil(), fixed(2 * SCALE));
+    expect!(fixed(SCALE + 1).ceil(), fixed(2 * SCALE));
 }
 
 #[test]
 fun ceil_of_just_below_integer() {
     // 1.999999999 -> 2.0
-    expect(fixed(2 * SCALE - 1).ceil(), fixed(2 * SCALE));
+    expect!(fixed(2 * SCALE - 1).ceil(), fixed(2 * SCALE));
 }
 
 #[test]
 fun ceil_large_integer() {
     // 1000000.0 -> 1000000.0 (integer preserved)
-    expect(fixed(1_000_000 * SCALE).ceil(), fixed(1_000_000 * SCALE));
+    expect!(fixed(1_000_000 * SCALE).ceil(), fixed(1_000_000 * SCALE));
 }
 
 #[test]
 fun ceil_of_999999999() {
     // 0.999999999 -> 1.0
-    expect(fixed(999_999_999).ceil(), fixed(SCALE));
+    expect!(fixed(999_999_999).ceil(), fixed(SCALE));
 }

--- a/math/fixed_point/tests/ud30x9_tests/ceil_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/ceil_tests.move
@@ -3,7 +3,8 @@ module openzeppelin_fp_math::ud30x9_ceil_tests;
 
 use openzeppelin_fp_math::ud30x9;
 use openzeppelin_fp_math::ud30x9_base;
-use openzeppelin_fp_math::ud30x9_test_helpers::{fixed, expect};
+use openzeppelin_fp_math::ud30x9_test_helpers::fixed;
+use std::unit_test::assert_eq;
 
 const SCALE: u128 = 1_000_000_000;
 
@@ -13,57 +14,57 @@ const SCALE: u128 = 1_000_000_000;
 fun ceil_rounds_up_fractional_values() {
     // 5.3 -> 6.0
     let value = fixed(5 * SCALE + 300_000_000);
-    expect!(value.ceil(), fixed(6 * SCALE));
+    assert_eq!(value.ceil(), fixed(6 * SCALE));
 
     // 5.9 -> 6.0
     let value = fixed(5 * SCALE + 900_000_000);
-    expect!(value.ceil(), fixed(6 * SCALE));
+    assert_eq!(value.ceil(), fixed(6 * SCALE));
 
     // 1.1 -> 2.0
     let value = fixed(SCALE + 100_000_000);
-    expect!(value.ceil(), fixed(2 * SCALE));
+    assert_eq!(value.ceil(), fixed(2 * SCALE));
 
     // 0.5 -> 1.0
     let value = fixed(500_000_000);
-    expect!(value.ceil(), fixed(SCALE));
+    assert_eq!(value.ceil(), fixed(SCALE));
 
     // 0.1 -> 1.0
     let value = fixed(100_000_000);
-    expect!(value.ceil(), fixed(SCALE));
+    assert_eq!(value.ceil(), fixed(SCALE));
 }
 
 #[test]
 fun ceil_preserves_integer_values() {
     // 5.0 -> 5.0
     let value = fixed(5 * SCALE);
-    expect!(value.ceil(), fixed(5 * SCALE));
+    assert_eq!(value.ceil(), fixed(5 * SCALE));
 
     // 0.0 -> 0.0
     let zero = fixed(0);
-    expect!(zero.ceil(), fixed(0));
+    assert_eq!(zero.ceil(), fixed(0));
 
     // 100.0 -> 100.0
     let value = fixed(100 * SCALE);
-    expect!(value.ceil(), fixed(100 * SCALE));
+    assert_eq!(value.ceil(), fixed(100 * SCALE));
 
     // 1.0 -> 1.0
     let value = fixed(SCALE);
-    expect!(value.ceil(), fixed(SCALE));
+    assert_eq!(value.ceil(), fixed(SCALE));
 }
 
 #[test]
 fun ceil_handles_edge_cases() {
     // 0.000000001 -> 1.0
     let tiny = fixed(1);
-    expect!(tiny.ceil(), fixed(SCALE));
+    assert_eq!(tiny.ceil(), fixed(SCALE));
 
     // 1000000000.5 -> 1000000001.0
     let large = fixed(1_000_000_000 * SCALE + 500_000_000);
-    expect!(large.ceil(), fixed(1_000_000_001 * SCALE));
+    assert_eq!(large.ceil(), fixed(1_000_000_001 * SCALE));
 
     // 5.999999999 -> 6.0
     let almost = fixed(6 * SCALE - 1);
-    expect!(almost.ceil(), fixed(6 * SCALE));
+    assert_eq!(almost.ceil(), fixed(6 * SCALE));
 }
 
 #[test, expected_failure(abort_code = ud30x9_base::EOverflow)]
@@ -73,29 +74,29 @@ fun ceil_fails_for_max() {
 
 #[test]
 fun ceil_of_zero() {
-    expect!(fixed(0).ceil(), fixed(0));
+    assert_eq!(fixed(0).ceil(), fixed(0));
 }
 
 #[test]
 fun ceil_of_just_above_integer() {
     // 1.000000001 -> 2.0
-    expect!(fixed(SCALE + 1).ceil(), fixed(2 * SCALE));
+    assert_eq!(fixed(SCALE + 1).ceil(), fixed(2 * SCALE));
 }
 
 #[test]
 fun ceil_of_just_below_integer() {
     // 1.999999999 -> 2.0
-    expect!(fixed(2 * SCALE - 1).ceil(), fixed(2 * SCALE));
+    assert_eq!(fixed(2 * SCALE - 1).ceil(), fixed(2 * SCALE));
 }
 
 #[test]
 fun ceil_large_integer() {
     // 1000000.0 -> 1000000.0 (integer preserved)
-    expect!(fixed(1_000_000 * SCALE).ceil(), fixed(1_000_000 * SCALE));
+    assert_eq!(fixed(1_000_000 * SCALE).ceil(), fixed(1_000_000 * SCALE));
 }
 
 #[test]
 fun ceil_of_999999999() {
     // 0.999999999 -> 1.0
-    expect!(fixed(999_999_999).ceil(), fixed(SCALE));
+    assert_eq!(fixed(999_999_999).ceil(), fixed(SCALE));
 }

--- a/math/fixed_point/tests/ud30x9_tests/comparison_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/comparison_tests.move
@@ -2,6 +2,7 @@
 module openzeppelin_fp_math::ud30x9_comparison_tests;
 
 use openzeppelin_fp_math::ud30x9_test_helpers::{fixed, pair, unpack};
+use std::unit_test::assert_eq;
 
 const MAX_VALUE: u128 = 0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF;
 const SCALE: u128 = 1_000_000_000;
@@ -25,7 +26,7 @@ fun comparison_helpers_cover_all_outcomes() {
     assert!(low.lte(low));
     assert!(!high.lte(low));
 
-    assert!(low.eq(low));
+    assert_eq!(low, low);
     assert!(!low.eq(high));
 
     assert!(low.neq(high));
@@ -39,7 +40,7 @@ fun comparison_helpers_cover_all_outcomes() {
 #[test]
 fun compare_equal_values() {
     let x = fixed(42 * SCALE);
-    assert!(x.eq(fixed(42 * SCALE)));
+    assert_eq!(x, fixed(42 * SCALE));
     assert!(x.lte(fixed(42 * SCALE)));
     assert!(x.gte(fixed(42 * SCALE)));
 }
@@ -70,7 +71,7 @@ fun eq_and_neq_consistency() {
     ];
     pairs.destroy!(|p| {
         let (a, b) = p.unpack();
-        assert!(a.eq(b));
+        assert_eq!(a, b);
         assert!(!a.neq(b));
     });
 }

--- a/math/fixed_point/tests/ud30x9_tests/div_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/div_tests.move
@@ -15,8 +15,8 @@ fun div_handles_zero_and_identity_cases() {
     let one = fixed(SCALE);
     let value = fixed(7 * SCALE + 500_000_000); // 7.5
 
-    expect(zero.div(value), zero);
-    expect(value.div(one), value);
+    expect!(zero.div(value), zero);
+    expect!(value.div(one), value);
 }
 
 #[test]
@@ -24,10 +24,10 @@ fun div_handles_exact_and_fractional_results() {
     // 7.5 / 2.5 = 3.0
     let numerator = fixed(7 * SCALE + 500_000_000);
     let denominator = fixed(2 * SCALE + 500_000_000);
-    expect(numerator.div(denominator), fixed(3 * SCALE));
+    expect!(numerator.div(denominator), fixed(3 * SCALE));
 
     // 1.0 / 3.0 = 0.333333333...
-    expect(fixed(SCALE).div(fixed(3 * SCALE)), fixed(333_333_333));
+    expect!(fixed(SCALE).div(fixed(3 * SCALE)), fixed(333_333_333));
 }
 
 #[test]
@@ -35,13 +35,13 @@ fun div_truncates_repeating_results() {
     // 2.000000001 / 2.0 = 1.0000000005 -> 1.000000000
     let numerator = fixed(2 * SCALE + 1);
     let denominator = fixed(2 * SCALE);
-    expect(numerator.div(denominator), fixed(SCALE));
+    expect!(numerator.div(denominator), fixed(SCALE));
 }
 
 #[test]
 fun div_handles_extreme_but_valid_inputs() {
     // max / max = 1.0
-    expect(ud30x9::max().div(ud30x9::max()), fixed(SCALE));
+    expect!(ud30x9::max().div(ud30x9::max()), fixed(SCALE));
 }
 
 #[test, expected_failure(arithmetic_error, location = openzeppelin_fp_math::ud30x9_base)]
@@ -64,24 +64,24 @@ fun div_self_is_one() {
         fixed(100 * SCALE),
     ];
     cases.destroy!(|x| {
-        expect(x.div(x), fixed(SCALE));
+        expect!(x.div(x), fixed(SCALE));
     });
 }
 
 #[test]
 fun div_large_by_small() {
     // 10.0 / 2.0 = 5.0
-    expect(fixed(10 * SCALE).div(fixed(2 * SCALE)), fixed(5 * SCALE));
+    expect!(fixed(10 * SCALE).div(fixed(2 * SCALE)), fixed(5 * SCALE));
 }
 
 #[test]
 fun div_small_by_large() {
     // 1.0 / 10.0 = 0.1
-    expect(fixed(SCALE).div(fixed(10 * SCALE)), fixed(100_000_000));
+    expect!(fixed(SCALE).div(fixed(10 * SCALE)), fixed(100_000_000));
 }
 
 #[test]
 fun div_two_by_four() {
     // 2.0 / 4.0 = 0.5
-    expect(fixed(2 * SCALE).div(fixed(4 * SCALE)), fixed(500_000_000));
+    expect!(fixed(2 * SCALE).div(fixed(4 * SCALE)), fixed(500_000_000));
 }

--- a/math/fixed_point/tests/ud30x9_tests/div_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/div_tests.move
@@ -3,7 +3,8 @@ module openzeppelin_fp_math::ud30x9_div_tests;
 
 use openzeppelin_fp_math::ud30x9;
 use openzeppelin_fp_math::ud30x9_base;
-use openzeppelin_fp_math::ud30x9_test_helpers::{fixed, expect};
+use openzeppelin_fp_math::ud30x9_test_helpers::fixed;
+use std::unit_test::assert_eq;
 
 const SCALE: u128 = 1_000_000_000;
 
@@ -15,8 +16,8 @@ fun div_handles_zero_and_identity_cases() {
     let one = fixed(SCALE);
     let value = fixed(7 * SCALE + 500_000_000); // 7.5
 
-    expect!(zero.div(value), zero);
-    expect!(value.div(one), value);
+    assert_eq!(zero.div(value), zero);
+    assert_eq!(value.div(one), value);
 }
 
 #[test]
@@ -24,10 +25,10 @@ fun div_handles_exact_and_fractional_results() {
     // 7.5 / 2.5 = 3.0
     let numerator = fixed(7 * SCALE + 500_000_000);
     let denominator = fixed(2 * SCALE + 500_000_000);
-    expect!(numerator.div(denominator), fixed(3 * SCALE));
+    assert_eq!(numerator.div(denominator), fixed(3 * SCALE));
 
     // 1.0 / 3.0 = 0.333333333...
-    expect!(fixed(SCALE).div(fixed(3 * SCALE)), fixed(333_333_333));
+    assert_eq!(fixed(SCALE).div(fixed(3 * SCALE)), fixed(333_333_333));
 }
 
 #[test]
@@ -35,13 +36,13 @@ fun div_truncates_repeating_results() {
     // 2.000000001 / 2.0 = 1.0000000005 -> 1.000000000
     let numerator = fixed(2 * SCALE + 1);
     let denominator = fixed(2 * SCALE);
-    expect!(numerator.div(denominator), fixed(SCALE));
+    assert_eq!(numerator.div(denominator), fixed(SCALE));
 }
 
 #[test]
 fun div_handles_extreme_but_valid_inputs() {
     // max / max = 1.0
-    expect!(ud30x9::max().div(ud30x9::max()), fixed(SCALE));
+    assert_eq!(ud30x9::max().div(ud30x9::max()), fixed(SCALE));
 }
 
 #[test, expected_failure(arithmetic_error, location = openzeppelin_fp_math::ud30x9_base)]
@@ -64,24 +65,24 @@ fun div_self_is_one() {
         fixed(100 * SCALE),
     ];
     cases.destroy!(|x| {
-        expect!(x.div(x), fixed(SCALE));
+        assert_eq!(x.div(x), fixed(SCALE));
     });
 }
 
 #[test]
 fun div_large_by_small() {
     // 10.0 / 2.0 = 5.0
-    expect!(fixed(10 * SCALE).div(fixed(2 * SCALE)), fixed(5 * SCALE));
+    assert_eq!(fixed(10 * SCALE).div(fixed(2 * SCALE)), fixed(5 * SCALE));
 }
 
 #[test]
 fun div_small_by_large() {
     // 1.0 / 10.0 = 0.1
-    expect!(fixed(SCALE).div(fixed(10 * SCALE)), fixed(100_000_000));
+    assert_eq!(fixed(SCALE).div(fixed(10 * SCALE)), fixed(100_000_000));
 }
 
 #[test]
 fun div_two_by_four() {
     // 2.0 / 4.0 = 0.5
-    expect!(fixed(2 * SCALE).div(fixed(4 * SCALE)), fixed(500_000_000));
+    assert_eq!(fixed(2 * SCALE).div(fixed(4 * SCALE)), fixed(500_000_000));
 }

--- a/math/fixed_point/tests/ud30x9_tests/floor_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/floor_tests.move
@@ -2,7 +2,8 @@
 module openzeppelin_fp_math::ud30x9_floor_tests;
 
 use openzeppelin_fp_math::ud30x9;
-use openzeppelin_fp_math::ud30x9_test_helpers::{fixed, expect};
+use openzeppelin_fp_math::ud30x9_test_helpers::fixed;
+use std::unit_test::assert_eq;
 
 const MAX_VALUE: u128 = 0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF;
 const SCALE: u128 = 1_000_000_000;
@@ -13,87 +14,87 @@ const SCALE: u128 = 1_000_000_000;
 fun floor_truncates_fractional_values() {
     // 5.3 -> 5.0
     let value = fixed(5 * SCALE + 300_000_000);
-    expect!(value.floor(), fixed(5 * SCALE));
+    assert_eq!(value.floor(), fixed(5 * SCALE));
 
     // 5.9 -> 5.0
     let value = fixed(5 * SCALE + 900_000_000);
-    expect!(value.floor(), fixed(5 * SCALE));
+    assert_eq!(value.floor(), fixed(5 * SCALE));
 
     // 1.1 -> 1.0
     let value = fixed(SCALE + 100_000_000);
-    expect!(value.floor(), fixed(SCALE));
+    assert_eq!(value.floor(), fixed(SCALE));
 
     // 0.5 -> 0.0
     let value = fixed(500_000_000);
-    expect!(value.floor(), fixed(0));
+    assert_eq!(value.floor(), fixed(0));
 
     // 0.1 -> 0.0
     let value = fixed(100_000_000);
-    expect!(value.floor(), fixed(0));
+    assert_eq!(value.floor(), fixed(0));
 }
 
 #[test]
 fun floor_preserves_integer_values() {
     // 5.0 -> 5.0
     let value = fixed(5 * SCALE);
-    expect!(value.floor(), fixed(5 * SCALE));
+    assert_eq!(value.floor(), fixed(5 * SCALE));
 
     // 0.0 -> 0.0
     let zero = fixed(0);
-    expect!(zero.floor(), fixed(0));
+    assert_eq!(zero.floor(), fixed(0));
 
     // 100.0 -> 100.0
     let value = fixed(100 * SCALE);
-    expect!(value.floor(), fixed(100 * SCALE));
+    assert_eq!(value.floor(), fixed(100 * SCALE));
 
     // 1.0 -> 1.0
     let value = fixed(SCALE);
-    expect!(value.floor(), fixed(SCALE));
+    assert_eq!(value.floor(), fixed(SCALE));
 }
 
 #[test]
 fun floor_handles_edge_cases() {
     // 0.000000001 -> 0.0
     let tiny = fixed(1);
-    expect!(tiny.floor(), fixed(0));
+    assert_eq!(tiny.floor(), fixed(0));
 
     // 1000000000.5 -> 1000000000.0
     let large = fixed(1_000_000_000 * SCALE + 500_000_000);
-    expect!(large.floor(), fixed(1_000_000_000 * SCALE));
+    assert_eq!(large.floor(), fixed(1_000_000_000 * SCALE));
 
     // 5.000000001 -> 5.0
     let almost = fixed(5 * SCALE + 1);
-    expect!(almost.floor(), fixed(5 * SCALE));
+    assert_eq!(almost.floor(), fixed(5 * SCALE));
 }
 
 #[test]
 fun floor_handles_max() {
     let max = ud30x9::max();
     let expected = MAX_VALUE - MAX_VALUE % SCALE;
-    expect!(max.floor(), fixed(expected));
+    assert_eq!(max.floor(), fixed(expected));
 }
 
 #[test]
 fun floor_of_zero() {
-    expect!(fixed(0).floor(), fixed(0));
+    assert_eq!(fixed(0).floor(), fixed(0));
 }
 
 #[test]
 fun floor_of_just_above_integer() {
     // 1.000000001 -> 1.0
-    expect!(fixed(SCALE + 1).floor(), fixed(SCALE));
+    assert_eq!(fixed(SCALE + 1).floor(), fixed(SCALE));
 }
 
 #[test]
 fun floor_of_just_below_integer() {
     // 1.999999999 -> 1.0
-    expect!(fixed(2 * SCALE - 1).floor(), fixed(SCALE));
+    assert_eq!(fixed(2 * SCALE - 1).floor(), fixed(SCALE));
 }
 
 #[test]
 fun floor_large_integer() {
     // 1000000.0 -> 1000000.0 (integer preserved)
-    expect!(fixed(1_000_000 * SCALE).floor(), fixed(1_000_000 * SCALE));
+    assert_eq!(fixed(1_000_000 * SCALE).floor(), fixed(1_000_000 * SCALE));
 }
 
 #[test]

--- a/math/fixed_point/tests/ud30x9_tests/floor_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/floor_tests.move
@@ -13,87 +13,87 @@ const SCALE: u128 = 1_000_000_000;
 fun floor_truncates_fractional_values() {
     // 5.3 -> 5.0
     let value = fixed(5 * SCALE + 300_000_000);
-    expect(value.floor(), fixed(5 * SCALE));
+    expect!(value.floor(), fixed(5 * SCALE));
 
     // 5.9 -> 5.0
     let value = fixed(5 * SCALE + 900_000_000);
-    expect(value.floor(), fixed(5 * SCALE));
+    expect!(value.floor(), fixed(5 * SCALE));
 
     // 1.1 -> 1.0
     let value = fixed(SCALE + 100_000_000);
-    expect(value.floor(), fixed(SCALE));
+    expect!(value.floor(), fixed(SCALE));
 
     // 0.5 -> 0.0
     let value = fixed(500_000_000);
-    expect(value.floor(), fixed(0));
+    expect!(value.floor(), fixed(0));
 
     // 0.1 -> 0.0
     let value = fixed(100_000_000);
-    expect(value.floor(), fixed(0));
+    expect!(value.floor(), fixed(0));
 }
 
 #[test]
 fun floor_preserves_integer_values() {
     // 5.0 -> 5.0
     let value = fixed(5 * SCALE);
-    expect(value.floor(), fixed(5 * SCALE));
+    expect!(value.floor(), fixed(5 * SCALE));
 
     // 0.0 -> 0.0
     let zero = fixed(0);
-    expect(zero.floor(), fixed(0));
+    expect!(zero.floor(), fixed(0));
 
     // 100.0 -> 100.0
     let value = fixed(100 * SCALE);
-    expect(value.floor(), fixed(100 * SCALE));
+    expect!(value.floor(), fixed(100 * SCALE));
 
     // 1.0 -> 1.0
     let value = fixed(SCALE);
-    expect(value.floor(), fixed(SCALE));
+    expect!(value.floor(), fixed(SCALE));
 }
 
 #[test]
 fun floor_handles_edge_cases() {
     // 0.000000001 -> 0.0
     let tiny = fixed(1);
-    expect(tiny.floor(), fixed(0));
+    expect!(tiny.floor(), fixed(0));
 
     // 1000000000.5 -> 1000000000.0
     let large = fixed(1_000_000_000 * SCALE + 500_000_000);
-    expect(large.floor(), fixed(1_000_000_000 * SCALE));
+    expect!(large.floor(), fixed(1_000_000_000 * SCALE));
 
     // 5.000000001 -> 5.0
     let almost = fixed(5 * SCALE + 1);
-    expect(almost.floor(), fixed(5 * SCALE));
+    expect!(almost.floor(), fixed(5 * SCALE));
 }
 
 #[test]
 fun floor_handles_max() {
     let max = ud30x9::max();
     let expected = MAX_VALUE - MAX_VALUE % SCALE;
-    expect(max.floor(), fixed(expected));
+    expect!(max.floor(), fixed(expected));
 }
 
 #[test]
 fun floor_of_zero() {
-    expect(fixed(0).floor(), fixed(0));
+    expect!(fixed(0).floor(), fixed(0));
 }
 
 #[test]
 fun floor_of_just_above_integer() {
     // 1.000000001 -> 1.0
-    expect(fixed(SCALE + 1).floor(), fixed(SCALE));
+    expect!(fixed(SCALE + 1).floor(), fixed(SCALE));
 }
 
 #[test]
 fun floor_of_just_below_integer() {
     // 1.999999999 -> 1.0
-    expect(fixed(2 * SCALE - 1).floor(), fixed(SCALE));
+    expect!(fixed(2 * SCALE - 1).floor(), fixed(SCALE));
 }
 
 #[test]
 fun floor_large_integer() {
     // 1000000.0 -> 1000000.0 (integer preserved)
-    expect(fixed(1_000_000 * SCALE).floor(), fixed(1_000_000 * SCALE));
+    expect!(fixed(1_000_000 * SCALE).floor(), fixed(1_000_000 * SCALE));
 }
 
 #[test]

--- a/math/fixed_point/tests/ud30x9_tests/helpers.move
+++ b/math/fixed_point/tests/ud30x9_tests/helpers.move
@@ -2,7 +2,6 @@
 module openzeppelin_fp_math::ud30x9_test_helpers;
 
 use openzeppelin_fp_math::ud30x9::{Self, UD30x9};
-use std::unit_test::assert_eq;
 
 public struct Pair has drop {
     x: UD30x9,
@@ -18,10 +17,4 @@ public(package) fun unpack(p: Pair): (UD30x9, UD30x9) {
 
 public(package) fun fixed(value: u128): UD30x9 {
     ud30x9::wrap(value)
-}
-
-public(package) macro fun expect($left: UD30x9, $right: UD30x9) {
-    let left = $left;
-    let right = $right;
-    assert_eq!(left.unwrap(), right.unwrap());
 }

--- a/math/fixed_point/tests/ud30x9_tests/helpers.move
+++ b/math/fixed_point/tests/ud30x9_tests/helpers.move
@@ -20,6 +20,8 @@ public(package) fun fixed(value: u128): UD30x9 {
     ud30x9::wrap(value)
 }
 
-public(package) fun expect(left: UD30x9, right: UD30x9) {
+public(package) macro fun expect($left: UD30x9, $right: UD30x9) {
+    let left = $left;
+    let right = $right;
     assert_eq!(left.unwrap(), right.unwrap());
 }

--- a/math/fixed_point/tests/ud30x9_tests/mul_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/mul_tests.move
@@ -3,7 +3,7 @@ module openzeppelin_fp_math::ud30x9_mul_tests;
 
 use openzeppelin_fp_math::ud30x9;
 use openzeppelin_fp_math::ud30x9_base;
-use openzeppelin_fp_math::ud30x9_test_helpers::{fixed, expect, pair, unpack};
+use openzeppelin_fp_math::ud30x9_test_helpers::{fixed, pair, unpack};
 use std::unit_test::assert_eq;
 
 const MAX_VALUE: u128 = 0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF;
@@ -23,8 +23,8 @@ fun mul_handles_multiplication_by_zero() {
     ];
 
     values.destroy!(|val| {
-        expect!(val.mul(zero), zero);
-        expect!(zero.mul(val), zero);
+        assert_eq!(val.mul(zero), zero);
+        assert_eq!(zero.mul(val), zero);
     });
 }
 
@@ -39,8 +39,8 @@ fun mul_handles_multiplication_by_one() {
     ];
 
     values.destroy!(|val| {
-        expect!(val.mul(one), val);
-        expect!(one.mul(val), val);
+        assert_eq!(val.mul(one), val);
+        assert_eq!(one.mul(val), val);
     });
 }
 
@@ -49,36 +49,36 @@ fun mul_handles_exact_and_fractional_products() {
     // 1.5 * 2.25 = 3.375
     let a = fixed(1_500_000_000);
     let b = fixed(2_250_000_000);
-    expect!(a.mul(b), fixed(3_375_000_000));
+    assert_eq!(a.mul(b), fixed(3_375_000_000));
 
     // 2.0 * 3.0 = 6.0
-    expect!(fixed(2 * SCALE).mul(fixed(3 * SCALE)), fixed(6 * SCALE));
+    assert_eq!(fixed(2 * SCALE).mul(fixed(3 * SCALE)), fixed(6 * SCALE));
 }
 
 #[test]
 fun mul_truncates_towards_zero_at_scale_boundary() {
     // 1.000000001 * 1.000000001 = 1.000000002000000001 -> 1.000000002
     let x = fixed(SCALE + 1);
-    expect!(x.mul(x), fixed(SCALE + 2));
+    assert_eq!(x.mul(x), fixed(SCALE + 2));
 
     // 1.000000001 * 1.000000002 = 1.000000003000000002 -> 1.000000003
-    expect!(fixed(SCALE + 1).mul(fixed(SCALE + 2)), fixed(SCALE + 3));
+    assert_eq!(fixed(SCALE + 1).mul(fixed(SCALE + 2)), fixed(SCALE + 3));
 
     // 0.999999999 * 0.999999999 = 0.999999998000000001 -> 0.999999998
     let almost_one = fixed(SCALE - 1);
-    expect!(almost_one.mul(almost_one), fixed(SCALE - 2));
+    assert_eq!(almost_one.mul(almost_one), fixed(SCALE - 2));
 }
 
 #[test]
 fun mul_handles_difficult_fractional_magnitudes() {
     // (999999999.999999999)^2 = 999999999999999998.000000000000000001
     let value = fixed(999_999_999_999_999_999);
-    expect!(value.mul(value), fixed(999_999_999_999_999_998_000_000_000));
+    assert_eq!(value.mul(value), fixed(999_999_999_999_999_998_000_000_000));
 
     // 123456789.123456789 * 987654321.987654321
     let left = fixed(123_456_789_123_456_789);
     let right = fixed(987_654_321_987_654_321);
-    expect!(left.mul(right), fixed(121_932_631_356_500_531_347_203_169));
+    assert_eq!(left.mul(right), fixed(121_932_631_356_500_531_347_203_169));
 }
 
 #[test]
@@ -87,15 +87,15 @@ fun mul_large_intermediate_product_does_not_overflow() {
     // multiplication uses a wider intermediate and only then divides by SCALE.
     let half = fixed(SCALE / 2); // 0.5
     let max = ud30x9::max();
-    expect!(max.mul(half), fixed(MAX_VALUE / 2));
-    expect!(half.mul(max), fixed(MAX_VALUE / 2));
+    assert_eq!(max.mul(half), fixed(MAX_VALUE / 2));
+    assert_eq!(half.mul(max), fixed(MAX_VALUE / 2));
 }
 
 #[test]
 fun mul_handles_max_times_one() {
     let max = ud30x9::max();
     let one = fixed(SCALE);
-    expect!(max.mul(one), max);
+    assert_eq!(max.mul(one), max);
 }
 
 #[test, expected_failure(abort_code = ud30x9_base::EOverflow)]
@@ -119,5 +119,5 @@ fun mul_commutativity() {
 #[test]
 fun mul_fractional_small() {
     // 0.5 * 0.5 = 0.25
-    expect!(fixed(500_000_000).mul(fixed(500_000_000)), fixed(250_000_000));
+    assert_eq!(fixed(500_000_000).mul(fixed(500_000_000)), fixed(250_000_000));
 }

--- a/math/fixed_point/tests/ud30x9_tests/mul_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/mul_tests.move
@@ -23,8 +23,8 @@ fun mul_handles_multiplication_by_zero() {
     ];
 
     values.destroy!(|val| {
-        expect(val.mul(zero), zero);
-        expect(zero.mul(val), zero);
+        expect!(val.mul(zero), zero);
+        expect!(zero.mul(val), zero);
     });
 }
 
@@ -39,8 +39,8 @@ fun mul_handles_multiplication_by_one() {
     ];
 
     values.destroy!(|val| {
-        expect(val.mul(one), val);
-        expect(one.mul(val), val);
+        expect!(val.mul(one), val);
+        expect!(one.mul(val), val);
     });
 }
 
@@ -49,36 +49,36 @@ fun mul_handles_exact_and_fractional_products() {
     // 1.5 * 2.25 = 3.375
     let a = fixed(1_500_000_000);
     let b = fixed(2_250_000_000);
-    expect(a.mul(b), fixed(3_375_000_000));
+    expect!(a.mul(b), fixed(3_375_000_000));
 
     // 2.0 * 3.0 = 6.0
-    expect(fixed(2 * SCALE).mul(fixed(3 * SCALE)), fixed(6 * SCALE));
+    expect!(fixed(2 * SCALE).mul(fixed(3 * SCALE)), fixed(6 * SCALE));
 }
 
 #[test]
 fun mul_truncates_towards_zero_at_scale_boundary() {
     // 1.000000001 * 1.000000001 = 1.000000002000000001 -> 1.000000002
     let x = fixed(SCALE + 1);
-    expect(x.mul(x), fixed(SCALE + 2));
+    expect!(x.mul(x), fixed(SCALE + 2));
 
     // 1.000000001 * 1.000000002 = 1.000000003000000002 -> 1.000000003
-    expect(fixed(SCALE + 1).mul(fixed(SCALE + 2)), fixed(SCALE + 3));
+    expect!(fixed(SCALE + 1).mul(fixed(SCALE + 2)), fixed(SCALE + 3));
 
     // 0.999999999 * 0.999999999 = 0.999999998000000001 -> 0.999999998
     let almost_one = fixed(SCALE - 1);
-    expect(almost_one.mul(almost_one), fixed(SCALE - 2));
+    expect!(almost_one.mul(almost_one), fixed(SCALE - 2));
 }
 
 #[test]
 fun mul_handles_difficult_fractional_magnitudes() {
     // (999999999.999999999)^2 = 999999999999999998.000000000000000001
     let value = fixed(999_999_999_999_999_999);
-    expect(value.mul(value), fixed(999_999_999_999_999_998_000_000_000));
+    expect!(value.mul(value), fixed(999_999_999_999_999_998_000_000_000));
 
     // 123456789.123456789 * 987654321.987654321
     let left = fixed(123_456_789_123_456_789);
     let right = fixed(987_654_321_987_654_321);
-    expect(left.mul(right), fixed(121_932_631_356_500_531_347_203_169));
+    expect!(left.mul(right), fixed(121_932_631_356_500_531_347_203_169));
 }
 
 #[test]
@@ -87,15 +87,15 @@ fun mul_large_intermediate_product_does_not_overflow() {
     // multiplication uses a wider intermediate and only then divides by SCALE.
     let half = fixed(SCALE / 2); // 0.5
     let max = ud30x9::max();
-    expect(max.mul(half), fixed(MAX_VALUE / 2));
-    expect(half.mul(max), fixed(MAX_VALUE / 2));
+    expect!(max.mul(half), fixed(MAX_VALUE / 2));
+    expect!(half.mul(max), fixed(MAX_VALUE / 2));
 }
 
 #[test]
 fun mul_handles_max_times_one() {
     let max = ud30x9::max();
     let one = fixed(SCALE);
-    expect(max.mul(one), max);
+    expect!(max.mul(one), max);
 }
 
 #[test, expected_failure(abort_code = ud30x9_base::EOverflow)]
@@ -119,5 +119,5 @@ fun mul_commutativity() {
 #[test]
 fun mul_fractional_small() {
     // 0.5 * 0.5 = 0.25
-    expect(fixed(500_000_000).mul(fixed(500_000_000)), fixed(250_000_000));
+    expect!(fixed(500_000_000).mul(fixed(500_000_000)), fixed(250_000_000));
 }

--- a/math/fixed_point/tests/ud30x9_tests/pow_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/pow_tests.move
@@ -12,27 +12,27 @@ const SCALE: u128 = 1_000_000_000;
 #[test]
 fun pow_handles_zero_and_one_exponents() {
     let x = fixed(12 * SCALE + 345_678_901);
-    expect(x.pow(0), fixed(SCALE));
-    expect(x.pow(1), x);
-    expect(fixed(0).pow(0), fixed(SCALE));
+    expect!(x.pow(0), fixed(SCALE));
+    expect!(x.pow(1), x);
+    expect!(fixed(0).pow(0), fixed(SCALE));
 }
 
 #[test]
 fun pow_handles_zero_and_one_bases() {
-    expect(fixed(0).pow(5), fixed(0));
-    expect(fixed(SCALE).pow(17), fixed(SCALE));
+    expect!(fixed(0).pow(5), fixed(0));
+    expect!(fixed(SCALE).pow(17), fixed(SCALE));
 }
 
 #[test]
 fun pow_handles_fractional_values_and_truncation() {
     // 1.5^2 = 2.25, 1.5^3 = 3.375
     let one_point_five = fixed(1_500_000_000);
-    expect(one_point_five.pow(2), fixed(2_250_000_000));
-    expect(one_point_five.pow(3), fixed(3_375_000_000));
+    expect!(one_point_five.pow(2), fixed(2_250_000_000));
+    expect!(one_point_five.pow(3), fixed(3_375_000_000));
 
     // 1.000000001^2 = 1.000000002000000001 -> 1.000000002
     let epsilon = fixed(SCALE + 1);
-    expect(epsilon.pow(2), fixed(SCALE + 2));
+    expect!(epsilon.pow(2), fixed(SCALE + 2));
 }
 
 #[test]
@@ -54,17 +54,17 @@ fun pow_overflow_aborts_with_correct_abort_code() {
 #[test]
 fun pow_two_squared() {
     // 2.0^2 = 4.0
-    expect(fixed(2 * SCALE).pow(2), fixed(4 * SCALE));
+    expect!(fixed(2 * SCALE).pow(2), fixed(4 * SCALE));
 }
 
 #[test]
 fun pow_three_cubed() {
     // 3.0^3 = 27.0
-    expect(fixed(3 * SCALE).pow(3), fixed(27 * SCALE));
+    expect!(fixed(3 * SCALE).pow(3), fixed(27 * SCALE));
 }
 
 #[test]
 fun pow_half_squared() {
     // 0.5^2 = 0.25
-    expect(fixed(500_000_000).pow(2), fixed(250_000_000));
+    expect!(fixed(500_000_000).pow(2), fixed(250_000_000));
 }

--- a/math/fixed_point/tests/ud30x9_tests/pow_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/pow_tests.move
@@ -3,7 +3,8 @@ module openzeppelin_fp_math::ud30x9_pow_tests;
 
 use openzeppelin_fp_math::ud30x9;
 use openzeppelin_fp_math::ud30x9_base;
-use openzeppelin_fp_math::ud30x9_test_helpers::{fixed, expect};
+use openzeppelin_fp_math::ud30x9_test_helpers::fixed;
+use std::unit_test::assert_eq;
 
 const SCALE: u128 = 1_000_000_000;
 
@@ -12,27 +13,27 @@ const SCALE: u128 = 1_000_000_000;
 #[test]
 fun pow_handles_zero_and_one_exponents() {
     let x = fixed(12 * SCALE + 345_678_901);
-    expect!(x.pow(0), fixed(SCALE));
-    expect!(x.pow(1), x);
-    expect!(fixed(0).pow(0), fixed(SCALE));
+    assert_eq!(x.pow(0), fixed(SCALE));
+    assert_eq!(x.pow(1), x);
+    assert_eq!(fixed(0).pow(0), fixed(SCALE));
 }
 
 #[test]
 fun pow_handles_zero_and_one_bases() {
-    expect!(fixed(0).pow(5), fixed(0));
-    expect!(fixed(SCALE).pow(17), fixed(SCALE));
+    assert_eq!(fixed(0).pow(5), fixed(0));
+    assert_eq!(fixed(SCALE).pow(17), fixed(SCALE));
 }
 
 #[test]
 fun pow_handles_fractional_values_and_truncation() {
     // 1.5^2 = 2.25, 1.5^3 = 3.375
     let one_point_five = fixed(1_500_000_000);
-    expect!(one_point_five.pow(2), fixed(2_250_000_000));
-    expect!(one_point_five.pow(3), fixed(3_375_000_000));
+    assert_eq!(one_point_five.pow(2), fixed(2_250_000_000));
+    assert_eq!(one_point_five.pow(3), fixed(3_375_000_000));
 
     // 1.000000001^2 = 1.000000002000000001 -> 1.000000002
     let epsilon = fixed(SCALE + 1);
-    expect!(epsilon.pow(2), fixed(SCALE + 2));
+    assert_eq!(epsilon.pow(2), fixed(SCALE + 2));
 }
 
 #[test]
@@ -54,17 +55,17 @@ fun pow_overflow_aborts_with_correct_abort_code() {
 #[test]
 fun pow_two_squared() {
     // 2.0^2 = 4.0
-    expect!(fixed(2 * SCALE).pow(2), fixed(4 * SCALE));
+    assert_eq!(fixed(2 * SCALE).pow(2), fixed(4 * SCALE));
 }
 
 #[test]
 fun pow_three_cubed() {
     // 3.0^3 = 27.0
-    expect!(fixed(3 * SCALE).pow(3), fixed(27 * SCALE));
+    assert_eq!(fixed(3 * SCALE).pow(3), fixed(27 * SCALE));
 }
 
 #[test]
 fun pow_half_squared() {
     // 0.5^2 = 0.25
-    expect!(fixed(500_000_000).pow(2), fixed(250_000_000));
+    assert_eq!(fixed(500_000_000).pow(2), fixed(250_000_000));
 }

--- a/math/fixed_point/tests/ud30x9_tests/unchecked_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/unchecked_tests.move
@@ -1,7 +1,7 @@
 #[test_only]
 module openzeppelin_fp_math::ud30x9_unchecked_tests;
 
-use openzeppelin_fp_math::ud30x9_test_helpers::{fixed, expect};
+use openzeppelin_fp_math::ud30x9_test_helpers::fixed;
 use std::unit_test::assert_eq;
 
 const MAX_VALUE: u128 = 0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF;
@@ -36,7 +36,7 @@ fun unchecked_add_zero_is_identity() {
     let zero = fixed(0);
     let cases = vector[fixed(1), fixed(100), fixed(MAX_VALUE / 2), fixed(999)];
     cases.destroy!(|x| {
-        expect!(x.unchecked_add(zero), x);
+        assert_eq!(x.unchecked_add(zero), x);
     });
 }
 
@@ -45,7 +45,7 @@ fun unchecked_sub_zero_is_identity() {
     let zero = fixed(0);
     let cases = vector[fixed(1), fixed(100), fixed(MAX_VALUE / 2), fixed(999)];
     cases.destroy!(|x| {
-        expect!(x.unchecked_sub(zero), x);
+        assert_eq!(x.unchecked_sub(zero), x);
     });
 }
 
@@ -64,6 +64,6 @@ fun unchecked_add_and_sub_are_inverse() {
     let delta = fixed(5);
     let cases = vector[fixed(10), fixed(100), fixed(1_000_000), fixed(42)];
     cases.destroy!(|x| {
-        expect!(x.unchecked_add(delta).unchecked_sub(delta), x);
+        assert_eq!(x.unchecked_add(delta).unchecked_sub(delta), x);
     });
 }

--- a/math/fixed_point/tests/ud30x9_tests/unchecked_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/unchecked_tests.move
@@ -36,7 +36,7 @@ fun unchecked_add_zero_is_identity() {
     let zero = fixed(0);
     let cases = vector[fixed(1), fixed(100), fixed(MAX_VALUE / 2), fixed(999)];
     cases.destroy!(|x| {
-        expect(x.unchecked_add(zero), x);
+        expect!(x.unchecked_add(zero), x);
     });
 }
 
@@ -45,7 +45,7 @@ fun unchecked_sub_zero_is_identity() {
     let zero = fixed(0);
     let cases = vector[fixed(1), fixed(100), fixed(MAX_VALUE / 2), fixed(999)];
     cases.destroy!(|x| {
-        expect(x.unchecked_sub(zero), x);
+        expect!(x.unchecked_sub(zero), x);
     });
 }
 
@@ -64,6 +64,6 @@ fun unchecked_add_and_sub_are_inverse() {
     let delta = fixed(5);
     let cases = vector[fixed(10), fixed(100), fixed(1_000_000), fixed(42)];
     cases.destroy!(|x| {
-        expect(x.unchecked_add(delta).unchecked_sub(delta), x);
+        expect!(x.unchecked_add(delta).unchecked_sub(delta), x);
     });
 }


### PR DESCRIPTION
`assert_eq!` macro can be used directly on fixed point types, so there's no need for `expect` wrapper.

https://move-book.com/reference/equality