### PR TITLE
ref: apply Code Quality Checklist

### DIFF
--- a/contracts/access/sources/ownership_transfer/delayed.move
+++ b/contracts/access/sources/ownership_transfer/delayed.move
@@ -17,8 +17,7 @@ use sui::clock::Clock;
 use sui::dynamic_object_field as dof;
 use sui::event;
 
-/// Dynamic field key for a wrapped object.
-public struct WrappedKey() has copy, drop, store;
+// === Errors ===
 
 /// A transfer or unwrap is already scheduled and must be executed or cancelled first.
 #[error(code = 0)]
@@ -38,6 +37,11 @@ const EWrongDelayedTransferWrapper: vector<u8> = "Wrong delayed transfer wrapper
 /// Borrow return was attempted with a different wrapped object than the one originally taken.
 #[error(code = 5)]
 const EWrongDelayedTransferObject: vector<u8> = "Wrong delayed transfer object";
+
+// === Structs ===
+
+/// Dynamic field key for a wrapped object.
+public struct WrappedKey() has copy, drop, store;
 
 /// Wrapper object that delays transfers by at least `min_delay_ms` after scheduling.
 public struct DelayedTransferWrapper<phantom T: key + store> has key {
@@ -99,6 +103,8 @@ public struct UnwrapExecuted<phantom T> has copy, drop {
     object_id: ID,
     owner: address,
 }
+
+// === Public Functions ===
 
 // === Wrap / unwrap / borrow ===
 
@@ -343,6 +349,8 @@ public fun cancel_schedule<T: key + store>(self: &mut DelayedTransferWrapper<T>)
     let PendingTransfer { .. } = self.pending.extract_or!(abort ENoPendingTransfer);
     event::emit(PendingTransferCancelled<T> { wrapper_id: object::id(self) });
 }
