### PR TITLE
fix: expose public `decompose` (L-05)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## Unreleased
 
+### `openzeppelin_fp_math`
+
+#### Added
+
+- `SD29x9::decompose` to extract sign and magnitude from a signed fixed-point value (#300)
+
 ## 1.1.0-rc.0 (10-03-2026)
 
 ### `openzeppelin_fp_math`

--- a/math/fixed_point/README.md
+++ b/math/fixed_point/README.md
@@ -26,6 +26,8 @@ let value = 1000000000_u128.into_UD30x9(); // Casting
 let positive = sd29x9::wrap(1000000000, false); // 1.0
 let negative = sd29x9::wrap(1000000000, true); // -1.0
 let zero = sd29x9::zero();
+
+let (is_negative, magnitude) = negative.decompose(); // Sign and magnitude extraction
 ```
 
 ## Usage example

--- a/math/fixed_point/sources/sd29x9/sd29x9.move
+++ b/math/fixed_point/sources/sd29x9/sd29x9.move
@@ -38,6 +38,7 @@ public use fun openzeppelin_fp_math::sd29x9_base::add as SD29x9.add;
 public use fun openzeppelin_fp_math::sd29x9_base::and as SD29x9.and;
 public use fun openzeppelin_fp_math::sd29x9_base::and2 as SD29x9.and2;
 public use fun openzeppelin_fp_math::sd29x9_base::ceil as SD29x9.ceil;
+public use fun openzeppelin_fp_math::sd29x9_base::decompose as SD29x9.decompose;
 public use fun openzeppelin_fp_math::sd29x9_base::div as SD29x9.div;
 public use fun openzeppelin_fp_math::sd29x9_base::eq as SD29x9.eq;
 public use fun openzeppelin_fp_math::sd29x9_base::floor as SD29x9.floor;

--- a/math/fixed_point/sources/sd29x9/sd29x9_base.move
+++ b/math/fixed_point/sources/sd29x9/sd29x9_base.move
@@ -36,7 +36,7 @@ const ECannotBeConvertedToUD30x9: vector<u8> = "Value cannot be converted to UD3
 /// #### Aborts
 /// - Aborts if `x` is negative.
 public fun into_UD30x9(x: SD29x9): UD30x9 {
-    let Components { neg, mag } = decompose(x.unwrap());
+    let Components { neg, mag } = decompose_bits(x.unwrap());
     assert!(!neg, ECannotBeConvertedToUD30x9);
     ud30x9::wrap(mag as u128)
 }
@@ -49,7 +49,7 @@ public fun into_UD30x9(x: SD29x9): UD30x9 {
 /// #### Returns
 /// - The `UD30x9` representation of `x` if `x` is non-negative, otherwise `none`.
 public fun try_into_UD30x9(x: SD29x9): Option<UD30x9> {
-    let Components { neg, mag } = decompose(x.unwrap());
+    let Components { neg, mag } = decompose_bits(x.unwrap());
     if (neg) {
         option::none()
     } else {
@@ -70,7 +70,7 @@ public fun try_into_UD30x9(x: SD29x9): Option<UD30x9> {
 /// #### Aborts
 /// - Aborts if `x` is the minimum representable value (`-2^127`), because `+2^127` is not representable.
 public fun abs(x: SD29x9): SD29x9 {
-    let mut components = decompose(x.unwrap());
+    let mut components = decompose_bits(x.unwrap());
     components.neg = false;
     wrap_components(components)
 }
@@ -87,7 +87,7 @@ public fun abs(x: SD29x9): SD29x9 {
 /// #### Aborts
 /// - Aborts if the resulting magnitude exceeds the representable `SD29x9` range.
 public fun add(x: SD29x9, y: SD29x9): SD29x9 {
-    let result = add_components(decompose(x.unwrap()), decompose(y.unwrap()));
+    let result = add_components(decompose_bits(x.unwrap()), decompose_bits(y.unwrap()));
     wrap_components(result)
 }
 
@@ -126,7 +126,7 @@ public fun and2(x: SD29x9, y: SD29x9): SD29x9 {
 /// #### Aborts
 /// - Aborts if the rounded positive result exceeds the representable `SD29x9` range.
 public fun ceil(x: SD29x9): SD29x9 {
-    let Components { neg, mag } = decompose(x.unwrap());
+    let Components { neg, mag } = decompose_bits(x.unwrap());
     let fractional = mag % SCALE;
     if (fractional == 0) {
         return x
@@ -163,7 +163,7 @@ public fun eq(x: SD29x9, y: SD29x9): bool {
 /// #### Aborts
 /// - Aborts if the rounded negative result magnitude exceeds the representable `SD29x9` range.
 public fun floor(x: SD29x9): SD29x9 {
-    let Components { neg, mag } = decompose(x.unwrap());
+    let Components { neg, mag } = decompose_bits(x.unwrap());
     let fractional = mag % SCALE;
     if (fractional == 0) {
         return x
@@ -271,8 +271,8 @@ public fun lte(x: SD29x9, y: SD29x9): bool {
 /// #### Aborts
 /// - Aborts if `y` is zero.
 public fun mod(x: SD29x9, y: SD29x9): SD29x9 {
-    let x = decompose(x.unwrap());
-    let y = decompose(y.unwrap());
+    let x = decompose_bits(x.unwrap());
+    let y = decompose_bits(y.unwrap());
     let remainder = x.mag % y.mag;
     wrap_components(Components { neg: x.neg, mag: remainder })
 }
@@ -289,8 +289,8 @@ public fun mod(x: SD29x9, y: SD29x9): SD29x9 {
 /// #### Aborts
 /// - Aborts if the resulting magnitude exceeds the representable `SD29x9` range.
 public fun mul(x: SD29x9, y: SD29x9): SD29x9 {
-    let x = decompose(x.unwrap());
-    let y = decompose(y.unwrap());
+    let x = decompose_bits(x.unwrap());
+    let y = decompose_bits(y.unwrap());
     let neg = x.neg != y.neg;
     let prod = x.mag * y.mag;
     let mag = prod / SCALE;
@@ -310,8 +310,8 @@ public fun mul(x: SD29x9, y: SD29x9): SD29x9 {
 /// - Aborts if `y` is zero.
 /// - Aborts if the resulting magnitude exceeds the representable `SD29x9` range.
 public fun div(x: SD29x9, y: SD29x9): SD29x9 {
-    let x = decompose(x.unwrap());
-    let y = decompose(y.unwrap());
+    let x = decompose_bits(x.unwrap());
+    let y = decompose_bits(y.unwrap());
     let neg = x.neg != y.neg;
     let numerator = x.mag * SCALE;
     let mag = numerator / y.mag;
@@ -347,7 +347,7 @@ public fun pow(x: SD29x9, exp: u8): SD29x9 {
     if (exp == 1) {
         return x
     };
-    let Components { neg, mag } = decompose(x.unwrap());
+    let Components { neg, mag } = decompose_bits(x.unwrap());
     let res_neg = neg && (exp % 2 != 0);
     let mut res_mag = mag;
     let times = exp - 1;
@@ -370,7 +370,7 @@ public fun pow(x: SD29x9, exp: u8): SD29x9 {
 /// #### Aborts
 /// - Aborts if `x` is the minimum representable value (`-2^127`), because `+2^127` is not representable.
 public fun negate(x: SD29x9): SD29x9 {
-    let value = decompose(x.unwrap());
+    let value = decompose_bits(x.unwrap());
     wrap_components(negate_components(value))
 }
 
@@ -455,8 +455,8 @@ public fun rshift(x: SD29x9, bits: u8): SD29x9 {
 /// #### Aborts
 /// - Aborts if the resulting magnitude exceeds the representable `SD29x9` range.
 public fun sub(x: SD29x9, y: SD29x9): SD29x9 {
-    let negated_y = negate_components(decompose(y.unwrap()));
-    let result = add_components(decompose(x.unwrap()), negated_y);
+    let negated_y = negate_components(decompose_bits(y.unwrap()));
+    let result = add_components(decompose_bits(x.unwrap()), negated_y);
     wrap_components(result)
 }
 
@@ -503,7 +503,7 @@ public struct Components has copy, drop {
     mag: u256,
 }
 
-fun decompose(bits: u128): Components {
+fun decompose_bits(bits: u128): Components {
     if ((bits & SIGN_BIT) != 0) {
         Components { neg: true, mag: two_complement(bits) as u256 }
     } else {
@@ -555,8 +555,8 @@ fun greater_than_bits(x_bits: u128, y_bits: u128): bool {
     if (x_bits == y_bits) {
         return false
     };
-    let x = decompose(x_bits);
-    let y = decompose(y_bits);
+    let x = decompose_bits(x_bits);
+    let y = decompose_bits(y_bits);
 
     if (x.neg != y.neg) {
         !x.neg

--- a/math/fixed_point/sources/sd29x9/sd29x9_base.move
+++ b/math/fixed_point/sources/sd29x9/sd29x9_base.move
@@ -36,7 +36,7 @@ const ECannotBeConvertedToUD30x9: vector<u8> = "Value cannot be converted to UD3
 /// #### Aborts
 /// - Aborts if `x` is negative.
 public fun into_UD30x9(x: SD29x9): UD30x9 {
-    let Components { neg, mag } = decompose_bits(x.unwrap());
+    let (neg, mag) = decompose(x);
     assert!(!neg, ECannotBeConvertedToUD30x9);
     ud30x9::wrap(mag as u128)
 }
@@ -49,7 +49,7 @@ public fun into_UD30x9(x: SD29x9): UD30x9 {
 /// #### Returns
 /// - The `UD30x9` representation of `x` if `x` is non-negative, otherwise `none`.
 public fun try_into_UD30x9(x: SD29x9): Option<UD30x9> {
-    let Components { neg, mag } = decompose_bits(x.unwrap());
+    let (neg, mag) = decompose(x);
     if (neg) {
         option::none()
     } else {
@@ -138,6 +138,20 @@ public fun ceil(x: SD29x9): SD29x9 {
         Components { mag: int_part * SCALE, neg: true }
     };
     wrap_components(result)
+}
+
+/// Decomposes a `SD29x9` value into its sign and magnitude.
+///
+/// #### Parameters
+/// - `x`: Input value.
+///
+/// #### Returns
+/// - A tuple `(is_negative, magnitude)` where:
+///   - `is_negative`: `true` if `x` is negative.
+///   - `magnitude`: The absolute value of `x` as a `u128`.
+public fun decompose(x: SD29x9): (bool, u128) {
+    let Components { neg, mag } = decompose_bits(x.unwrap());
+    (neg, mag as u128)
 }
 
 /// Checks whether two `SD29x9` values are bitwise equal.

--- a/math/fixed_point/tests/sd29x9_tests/decompose_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/decompose_tests.move
@@ -1,0 +1,89 @@
+#[test_only]
+module openzeppelin_fp_math::sd29x9_decompose_tests;
+
+use openzeppelin_fp_math::sd29x9;
+use openzeppelin_fp_math::sd29x9_test_helpers::{pos, neg};
+use std::unit_test::assert_eq;
+
+const SCALE: u128 = 1_000_000_000;
+const MAX_POSITIVE_VALUE: u128 = 0x7FFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF;
+const MIN_NEGATIVE_VALUE: u128 = 0x8000_0000_0000_0000_0000_0000_0000_0000;
+
+#[test]
+fun decompose_zero() {
+    let (neg, mag) = sd29x9::zero().decompose();
+    assert!(!neg);
+    assert_eq!(mag, 0);
+}
+
+#[test]
+fun decompose_positive_integer() {
+    let (neg, mag) = pos(5 * SCALE).decompose();
+    assert!(!neg);
+    assert_eq!(mag, 5 * SCALE);
+}
+
+#[test]
+fun decompose_negative_integer() {
+    let (neg, mag) = neg(5 * SCALE).decompose();
+    assert!(neg);
+    assert_eq!(mag, 5 * SCALE);
+}
+
+#[test]
+fun decompose_positive_fractional() {
+    let (neg, mag) = pos(5 * SCALE + 500_000_000).decompose();
+    assert!(!neg);
+    assert_eq!(mag, 5_500_000_000);
+}
+
+#[test]
+fun decompose_negative_fractional() {
+    let (neg, mag) = neg(5 * SCALE + 500_000_000).decompose();
+    assert!(neg);
+    assert_eq!(mag, 5_500_000_000);
+}
+
+#[test]
+fun decompose_smallest_positive() {
+    let (neg, mag) = pos(1).decompose();
+    assert!(!neg);
+    assert_eq!(mag, 1);
+}
+
+#[test]
+fun decompose_smallest_negative() {
+    let (neg, mag) = neg(1).decompose();
+    assert!(neg);
+    assert_eq!(mag, 1);
+}
+
+#[test]
+fun decompose_max_value() {
+    let (neg, mag) = sd29x9::max().decompose();
+    assert!(!neg);
+    assert_eq!(mag, MAX_POSITIVE_VALUE);
+}
+
+#[test]
+fun decompose_min_value() {
+    let (neg, mag) = sd29x9::min().decompose();
+    assert!(neg);
+    assert_eq!(mag, MIN_NEGATIVE_VALUE);
+}
+
+#[test]
+fun decompose_roundtrip_positive() {
+    let original = pos(42 * SCALE);
+    let (neg, mag) = original.decompose();
+    let reconstructed = sd29x9::wrap(mag, neg);
+    assert_eq!(original, reconstructed);
+}
+
+#[test]
+fun decompose_roundtrip_negative() {
+    let original = neg(42 * SCALE);
+    let (neg, mag) = original.decompose();
+    let reconstructed = sd29x9::wrap(mag, neg);
+    assert_eq!(original, reconstructed);
+}


### PR DESCRIPTION
Summary
                                                                                                                         
- Expose `SD29x9::decompose` as a public function returning `(bool, u128)` so external callers can extract sign and
magnitude through the canonical decomposition path instead of reimplementing the logic
- Rename the internal helper to `decompose_bits` to avoid name collision