### PR TITLE
fix: add missing 10^77 entry to u256::is_power_of_ten lookup table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 #### Fixed
 
-- `u256::is_power_of_ten` helper now properly handles valid `10^77` value. (#)
+- `u256::is_power_of_ten` helper now properly handles valid `10^77` value. (#291)
 
 ## 1.1.0-rc.0 (10-03-2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## Unreleased
 
+### `openzeppelin_math`
+
+#### Fixed
+
+- `u256::is_power_of_ten` helper now properly handles valid `10^77` value. (#)
+
 ## 1.1.0-rc.0 (10-03-2026)
 
 ### `openzeppelin_fp_math`

--- a/math/core/sources/u256.move
+++ b/math/core/sources/u256.move
@@ -223,7 +223,7 @@ public fun mul_mod(a: u256, b: u256, modulus: u256): u256 {
 /// Returns `true` if `n` is a power of ten.
 ///
 /// Uses a lookup table with binary search for efficiency.
-/// For `u256`, valid powers of ten range from 10^0 to 10^76.
+/// For `u256`, valid powers of ten range from 10^0 to 10^77.
 ///
 /// #### Parameters
 /// - `n`: Input value.
@@ -231,7 +231,7 @@ public fun mul_mod(a: u256, b: u256, modulus: u256): u256 {
 /// #### Returns
 /// - `true` if `n` is a power of ten within the `u256` range, otherwise `false`.
 public fun is_power_of_ten(n: u256): bool {
-    // Powers of 10 from 10^0 to 10^76 for u256
+    // Powers of 10 from 10^0 to 10^77 for u256
     let powers = vector[
         1u256,
         10u256,
@@ -310,6 +310,7 @@ public fun is_power_of_ten(n: u256): bool {
         100000000000000000000000000000000000000000000000000000000000000000000000000u256,
         1000000000000000000000000000000000000000000000000000000000000000000000000000u256,
         10000000000000000000000000000000000000000000000000000000000000000000000000000u256,
+        100000000000000000000000000000000000000000000000000000000000000000000000000000u256,
     ];
 
     macros::binary_search!(powers, n)

--- a/math/core/tests/u256_tests.move
+++ b/math/core/tests/u256_tests.move
@@ -877,10 +877,10 @@ fun is_power_of_ten_basic() {
     assert_eq!(u256::is_power_of_ten(1000000000000000000000000000000), true); // 10^30
     assert_eq!(
         u256::is_power_of_ten(
-            10000000000000000000000000000000000000000000000000000000000000000000000000000,
+            100000000000000000000000000000000000000000000000000000000000000000000000000000,
         ),
         true,
-    ); // 10^76 (max for u256)
+    ); // 10^77 (max for u256)
     assert_eq!(u256::is_power_of_ten(0), false);
     assert_eq!(u256::is_power_of_ten(2), false);
     assert_eq!(u256::is_power_of_ten(11), false);


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Resolves #290 

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

#### PR Checklist

<!-- For the PRs that introduce new features, all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items below may not apply to your case (for example: fixing a typo). -->

- [x] Tests
- [x] Documentation
- [x] Changelog
