### PR TITLE
fix: `EUnderflow` for `SD30x9` (N-03)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## Unreleased
 
+### `openzeppelin_fp_math`
+
+#### Changed (Breaking)
+
+- `UD30x9::sub` now aborts with `EUnderflow` instead of `EOverflow` when the result would be negative (#297)
+
 ## 1.1.0-rc.0 (10-03-2026)
 
 ### `openzeppelin_fp_math`

--- a/math/fixed_point/sources/ud30x9/ud30x9_base.move
+++ b/math/fixed_point/sources/ud30x9/ud30x9_base.move
@@ -20,6 +20,10 @@ const EOverflow: vector<u8> = "Value overflows UD30x9 (must fit in 2^128 unsigne
 #[error(code = 1)]
 const ECannotBeConvertedToSD29x9: vector<u8> = "Value cannot be converted to SD29x9";
 
+/// Arithmetic underflow: the result would be negative, which is unrepresentable in `UD30x9`
+#[error(code = 2)]
+const EUnderflow: vector<u8> = "Value underflows UD30x9 (result would be negative)";
+
 // === Conversion ===
 
 /// Converts a `UD30x9` value to a `SD29x9` value.
@@ -394,7 +398,7 @@ public fun rshift(x: UD30x9, bits: u8): UD30x9 {
 /// - Aborts if `y > x`.
 public fun sub(x: UD30x9, y: UD30x9): UD30x9 {
     let (x, y) = (x.unwrap(), y.unwrap());
-    assert!(x >= y, EOverflow);
+    assert!(x >= y, EUnderflow);
     wrap(x - y)
 }
 

--- a/math/fixed_point/tests/ud30x9_tests/arithmetic_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/arithmetic_tests.move
@@ -28,7 +28,7 @@ fun checked_add_overflow_aborts_as_expected() {
     fixed(MAX_VALUE).add(fixed(1));
 }
 
-#[test, expected_failure(abort_code = ud30x9_base::EOverflow)]
+#[test, expected_failure(abort_code = ud30x9_base::EUnderflow)]
 fun checked_sub_underflow_aborts_as_expected() {
     fixed(0).sub(fixed(1));
 }


### PR DESCRIPTION
### Summary                                                                                                               
                                               
- Introduced a distinct `EUnderflow` error constant (code 2) for `UD30x9` arithmetic underflow                         
- Changed `sub` function to abort with `EUnderflow` instead of `EOverflow` when y > x