+
+// === Test-Only Helpers ===
 
 #[test_only]
 public fun test_new_wrap_executed<T>(

--- a/contracts/access/sources/ownership_transfer/delayed.move
+++ b/contracts/access/sources/ownership_transfer/delayed.move
@@ -218,10 +218,12 @@ public fun schedule_transfer<T: key + store>(
 ) {
     assert!(self.pending.is_none(), ETransferAlreadyScheduled);
     let execute_after = clock.timestamp_ms() + self.min_delay_ms;
-    self.pending.fill(PendingTransfer {
-        recipient: option::some(new_owner),
-        execute_after_ms: execute_after,
-    });
+    self
+        .pending
+        .fill(PendingTransfer {
+            recipient: option::some(new_owner),
+            execute_after_ms: execute_after,
+        });
     event::emit(TransferScheduled<T> {
         wrapper_id: object::id(self),
         current_owner: ctx.sender(),
@@ -247,10 +249,12 @@ public fun schedule_unwrap<T: key + store>(
 ) {
     assert!(self.pending.is_none(), ETransferAlreadyScheduled);
     let execute_after = clock.timestamp_ms() + self.min_delay_ms;
-    self.pending.fill(PendingTransfer {
-        recipient: option::none(),
-        execute_after_ms: execute_after,
-    });
+    self
+        .pending
+        .fill(PendingTransfer {
+            recipient: option::none(),
+            execute_after_ms: execute_after,
+        });
     event::emit(UnwrapScheduled<T> {
         wrapper_id: object::id(self),
         current_owner: ctx.sender(),

--- a/contracts/access/sources/ownership_transfer/delayed.move
+++ b/contracts/access/sources/ownership_transfer/delayed.move
@@ -218,13 +218,10 @@ public fun schedule_transfer<T: key + store>(
 ) {
     assert!(self.pending.is_none(), ETransferAlreadyScheduled);
     let execute_after = clock.timestamp_ms() + self.min_delay_ms;
-    option::fill(
-        &mut self.pending,
-        PendingTransfer {
-            recipient: option::some(new_owner),
-            execute_after_ms: execute_after,
-        },
-    );
+    self.pending.fill(PendingTransfer {
+        recipient: option::some(new_owner),
+        execute_after_ms: execute_after,
+    });
     event::emit(TransferScheduled<T> {
         wrapper_id: object::id(self),
         current_owner: ctx.sender(),
@@ -250,13 +247,10 @@ public fun schedule_unwrap<T: key + store>(
 ) {
     assert!(self.pending.is_none(), ETransferAlreadyScheduled);
     let execute_after = clock.timestamp_ms() + self.min_delay_ms;
-    option::fill(
-        &mut self.pending,
-        PendingTransfer {
-            recipient: option::none(),
-            execute_after_ms: execute_after,
-        },
-    );
+    self.pending.fill(PendingTransfer {
+        recipient: option::none(),
+        execute_after_ms: execute_after,
+    });
     event::emit(UnwrapScheduled<T> {
         wrapper_id: object::id(self),
         current_owner: ctx.sender(),

--- a/contracts/access/sources/ownership_transfer/two_step.move
+++ b/contracts/access/sources/ownership_transfer/two_step.move
@@ -45,8 +45,7 @@ use sui::dynamic_object_field as dof;
 use sui::event;
 use sui::transfer::Receiving;
 
-/// Dynamic field key for a wrapped object.
-public struct WrappedKey() has copy, drop, store;
+// === Errors ===
 
 /// Transfer request does not correspond to the provided wrapper
 #[error(code = 0)]
@@ -63,6 +62,11 @@ const ENotOwner: vector<u8> = "Caller is not the current owner";
 /// Caller is not the prospective owner.
 #[error(code = 4)]
 const ENotNewOwner: vector<u8> = "Caller is not the prospective owner";
+
+// === Structs ===
+
+/// Dynamic field key for a wrapped object.
+public struct WrappedKey() has copy, drop, store;
 
 /// Wrapper that owns the underlying object, stored as a dynamic object field.
 ///
@@ -123,6 +127,8 @@ public struct TransferCancelled<phantom T> has copy, drop {
     current_owner: address,
     new_owner: address,
 }
+
+// === Public Functions ===
 
 // === Wrap / unwrap / borrow ===
 
@@ -383,6 +389,8 @@ public fun request_return_val<T: key + store>(
 
     transfer::transfer(wrapper, object::id_address(request));
 }
+
+// === Test-Only Helpers ===
 
 #[test_only]
 public fun test_new_request<T: key + store>(

--- a/contracts/access/tests/delayed_tests.move
+++ b/contracts/access/tests/delayed_tests.move
@@ -262,8 +262,8 @@ fun borrow_and_return_roundtrip() {
     let mut clk = clock::create_for_testing(test.ctx());
     clk.set_for_testing(0);
 
-    let first_id = object::id(delayed_transfer::borrow(&wrapper));
-    assert_eq!(first_id, object::id(delayed_transfer::borrow_mut(&mut wrapper)));
+    let first_id = object::id(wrapper.borrow());
+    assert_eq!(first_id, object::id(wrapper.borrow_mut()));
 
     let (obj, borrow_token) = wrapper.borrow_val();
     wrapper.return_val(obj, borrow_token);

--- a/contracts/access/tests/two_step_tests.move
+++ b/contracts/access/tests/two_step_tests.move
@@ -30,7 +30,7 @@ fun initiate_transfer_emits_event() {
     let wrapper = two_step_transfer::wrap(new_cap(test.ctx()), test.ctx());
     let wrapper_id = object::id(&wrapper);
 
-    two_step_transfer::initiate_transfer(wrapper, new_owner, test.ctx());
+    wrapper.initiate_transfer(new_owner, test.ctx());
 
     let expected_event = two_step_transfer::test_new_transfer_initiated(
         wrapper_id,
@@ -47,11 +47,11 @@ fun initiate_transfer_emits_event() {
     let ticket = test_scenario::most_recent_receiving_ticket<
         two_step_transfer::TwoStepTransferWrapper<DummyCap>,
     >(&request_id);
-    two_step_transfer::cancel_transfer(request, ticket, test.ctx());
+    request.cancel_transfer(ticket, test.ctx());
 
     test.next_tx(owner);
     let wrapper = test.take_from_sender<two_step_transfer::TwoStepTransferWrapper<DummyCap>>();
-    let DummyCap { id } = two_step_transfer::unwrap(wrapper, test.ctx());
+    let DummyCap { id } = wrapper.unwrap(test.ctx());
     id.delete();
     test.end();
 }
@@ -134,7 +134,7 @@ fun accept_transfer_emits_event() {
     let mut test = test_scenario::begin(owner);
     let wrapper = two_step_transfer::wrap(new_cap(test.ctx()), test.ctx());
     let wrapper_id = object::id(&wrapper);
-    two_step_transfer::initiate_transfer(wrapper, new_owner, test.ctx());
+    wrapper.initiate_transfer(new_owner, test.ctx());
 
     test.next_tx(new_owner);
     let request = test.take_shared<two_step_transfer::PendingOwnershipTransfer<DummyCap>>();
@@ -142,7 +142,7 @@ fun accept_transfer_emits_event() {
     let ticket = test_scenario::most_recent_receiving_ticket<
         two_step_transfer::TwoStepTransferWrapper<DummyCap>,
     >(&request_id);
-    two_step_transfer::accept_transfer(request, ticket, test.ctx());
+    request.accept_transfer(ticket, test.ctx());
 
     let expected_event = two_step_transfer::test_new_transfer_accepted(
         wrapper_id,
@@ -155,7 +155,7 @@ fun accept_transfer_emits_event() {
 
     test.next_tx(new_owner);
     let wrapper = test.take_from_sender<two_step_transfer::TwoStepTransferWrapper<DummyCap>>();
-    let DummyCap { id } = two_step_transfer::unwrap(wrapper, test.ctx());
+    let DummyCap { id } = wrapper.unwrap(test.ctx());
     id.delete();
     test.end();
 }
@@ -167,7 +167,7 @@ fun accept_transfer_rejects_non_new_owner() {
     let attacker = @0x13;
     let mut test = test_scenario::begin(owner);
     let wrapper = two_step_transfer::wrap(new_cap(test.ctx()), test.ctx());
-    two_step_transfer::initiate_transfer(wrapper, new_owner, test.ctx());
+    wrapper.initiate_transfer(new_owner, test.ctx());
 
     test.next_tx(attacker);
     let request = test.take_shared<two_step_transfer::PendingOwnershipTransfer<DummyCap>>();
@@ -175,7 +175,7 @@ fun accept_transfer_rejects_non_new_owner() {
     let ticket = test_scenario::most_recent_receiving_ticket<
         two_step_transfer::TwoStepTransferWrapper<DummyCap>,
     >(&request_id);
-    two_step_transfer::accept_transfer(request, ticket, test.ctx());
+    request.accept_transfer(ticket, test.ctx());
     test.end();
 }
 
@@ -187,8 +187,8 @@ fun accept_transfer_rejects_mismatched_wrapper() {
     let mut test = test_scenario::begin(owner);
     let wrapper = two_step_transfer::wrap(new_cap(test.ctx()), test.ctx());
     let extra_wrapper = two_step_transfer::wrap(new_cap(test.ctx()), test.ctx());
-    two_step_transfer::initiate_transfer(wrapper, new_owner, test.ctx());
-    two_step_transfer::test_transfer_wrapper(extra_wrapper, owner);
+    wrapper.initiate_transfer(new_owner, test.ctx());
+    extra_wrapper.test_transfer_wrapper(owner);
 
     test.next_tx(owner);
     let request = test.take_shared<two_step_transfer::PendingOwnershipTransfer<DummyCap>>();
@@ -196,7 +196,7 @@ fun accept_transfer_rejects_mismatched_wrapper() {
     let extra_wrapper = test.take_from_sender<
         two_step_transfer::TwoStepTransferWrapper<DummyCap>,
     >();
-    two_step_transfer::test_transfer_wrapper(extra_wrapper, object::id_address(&request));
+    extra_wrapper.test_transfer_wrapper(object::id_address(&request));
     test_scenario::return_shared(request);
 
     test.next_tx(new_owner);
@@ -204,7 +204,7 @@ fun accept_transfer_rejects_mismatched_wrapper() {
     let ticket = test_scenario::most_recent_receiving_ticket<
         two_step_transfer::TwoStepTransferWrapper<DummyCap>,
     >(&request_id);
-    two_step_transfer::accept_transfer(request, ticket, test.ctx());
+    request.accept_transfer(ticket, test.ctx());
     test.end();
 }
 
@@ -216,7 +216,7 @@ fun cancel_transfer_emits_event() {
     let mut test = test_scenario::begin(owner);
     let wrapper = two_step_transfer::wrap(new_cap(test.ctx()), test.ctx());
     let wrapper_id = object::id(&wrapper);
-    two_step_transfer::initiate_transfer(wrapper, new_owner, test.ctx());
+    wrapper.initiate_transfer(new_owner, test.ctx());
 
     test.next_tx(owner);
     let request = test.take_shared<two_step_transfer::PendingOwnershipTransfer<DummyCap>>();
@@ -224,7 +224,7 @@ fun cancel_transfer_emits_event() {
     let ticket = test_scenario::most_recent_receiving_ticket<
         two_step_transfer::TwoStepTransferWrapper<DummyCap>,
     >(&request_id);
-    two_step_transfer::cancel_transfer(request, ticket, test.ctx());
+    request.cancel_transfer(ticket, test.ctx());
 
     let expected_event = two_step_transfer::test_new_transfer_cancelled(
         wrapper_id,
@@ -238,7 +238,7 @@ fun cancel_transfer_emits_event() {
 
     test.next_tx(owner);
     let wrapper = test.take_from_sender<two_step_transfer::TwoStepTransferWrapper<DummyCap>>();
-    let DummyCap { id } = two_step_transfer::unwrap(wrapper, test.ctx());
+    let DummyCap { id } = wrapper.unwrap(test.ctx());
     id.delete();
     test.end();
 }
@@ -250,7 +250,7 @@ fun cancel_transfer_rejects_non_owner() {
     let attacker = @0x14;
     let mut test = test_scenario::begin(owner);
     let wrapper = two_step_transfer::wrap(new_cap(test.ctx()), test.ctx());
-    two_step_transfer::initiate_transfer(wrapper, new_owner, test.ctx());
+    wrapper.initiate_transfer(new_owner, test.ctx());
 
     test.next_tx(attacker);
     let request = test.take_shared<two_step_transfer::PendingOwnershipTransfer<DummyCap>>();
@@ -258,7 +258,7 @@ fun cancel_transfer_rejects_non_owner() {
     let ticket = test_scenario::most_recent_receiving_ticket<
         two_step_transfer::TwoStepTransferWrapper<DummyCap>,
     >(&request_id);
-    two_step_transfer::cancel_transfer(request, ticket, test.ctx());
+    request.cancel_transfer(ticket, test.ctx());
     test.end();
 }
 
@@ -268,7 +268,7 @@ fun request_borrow_val_roundtrip() {
     let new_owner = @0x21;
     let mut test = test_scenario::begin(owner);
     let wrapper = two_step_transfer::wrap(new_cap(test.ctx()), test.ctx());
-    two_step_transfer::initiate_transfer(wrapper, new_owner, test.ctx());
+    wrapper.initiate_transfer(new_owner, test.ctx());
 
     test.next_tx(owner);
     let mut request = test.take_shared<two_step_transfer::PendingOwnershipTransfer<DummyCap>>();
@@ -276,12 +276,8 @@ fun request_borrow_val_roundtrip() {
     let ticket = test_scenario::most_recent_receiving_ticket<
         two_step_transfer::TwoStepTransferWrapper<DummyCap>,
     >(&request_id);
-    let (wrapper, borrow) = two_step_transfer::request_borrow_val(
-        &mut request,
-        ticket,
-        test.ctx(),
-    );
-    two_step_transfer::request_return_val(&request, wrapper, borrow);
+    let (wrapper, borrow) = request.request_borrow_val(ticket, test.ctx());
+    request.request_return_val(wrapper, borrow);
     test_scenario::return_shared(request);
 
     test.next_tx(owner);
@@ -290,11 +286,11 @@ fun request_borrow_val_roundtrip() {
     let ticket = test_scenario::most_recent_receiving_ticket<
         two_step_transfer::TwoStepTransferWrapper<DummyCap>,
     >(&request_id);
-    two_step_transfer::cancel_transfer(request, ticket, test.ctx());
+    request.cancel_transfer(ticket, test.ctx());
 
     test.next_tx(owner);
     let wrapper = test.take_from_sender<two_step_transfer::TwoStepTransferWrapper<DummyCap>>();
-    let DummyCap { id } = two_step_transfer::unwrap(wrapper, test.ctx());
+    let DummyCap { id } = wrapper.unwrap(test.ctx());
     id.delete();
     test.end();
 }
@@ -306,7 +302,7 @@ fun request_borrow_val_rejects_non_owner() {
     let attacker = @0x23;
     let mut test = test_scenario::begin(owner);
     let wrapper = two_step_transfer::wrap(new_cap(test.ctx()), test.ctx());
-    two_step_transfer::initiate_transfer(wrapper, new_owner, test.ctx());
+    wrapper.initiate_transfer(new_owner, test.ctx());
 
     test.next_tx(attacker);
     let mut request = test.take_shared<two_step_transfer::PendingOwnershipTransfer<DummyCap>>();
@@ -314,12 +310,8 @@ fun request_borrow_val_rejects_non_owner() {
     let ticket = test_scenario::most_recent_receiving_ticket<
         two_step_transfer::TwoStepTransferWrapper<DummyCap>,
     >(&request_id);
-    let (wrapper, borrow) = two_step_transfer::request_borrow_val(
-        &mut request,
-        ticket,
-        test.ctx(),
-    );
-    two_step_transfer::request_return_val(&request, wrapper, borrow);
+    let (wrapper, borrow) = request.request_borrow_val(ticket, test.ctx());
+    request.request_return_val(wrapper, borrow);
     test_scenario::return_shared(request);
     test.end();
 }
@@ -331,8 +323,8 @@ fun request_return_val_rejects_wrong_wrapper() {
     let mut test = test_scenario::begin(owner);
     let wrapper = two_step_transfer::wrap(new_cap(test.ctx()), test.ctx());
     let extra_wrapper = two_step_transfer::wrap(new_cap(test.ctx()), test.ctx());
-    two_step_transfer::test_transfer_wrapper(extra_wrapper, owner);
-    two_step_transfer::initiate_transfer(wrapper, new_owner, test.ctx());
+    extra_wrapper.test_transfer_wrapper(owner);
+    wrapper.initiate_transfer(new_owner, test.ctx());
 
     test.next_tx(owner);
     let mut request = test.take_shared<two_step_transfer::PendingOwnershipTransfer<DummyCap>>();
@@ -343,15 +335,11 @@ fun request_return_val_rejects_wrong_wrapper() {
     let ticket = test_scenario::most_recent_receiving_ticket<
         two_step_transfer::TwoStepTransferWrapper<DummyCap>,
     >(&request_id);
-    let (wrapper, borrow) = two_step_transfer::request_borrow_val(
-        &mut request,
-        ticket,
-        test.ctx(),
-    );
-    let DummyCap { id } = two_step_transfer::unwrap(wrapper, test.ctx());
+    let (wrapper, borrow) = request.request_borrow_val(ticket, test.ctx());
+    let DummyCap { id } = wrapper.unwrap(test.ctx());
     id.delete();
 
-    two_step_transfer::request_return_val(&request, extra_wrapper, borrow);
+    request.request_return_val(extra_wrapper, borrow);
     test_scenario::return_shared(request);
     test.end();
 }
@@ -363,8 +351,8 @@ fun cancel_transfer_rejects_mismatched_wrapper() {
     let mut test = test_scenario::begin(owner);
     let wrapper = two_step_transfer::wrap(new_cap(test.ctx()), test.ctx());
     let extra_wrapper = two_step_transfer::wrap(new_cap(test.ctx()), test.ctx());
-    two_step_transfer::initiate_transfer(wrapper, new_owner, test.ctx());
-    two_step_transfer::test_transfer_wrapper(extra_wrapper, owner);
+    wrapper.initiate_transfer(new_owner, test.ctx());
+    extra_wrapper.test_transfer_wrapper(owner);
 
     test.next_tx(owner);
     let request = test.take_shared<two_step_transfer::PendingOwnershipTransfer<DummyCap>>();
@@ -372,7 +360,7 @@ fun cancel_transfer_rejects_mismatched_wrapper() {
     let extra_wrapper = test.take_from_sender<
         two_step_transfer::TwoStepTransferWrapper<DummyCap>,
     >();
-    two_step_transfer::test_transfer_wrapper(extra_wrapper, object::id_address(&request));
+    extra_wrapper.test_transfer_wrapper(object::id_address(&request));
     test_scenario::return_shared(request);
 
     test.next_tx(owner);
@@ -380,7 +368,7 @@ fun cancel_transfer_rejects_mismatched_wrapper() {
     let ticket = test_scenario::most_recent_receiving_ticket<
         two_step_transfer::TwoStepTransferWrapper<DummyCap>,
     >(&request_id);
-    two_step_transfer::cancel_transfer(request, ticket, test.ctx());
+    request.cancel_transfer(ticket, test.ctx());
     test.end();
 }
 
@@ -390,7 +378,7 @@ fun request_borrow_val_inner_cap_roundtrip() {
     let new_owner = @0x43;
     let mut test = test_scenario::begin(owner);
     let wrapper = two_step_transfer::wrap(new_cap(test.ctx()), test.ctx());
-    two_step_transfer::initiate_transfer(wrapper, new_owner, test.ctx());
+    wrapper.initiate_transfer(new_owner, test.ctx());
 
     test.next_tx(owner);
     let mut request = test.take_shared<two_step_transfer::PendingOwnershipTransfer<DummyCap>>();
@@ -398,16 +386,12 @@ fun request_borrow_val_inner_cap_roundtrip() {
     let ticket = test_scenario::most_recent_receiving_ticket<
         two_step_transfer::TwoStepTransferWrapper<DummyCap>,
     >(&request_id);
-    let (mut wrapper, request_borrow) = two_step_transfer::request_borrow_val(
-        &mut request,
-        ticket,
-        test.ctx(),
-    );
+    let (mut wrapper, request_borrow) = request.request_borrow_val(ticket, test.ctx());
 
     let (obj, obj_borrow) = wrapper.borrow_val();
     wrapper.return_val(obj, obj_borrow);
 
-    two_step_transfer::request_return_val(&request, wrapper, request_borrow);
+    request.request_return_val(wrapper, request_borrow);
     test_scenario::return_shared(request);
 
     test.next_tx(owner);
@@ -416,11 +400,11 @@ fun request_borrow_val_inner_cap_roundtrip() {
     let ticket = test_scenario::most_recent_receiving_ticket<
         two_step_transfer::TwoStepTransferWrapper<DummyCap>,
     >(&request_id);
-    two_step_transfer::cancel_transfer(request, ticket, test.ctx());
+    request.cancel_transfer(ticket, test.ctx());
 
     test.next_tx(owner);
     let wrapper = test.take_from_sender<two_step_transfer::TwoStepTransferWrapper<DummyCap>>();
-    let DummyCap { id } = two_step_transfer::unwrap(wrapper, test.ctx());
+    let DummyCap { id } = wrapper.unwrap(test.ctx());
     id.delete();
     test.end();
 }
@@ -431,7 +415,7 @@ fun request_return_val_rejects_wrong_request() {
     let new_owner = @0x45;
     let mut test = test_scenario::begin(owner);
     let wrapper = two_step_transfer::wrap(new_cap(test.ctx()), test.ctx());
-    two_step_transfer::initiate_transfer(wrapper, new_owner, test.ctx());
+    wrapper.initiate_transfer(new_owner, test.ctx());
 
     test.next_tx(owner);
     let mut request = test.take_shared<two_step_transfer::PendingOwnershipTransfer<DummyCap>>();
@@ -439,11 +423,7 @@ fun request_return_val_rejects_wrong_request() {
     let ticket = test_scenario::most_recent_receiving_ticket<
         two_step_transfer::TwoStepTransferWrapper<DummyCap>,
     >(&request_id);
-    let (wrapper, borrow) = two_step_transfer::request_borrow_val(
-        &mut request,
-        ticket,
-        test.ctx(),
-    );
+    let (wrapper, borrow) = request.request_borrow_val(ticket, test.ctx());
 
     let temp_cap = new_cap(test.ctx());
     let wrong_wrapper_id = object::id(&temp_cap);
@@ -457,8 +437,8 @@ fun request_return_val_rejects_wrong_request() {
         test.ctx(),
     );
 
-    two_step_transfer::request_return_val(&bogus_request, wrapper, borrow);
-    two_step_transfer::test_destroy_request(bogus_request);
+    bogus_request.request_return_val(wrapper, borrow);
+    bogus_request.test_destroy_request();
     test_scenario::return_shared(request);
     test.end();
 }
@@ -472,7 +452,7 @@ fun consecutive_transfers() {
     let wrapper = two_step_transfer::wrap(new_cap(test.ctx()), test.ctx());
 
     // A → B
-    two_step_transfer::initiate_transfer(wrapper, owner_b, test.ctx());
+    wrapper.initiate_transfer(owner_b, test.ctx());
 
     test.next_tx(owner_b);
     let request = test.take_shared<two_step_transfer::PendingOwnershipTransfer<DummyCap>>();
@@ -480,12 +460,12 @@ fun consecutive_transfers() {
     let ticket = test_scenario::most_recent_receiving_ticket<
         two_step_transfer::TwoStepTransferWrapper<DummyCap>,
     >(&request_id);
-    two_step_transfer::accept_transfer(request, ticket, test.ctx());
+    request.accept_transfer(ticket, test.ctx());
 
     // B → C
     test.next_tx(owner_b);
     let wrapper = test.take_from_sender<two_step_transfer::TwoStepTransferWrapper<DummyCap>>();
-    two_step_transfer::initiate_transfer(wrapper, owner_c, test.ctx());
+    wrapper.initiate_transfer(owner_c, test.ctx());
 
     test.next_tx(owner_c);
     let request = test.take_shared<two_step_transfer::PendingOwnershipTransfer<DummyCap>>();
@@ -493,12 +473,12 @@ fun consecutive_transfers() {
     let ticket = test_scenario::most_recent_receiving_ticket<
         two_step_transfer::TwoStepTransferWrapper<DummyCap>,
     >(&request_id);
-    two_step_transfer::accept_transfer(request, ticket, test.ctx());
+    request.accept_transfer(ticket, test.ctx());
 
     // C unwraps
     test.next_tx(owner_c);
     let wrapper = test.take_from_sender<two_step_transfer::TwoStepTransferWrapper<DummyCap>>();
-    let DummyCap { id } = two_step_transfer::unwrap(wrapper, test.ctx());
+    let DummyCap { id } = wrapper.unwrap(test.ctx());
     id.delete();
     test.end();
 }
@@ -509,7 +489,7 @@ fun new_owner_can_use_wrapper_after_accept() {
     let new_owner = @0x4A;
     let mut test = test_scenario::begin(owner);
     let wrapper = two_step_transfer::wrap(new_cap(test.ctx()), test.ctx());
-    two_step_transfer::initiate_transfer(wrapper, new_owner, test.ctx());
+    wrapper.initiate_transfer(new_owner, test.ctx());
 
     test.next_tx(new_owner);
     let request = test.take_shared<two_step_transfer::PendingOwnershipTransfer<DummyCap>>();
@@ -517,7 +497,7 @@ fun new_owner_can_use_wrapper_after_accept() {
     let ticket = test_scenario::most_recent_receiving_ticket<
         two_step_transfer::TwoStepTransferWrapper<DummyCap>,
     >(&request_id);
-    two_step_transfer::accept_transfer(request, ticket, test.ctx());
+    request.accept_transfer(ticket, test.ctx());
 
     test.next_tx(new_owner);
     let mut wrapper = test.take_from_sender<two_step_transfer::TwoStepTransferWrapper<DummyCap>>();
@@ -525,7 +505,7 @@ fun new_owner_can_use_wrapper_after_accept() {
     let (obj, borrow_token) = wrapper.borrow_val();
     wrapper.return_val(obj, borrow_token);
 
-    let DummyCap { id } = two_step_transfer::unwrap(wrapper, test.ctx());
+    let DummyCap { id } = wrapper.unwrap(test.ctx());
     id.delete();
     test.end();
 }

--- a/math/core/sources/decimal_scaling.move
+++ b/math/core/sources/decimal_scaling.move
@@ -151,6 +151,8 @@ public fun safe_upcast_balance(amount: u64, source_decimals: u8, target_decimals
     scale_amount(amount as u256, source_decimals, target_decimals)
 }
 
+// === Private Functions ===
+
 /// Internal helper to scale an amount between different decimal precisions.
 ///
 /// # Truncation Behavior

--- a/math/core/sources/internal/common.move
+++ b/math/core/sources/internal/common.move
@@ -1,6 +1,7 @@
 /// Common internal utilities used in multiple places of the package.
-///
 module openzeppelin_math::common;
+
+// === Package Functions ===
 
 /// Count the number of leading zeros for one of the package's supported unsigned widths.
 ///

--- a/math/core/sources/internal/macros.move
+++ b/math/core/sources/internal/macros.move
@@ -8,10 +8,14 @@ use openzeppelin_math::common;
 use openzeppelin_math::rounding::{Self, RoundingMode};
 use openzeppelin_math::u512;
 
+// === Errors ===
+
 #[error(code = 0)]
 const EDivideByZero: vector<u8> = "Divisor must be non-zero";
 #[error(code = 1)]
 const EZeroModulus: vector<u8> = "Modulus must be non-zero";
+
+// === Package Functions ===
 
 /// Compute the arithmetic mean of two unsigned integers with configurable rounding.
 ///

--- a/math/core/sources/rounding.move
+++ b/math/core/sources/rounding.move
@@ -5,6 +5,8 @@
 /// integer modules.
 module openzeppelin_math::rounding;
 
+// === Structs ===
+
 /// Enumerates the supported rounding strategies shared by arithmetic helpers in this package.
 /// - Down: Always round the truncated result down towards zero.
 /// - Up: Always round the truncated result up (ceiling).
@@ -14,6 +16,8 @@ public enum RoundingMode has copy, drop {
     Up,
     Nearest,
 }
+
+// === Public Functions ===
 
 /// Helper returning the enum value for downward rounding.
 public fun down(): RoundingMode { RoundingMode::Down }

--- a/math/core/sources/u128.move
+++ b/math/core/sources/u128.move
@@ -8,7 +8,11 @@ module openzeppelin_math::u128;
 use openzeppelin_math::macros;
 use openzeppelin_math::rounding::RoundingMode;
 
+// === Constants ===
+
 const BIT_WIDTH: u8 = 128;
+
+// === Public Functions ===
 
 /// Compute the arithmetic mean of two `u128` values with configurable rounding.
 ///

--- a/math/core/sources/u16.move
+++ b/math/core/sources/u16.move
@@ -8,7 +8,11 @@ module openzeppelin_math::u16;
 use openzeppelin_math::macros;
 use openzeppelin_math::rounding::RoundingMode;
 
+// === Constants ===
+
 const BIT_WIDTH: u8 = 16;
+
+// === Public Functions ===
 
 /// Compute the arithmetic mean of two `u16` values with configurable rounding.
 ///

--- a/math/core/sources/u256.move
+++ b/math/core/sources/u256.move
@@ -8,10 +8,14 @@ module openzeppelin_math::u256;
 use openzeppelin_math::macros;
 use openzeppelin_math::rounding::RoundingMode;
 
+// === Constants ===
+
 /// Bit width for `u256`.
 ///
 /// Stored as `u16` because 256 cannot be represented as `u8`.
 const BIT_WIDTH: u16 = 256;
+
+// === Public Functions ===
 
 /// Compute the arithmetic mean of two `u256` values with configurable rounding.
 ///

--- a/math/core/sources/u32.move
+++ b/math/core/sources/u32.move
@@ -8,7 +8,11 @@ module openzeppelin_math::u32;
 use openzeppelin_math::macros;
 use openzeppelin_math::rounding::RoundingMode;
 
+// === Constants ===
+
 const BIT_WIDTH: u8 = 32;
+
+// === Public Functions ===
 
 /// Compute the arithmetic mean of two `u32` values with configurable rounding.
 ///

--- a/math/core/sources/u512.move
+++ b/math/core/sources/u512.move
@@ -6,14 +6,7 @@ module openzeppelin_math::u512;
 
 use openzeppelin_math::common;
 
-/// Represents a 512-bit unsigned integer as two 256-bit words.
-public struct U512 has copy, drop, store {
-    hi: u256,
-    lo: u256,
-}
-
-const HALF_BITS: u8 = 128;
-const HALF_MASK: u256 = (1u256 << HALF_BITS) - 1;
+// === Errors ===
 
 #[error(code = 0)]
 const ECarryOverflow: vector<u8> = "Cross-limb addition overflowed";
@@ -23,6 +16,21 @@ const EUnderflow: vector<u8> = "Borrow underflowed high limb";
 const EDivideByZero: vector<u8> = "Divisor must be non-zero";
 #[error(code = 3)]
 const EInvalidRemainder: vector<u8> = "High remainder bits must be zero";
+
+// === Constants ===
+
+const HALF_BITS: u8 = 128;
+const HALF_MASK: u256 = (1u256 << HALF_BITS) - 1;
+
+// === Structs ===
+
+/// Represents a 512-bit unsigned integer as two 256-bit words.
+public struct U512 has copy, drop, store {
+    hi: u256,
+    lo: u256,
+}
+
+// === Public Functions ===
 
 /// Construct a `U512` from its high and low 256-bit components.
 ///
@@ -205,7 +213,7 @@ public fun div_rem_u256(numerator: U512, divisor: u256): (bool, u256, u256) {
     if (overflow) (true, 0, remainder.lo) else (false, quotient, remainder.lo)
 }
 
-/// === Internal helpers ===
+// === Private Functions ===
 
 /// Check whether `value` is greater than or equal to a `u256` scalar.
 ///
@@ -327,6 +335,8 @@ fun msb(value: &U512): u16 {
         common::msb(value.lo, 256) as u16
     }
 }
+
+// === Test-Only Helpers ===
 
 #[test_only]
 public fun sub_u256_for_testing(value: U512, other: u256): U512 {

--- a/math/core/sources/u64.move
+++ b/math/core/sources/u64.move
@@ -8,7 +8,11 @@ module openzeppelin_math::u64;
 use openzeppelin_math::macros;
 use openzeppelin_math::rounding::RoundingMode;
 
+// === Constants ===
+
 const BIT_WIDTH: u8 = 64;
+
+// === Public Functions ===
 
 /// Compute the arithmetic mean of two `u64` values with configurable rounding.
 ///

--- a/math/core/sources/u8.move
+++ b/math/core/sources/u8.move
@@ -9,7 +9,11 @@ use openzeppelin_math::macros;
 use openzeppelin_math::rounding::RoundingMode;
 use std::u256::try_as_u8;
 
+// === Constants ===
+
 const BIT_WIDTH: u8 = 8;
+
+// === Public Functions ===
 
 /// Compute the arithmetic mean of two `u8` values with configurable rounding.
 ///

--- a/math/core/sources/vector.move
+++ b/math/core/sources/vector.move
@@ -1,5 +1,7 @@
 module openzeppelin_math::vector;
 
+// === Public Functions ===
+
 /// Sort an unsigned integer vector in-place using the quicksort algorithm.
 ///
 /// NOTE: This is an unstable in-place sort.

--- a/math/fixed_point/sources/casting/u128.move
+++ b/math/fixed_point/sources/casting/u128.move
@@ -3,6 +3,8 @@ module openzeppelin_fp_math::casting_u128;
 
 use openzeppelin_fp_math::ud30x9::{UD30x9, wrap};
 
+// === Public Functions ===
+
 /// Converts a `u128` value into a `UD30x9` value.
 ///
 /// #### Parameters

--- a/math/fixed_point/sources/sd29x9/sd29x9.move
+++ b/math/fixed_point/sources/sd29x9/sd29x9.move
@@ -15,8 +15,11 @@
 ///   values that might dip below zero, unlike unsigned types.
 module openzeppelin_fp_math::sd29x9;
 
-/// The `SD29x9` decimal fixed-point type.
-public struct SD29x9(u128) has copy, drop, store;
+// === Errors ===
+
+/// Value cannot be represented as `SD29x9`
+#[error(code = 0)]
+const EOverflow: vector<u8> = "Value overflows SD29x9 (must fit in 2^127 signed range)";
 
 // === Constants ===
 
@@ -25,13 +28,12 @@ const MIN_NEGATIVE_VALUE: u128 = 0x8000_0000_0000_0000_0000_0000_0000_0000; // -
 const U128_MAX_VALUE: u128 = 0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF; // 2^128 - 1
 const SCALE: u128 = 1_000_000_000; // 10^9
 
-// === Errors ===
+// === Structs ===
 
-/// Value cannot be represented as `SD29x9`
-#[error(code = 0)]
-const EOverflow: vector<u8> = "Value overflows SD29x9 (must fit in 2^127 signed range)";
+/// The `SD29x9` decimal fixed-point type.
+public struct SD29x9(u128) has copy, drop, store;
 
-// === Functions ===
+// === Method Aliases ===
 
 public use fun openzeppelin_fp_math::sd29x9_base::abs as SD29x9.abs;
 public use fun openzeppelin_fp_math::sd29x9_base::add as SD29x9.add;
@@ -94,6 +96,8 @@ public fun max(): SD29x9 {
     SD29x9(MAX_POSITIVE_VALUE)
 }
 
+// === Public Functions ===
+
 // === Casting helpers ===
 
 /// Converts an unsigned 128-bit integer (`u128`) into an `SD29x9` value type,
@@ -143,7 +147,7 @@ public fun unwrap(x: SD29x9): u128 {
     x.0
 }
 
-// ==== Internal Functions ====
+// === Package Functions ===
 
 /// Compute the two's complement of a `u128` bit pattern.
 ///

--- a/math/fixed_point/sources/sd29x9/sd29x9.move
+++ b/math/fixed_point/sources/sd29x9/sd29x9.move
@@ -64,6 +64,8 @@ public use fun openzeppelin_fp_math::sd29x9_base::unchecked_add as SD29x9.unchec
 public use fun openzeppelin_fp_math::sd29x9_base::unchecked_sub as SD29x9.unchecked_sub;
 public use fun openzeppelin_fp_math::sd29x9_base::xor as SD29x9.xor;
 
+// === Public Functions ===
+
 /// Constructs the zero value in `SD29x9` representation.
 ///
 /// #### Returns
@@ -95,8 +97,6 @@ public fun min(): SD29x9 {
 public fun max(): SD29x9 {
     SD29x9(MAX_POSITIVE_VALUE)
 }
-
-// === Public Functions ===
 
 // === Casting helpers ===
 

--- a/math/fixed_point/sources/sd29x9/sd29x9_base.move
+++ b/math/fixed_point/sources/sd29x9/sd29x9_base.move
@@ -6,13 +6,6 @@ module openzeppelin_fp_math::sd29x9_base;
 use openzeppelin_fp_math::sd29x9::{SD29x9, from_bits, zero, min, one, two_complement, wrap};
 use openzeppelin_fp_math::ud30x9::{Self, UD30x9};
 
-// === Constants ===
-
-const U128_MAX_VALUE: u128 = 0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF; // 2^128 - 1
-const MIN_NEGATIVE_VALUE: u128 = 0x8000_0000_0000_0000_0000_0000_0000_0000; // -2^127 in two's complement
-const SIGN_BIT: u128 = 1u128 << 127;
-const SCALE: u256 = 1_000_000_000; // 10^9
-
 // === Errors ===
 
 /// Value overflows `SD29x9` (must fit in 2^127 signed range)
@@ -22,6 +15,20 @@ const EOverflow: vector<u8> = "Value overflows SD29x9 (must fit in 2^127 signed 
 /// Value cannot be converted to `UD30x9`
 #[error(code = 1)]
 const ECannotBeConvertedToUD30x9: vector<u8> = "Value cannot be converted to UD30x9";
+
+// === Constants ===
+
+const U128_MAX_VALUE: u128 = 0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF; // 2^128 - 1
+const MIN_NEGATIVE_VALUE: u128 = 0x8000_0000_0000_0000_0000_0000_0000_0000; // -2^127 in two's complement
+const SIGN_BIT: u128 = 1u128 << 127;
+const SCALE: u256 = 1_000_000_000; // 10^9
+
+// === Structs ===
+
+public struct Components has copy, drop {
+    neg: bool,
+    mag: u256,
+}
 
 // === Conversion ===
 
@@ -496,12 +503,7 @@ public fun xor(x: SD29x9, y: SD29x9): SD29x9 {
     from_bits(x.unwrap() ^ y.unwrap())
 }
 
-// === Internal helpers ===
-
-public struct Components has copy, drop {
-    neg: bool,
-    mag: u256,
-}
+// === Private Functions ===
 
 fun decompose(bits: u128): Components {
     if ((bits & SIGN_BIT) != 0) {

--- a/math/fixed_point/sources/ud30x9/ud30x9.move
+++ b/math/fixed_point/sources/ud30x9/ud30x9.move
@@ -15,14 +15,16 @@
 ///   internally.
 module openzeppelin_fp_math::ud30x9;
 
-/// The `UD30x9` decimal fixed-point type.
-public struct UD30x9(u128) has copy, drop, store;
-
 // === Constants ===
 
 const SCALE: u128 = 1_000_000_000; // 10^9
 
-// === Functions ===
+// === Structs ===
+
+/// The `UD30x9` decimal fixed-point type.
+public struct UD30x9(u128) has copy, drop, store;
+
+// === Method Aliases ===
 
 public use fun openzeppelin_fp_math::ud30x9_base::abs as UD30x9.abs;
 public use fun openzeppelin_fp_math::ud30x9_base::add as UD30x9.add;
@@ -75,6 +77,8 @@ public fun one(): UD30x9 {
 public fun max(): UD30x9 {
     UD30x9(std::u128::max_value!())
 }
+
+// === Public Functions ===
 
 // === Casting helpers ===
 

--- a/math/fixed_point/sources/ud30x9/ud30x9.move
+++ b/math/fixed_point/sources/ud30x9/ud30x9.move
@@ -54,6 +54,8 @@ public use fun openzeppelin_fp_math::ud30x9_base::unchecked_add as UD30x9.unchec
 public use fun openzeppelin_fp_math::ud30x9_base::unchecked_sub as UD30x9.unchecked_sub;
 public use fun openzeppelin_fp_math::ud30x9_base::xor as UD30x9.xor;
 
+// === Public Functions ===
+
 /// Constructs the zero value in `UD30x9` representation.
 ///
 /// #### Returns
@@ -77,8 +79,6 @@ public fun one(): UD30x9 {
 public fun max(): UD30x9 {
     UD30x9(std::u128::max_value!())
 }
-
-// === Public Functions ===
 
 // === Casting helpers ===
 

--- a/math/fixed_point/sources/ud30x9/ud30x9_base.move
+++ b/math/fixed_point/sources/ud30x9/ud30x9_base.move
@@ -4,13 +4,6 @@ module openzeppelin_fp_math::ud30x9_base;
 use openzeppelin_fp_math::sd29x9::{Self, SD29x9};
 use openzeppelin_fp_math::ud30x9::{UD30x9, wrap, one};
 
-// === Constants ===
-
-const U128_MAX_VALUE: u128 = 0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF; // 2^128 - 1
-const SCALE: u128 = 1_000_000_000; // 10^9
-const SCALE_U256: u256 = SCALE as u256; // 10^9
-const MAX_POSITIVE_SD29X9: u128 = 0x7FFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF; // 2^127 - 1
-
 // === Errors ===
 
 #[error(code = 0)]
@@ -19,6 +12,13 @@ const EOverflow: vector<u8> = "Value overflows UD30x9 (must fit in 2^128 unsigne
 /// Value cannot be converted to `SD29x9`
 #[error(code = 1)]
 const ECannotBeConvertedToSD29x9: vector<u8> = "Value cannot be converted to SD29x9";
+
+// === Constants ===
+
+const U128_MAX_VALUE: u128 = 0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF; // 2^128 - 1
+const SCALE: u128 = 1_000_000_000; // 10^9
+const SCALE_U256: u256 = SCALE as u256; // 10^9
+const MAX_POSITIVE_SD29X9: u128 = 0x7FFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF; // 2^127 - 1
 
 // === Conversion ===
 
@@ -449,7 +449,7 @@ public fun xor(x: UD30x9, y: UD30x9): UD30x9 {
     wrap(x.unwrap() ^ y.unwrap())
 }
 
-// === Internal Functions ===
+// === Private Functions ===
 
 fun wrap_u256(value: u256): UD30x9 {
     assert!(value <= U128_MAX_VALUE as u256, EOverflow);


### PR DESCRIPTION
## Summary

- Added mandatory `// === <Name> ===` section headers (Errors, Constants, Structs, Public Functions, Package Functions, Private Functions, Test-Only Helpers) across all source files in `contracts/access`, `math/core`, and `math/fixed_point`
- Fixed section ordering violations (Constants before Errors → swapped to Errors first)
- Moved structs declared before errors into proper `// === Structs ===` sections (`WrappedKey`, `U512`, `SD29x9`, `UD30x9`, `Components`)
- Renamed non-standard section headers (`// === Functions ===` → `// === Method Aliases ===`, `// ==== Internal Functions ====` → `// === Package Functions ===`, `/// === Internal helpers ===` → `// === Private Functions ===`)
- Feature-oriented sub-grouping comments preserved (`// === Wrap / unwrap / borrow ===`, `// === Scheduling / delay management ===`, `// === Transfer flow ===`, etc.)
- Fixed misplaced `// === Public Functions ===` headers in `ud30x9.move` and `sd29x9.move` so that `zero/one/max` (and `min`) constructors are correctly grouped under Public Functions rather than Method Aliases

#### PR Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Changelog