### PR TITLE
fix: changed `mod`, add `rem` (L-03)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## Unreleased
 
+### `openzeppelin_fp_math`
+
+#### Added
+
+- `SD29x9::rem` function for truncated remainder semantics (sign follows the dividend). (#301)
+
+#### Changed (Breaking)
+
+- `SD29x9::mod` now uses Euclidean remainder semantics (result is always non-negative). The previous truncated remainder behavior is available via `SD29x9::rem`. (#301)
+
 ## 1.1.0-rc.0 (10-03-2026)
 
 ### `openzeppelin_fp_math`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 #### Added
 
-- `SD29x9::rem` function for truncated remainder semantics (sign follows the dividend). (#301)
+- `SD29x9::rem` function for truncated remainder semantics (sign follows the dividend) (#301)
 
 #### Changed (Breaking)
 
-- `SD29x9::mod` now uses Euclidean remainder semantics (result is always non-negative). The previous truncated remainder behavior is available via `SD29x9::rem`. (#301)
+- `SD29x9::mod` now uses Euclidean remainder semantics (result is always non-negative). The previous truncated remainder behavior is available via `SD29x9::rem` (#301)
 
 ## 1.1.0-rc.0 (10-03-2026)
 

--- a/math/fixed_point/sources/sd29x9/sd29x9.move
+++ b/math/fixed_point/sources/sd29x9/sd29x9.move
@@ -55,6 +55,7 @@ public use fun openzeppelin_fp_math::sd29x9_base::neq as SD29x9.neq;
 public use fun openzeppelin_fp_math::sd29x9_base::not as SD29x9.not;
 public use fun openzeppelin_fp_math::sd29x9_base::or as SD29x9.or;
 public use fun openzeppelin_fp_math::sd29x9_base::pow as SD29x9.pow;
+public use fun openzeppelin_fp_math::sd29x9_base::rem as SD29x9.rem;
 public use fun openzeppelin_fp_math::sd29x9_base::rshift as SD29x9.rshift;
 public use fun openzeppelin_fp_math::sd29x9_base::sub as SD29x9.sub;
 public use fun openzeppelin_fp_math::sd29x9_base::try_into_UD30x9 as SD29x9.try_into_UD30x9;

--- a/math/fixed_point/sources/sd29x9/sd29x9_base.move
+++ b/math/fixed_point/sources/sd29x9/sd29x9_base.move
@@ -296,11 +296,12 @@ public fun mod(x: SD29x9, y: SD29x9): SD29x9 {
     let x = decompose(x.unwrap());
     let y = decompose(y.unwrap());
     let remainder = x.mag % y.mag;
-    if (x.neg && remainder > 0) {
-        wrap_components(Components { neg: false, mag: y.mag - remainder })
+    let mag = if (x.neg && remainder > 0) {
+        y.mag - remainder
     } else {
-        wrap_components(Components { neg: false, mag: remainder })
-    }
+        remainder
+    };
+    wrap_components(Components { neg: false, mag })
 }
 
 /// Multiplies two `SD29x9` values with fixed-point scaling.

--- a/math/fixed_point/sources/sd29x9/sd29x9_base.move
+++ b/math/fixed_point/sources/sd29x9/sd29x9_base.move
@@ -277,19 +277,17 @@ public fun rem(x: SD29x9, y: SD29x9): SD29x9 {
     wrap_components(Components { neg: x.neg, mag: remainder })
 }
 
-/// Computes the truncating remainder of dividing one `SD29x9` value by another.
+/// Computes the Euclidean remainder of dividing one `SD29x9` value by another.
 ///
-/// This helper follows remainder semantics, not Euclidean modulo semantics. The magnitude is
-/// computed as `abs(x) % abs(y)`, and the sign of the result follows the dividend `x`. In
-/// particular, a negative dividend can produce a negative non-zero remainder, while the sign of
-/// `y` does not affect the result apart from the zero-divisor check.
+/// The result is always non-negative and satisfies `0 <= result < abs(y)`. When the
+/// truncating remainder is negative, `abs(y)` is added to produce the Euclidean result.
 ///
 /// #### Parameters
 /// - `x`: Dividend.
 /// - `y`: Divisor.
 ///
 /// #### Returns
-/// - The truncating remainder of `x` divided by `y`.
+/// - The Euclidean remainder of `x` divided by `y`, always non-negative.
 /// - Returns `0` when `x` is an exact multiple of `y`.
 ///
 /// #### Aborts
@@ -298,7 +296,11 @@ public fun mod(x: SD29x9, y: SD29x9): SD29x9 {
     let x = decompose(x.unwrap());
     let y = decompose(y.unwrap());
     let remainder = x.mag % y.mag;
-    wrap_components(Components { neg: x.neg, mag: remainder })
+    if (x.neg && remainder > 0) {
+        wrap_components(Components { neg: false, mag: y.mag - remainder })
+    } else {
+        wrap_components(Components { neg: false, mag: remainder })
+    }
 }
 
 /// Multiplies two `SD29x9` values with fixed-point scaling.

--- a/math/fixed_point/sources/sd29x9/sd29x9_base.move
+++ b/math/fixed_point/sources/sd29x9/sd29x9_base.move
@@ -255,6 +255,30 @@ public fun lte(x: SD29x9, y: SD29x9): bool {
 
 /// Computes the truncating remainder of dividing one `SD29x9` value by another.
 ///
+/// This function follows remainder semantics, not Euclidean modulo semantics. The magnitude is
+/// computed as `abs(x) % abs(y)`, and the sign of the result follows the dividend `x`. In
+/// particular, a negative dividend can produce a negative non-zero remainder, while the sign of
+/// `y` does not affect the result apart from the zero-divisor check.
+///
+/// #### Parameters
+/// - `x`: Dividend.
+/// - `y`: Divisor.
+///
+/// #### Returns
+/// - The truncating remainder of `x` divided by `y`.
+/// - Returns `0` when `x` is an exact multiple of `y`.
+///
+/// #### Aborts
+/// - Aborts if `y` is zero.
+public fun rem(x: SD29x9, y: SD29x9): SD29x9 {
+    let x = decompose(x.unwrap());
+    let y = decompose(y.unwrap());
+    let remainder = x.mag % y.mag;
+    wrap_components(Components { neg: x.neg, mag: remainder })
+}
+
+/// Computes the truncating remainder of dividing one `SD29x9` value by another.
+///
 /// This helper follows remainder semantics, not Euclidean modulo semantics. The magnitude is
 /// computed as `abs(x) % abs(y)`, and the sign of the result follows the dividend `x`. In
 /// particular, a negative dividend can produce a negative non-zero remainder, while the sign of

--- a/math/fixed_point/tests/sd29x9_tests/mod_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/mod_tests.move
@@ -8,9 +8,9 @@ use std::unit_test::assert_eq;
 const SCALE: u128 = 1_000_000_000;
 
 #[test]
-fun mod_tracks_dividend_sign() {
+fun mod_result_always_non_negative() {
     assert_eq!(pos(100 * SCALE).mod(pos(15 * SCALE)), pos(10 * SCALE));
-    assert_eq!(neg(100 * SCALE).mod(pos(15 * SCALE)), neg(10 * SCALE));
+    assert_eq!(neg(100 * SCALE).mod(pos(15 * SCALE)), pos(5 * SCALE));
     assert_eq!(pos(42 * SCALE).mod(neg(21 * SCALE)), sd29x9::zero());
 }
 
@@ -25,31 +25,57 @@ fun mod_positive_positive() {
 }
 
 #[test]
+fun mod_negative_positive() {
+    // rem(-10, 3) = -1, but mod(-10, 3) = 3 - 1 = 2
+    assert_eq!(neg(10 * SCALE).mod(pos(3 * SCALE)), pos(2 * SCALE));
+}
+
+#[test]
+fun mod_positive_negative() {
+    assert_eq!(pos(10 * SCALE).mod(neg(3 * SCALE)), pos(SCALE));
+}
+
+#[test]
+fun mod_negative_negative() {
+    // rem(-10, -3) = -1, but mod(-10, -3) = 3 - 1 = 2
+    assert_eq!(neg(10 * SCALE).mod(neg(3 * SCALE)), pos(2 * SCALE));
+}
+
+#[test]
 fun mod_exact_division() {
     assert_eq!(pos(15 * SCALE).mod(pos(5 * SCALE)), sd29x9::zero());
+    assert_eq!(neg(15 * SCALE).mod(pos(5 * SCALE)), sd29x9::zero());
+    assert_eq!(pos(15 * SCALE).mod(neg(5 * SCALE)), sd29x9::zero());
+    assert_eq!(neg(15 * SCALE).mod(neg(5 * SCALE)), sd29x9::zero());
 }
 
 #[test]
 fun mod_dividend_equals_divisor() {
     assert_eq!(pos(7 * SCALE).mod(pos(7 * SCALE)), sd29x9::zero());
+    assert_eq!(neg(7 * SCALE).mod(pos(7 * SCALE)), sd29x9::zero());
 }
 
 #[test]
 fun mod_dividend_less_than_divisor() {
     assert_eq!(pos(3 * SCALE).mod(pos(10 * SCALE)), pos(3 * SCALE));
+    // rem(-3, 10) = -3, but mod(-3, 10) = 10 - 3 = 7
+    assert_eq!(neg(3 * SCALE).mod(pos(10 * SCALE)), pos(7 * SCALE));
 }
 
 #[test]
 fun mod_large_fractional() {
     assert_eq!(pos(100 * SCALE + 500_000_000).mod(pos(SCALE)), pos(500_000_000));
+    assert_eq!(neg(100 * SCALE + 500_000_000).mod(pos(SCALE)), pos(500_000_000));
 }
 
 #[test]
-fun mod_negative_negative() {
-    assert_eq!(neg(13 * SCALE).mod(neg(5 * SCALE)), neg(3 * SCALE));
+fun mod_zero_dividend() {
+    assert_eq!(sd29x9::zero().mod(pos(5 * SCALE)), sd29x9::zero());
 }
 
 #[test]
-fun mod_negative_divisor_keeps_positive_dividend_sign() {
-    assert_eq!(pos(13 * SCALE).mod(neg(5 * SCALE)), pos(3 * SCALE));
+fun mod_negative_large_values() {
+    // rem(-13, 5) = -3, but mod(-13, 5) = 5 - 3 = 2
+    assert_eq!(neg(13 * SCALE).mod(pos(5 * SCALE)), pos(2 * SCALE));
+    assert_eq!(neg(13 * SCALE).mod(neg(5 * SCALE)), pos(2 * SCALE));
 }

--- a/math/fixed_point/tests/sd29x9_tests/rem_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/rem_tests.move
@@ -1,0 +1,55 @@
+#[test_only]
+module openzeppelin_fp_math::sd29x9_rem_tests;
+
+use openzeppelin_fp_math::sd29x9;
+use openzeppelin_fp_math::sd29x9_test_helpers::{pos, neg};
+use std::unit_test::assert_eq;
+
+const SCALE: u128 = 1_000_000_000;
+
+#[test]
+fun rem_tracks_dividend_sign() {
+    assert_eq!(pos(100 * SCALE).rem(pos(15 * SCALE)), pos(10 * SCALE));
+    assert_eq!(neg(100 * SCALE).rem(pos(15 * SCALE)), neg(10 * SCALE));
+    assert_eq!(pos(42 * SCALE).rem(neg(21 * SCALE)), sd29x9::zero());
+}
+
+#[test, expected_failure(arithmetic_error, location = openzeppelin_fp_math::sd29x9_base)]
+fun rem_with_zero_divisor_aborts() {
+    pos(10).rem(sd29x9::zero());
+}
+
+#[test]
+fun rem_positive_positive() {
+    assert_eq!(pos(10 * SCALE).rem(pos(3 * SCALE)), pos(SCALE));
+}
+
+#[test]
+fun rem_exact_division() {
+    assert_eq!(pos(15 * SCALE).rem(pos(5 * SCALE)), sd29x9::zero());
+}
+
+#[test]
+fun rem_dividend_equals_divisor() {
+    assert_eq!(pos(7 * SCALE).rem(pos(7 * SCALE)), sd29x9::zero());
+}
+
+#[test]
+fun rem_dividend_less_than_divisor() {
+    assert_eq!(pos(3 * SCALE).rem(pos(10 * SCALE)), pos(3 * SCALE));
+}
+
+#[test]
+fun rem_large_fractional() {
+    assert_eq!(pos(100 * SCALE + 500_000_000).rem(pos(SCALE)), pos(500_000_000));
+}
+
+#[test]
+fun rem_negative_negative() {
+    assert_eq!(neg(13 * SCALE).rem(neg(5 * SCALE)), neg(3 * SCALE));
+}
+
+#[test]
+fun rem_negative_divisor_keeps_positive_dividend_sign() {
+    assert_eq!(pos(13 * SCALE).rem(neg(5 * SCALE)), pos(3 * SCALE));
+}


### PR DESCRIPTION
#### Summary                                                                         
                                                                                              
- Renamed `SD29x9::mod` to `SD29x9::rem` to clearly communicate its truncated remainder       
semantics (sign follows the dividend).
- Redefined `SD29x9::mod` to use Euclidean remainder semantics, where the result is always  
non-negative.

#### PR Checklist

- [x] Tests
- [x] Documentation
- [x] Changelog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `rem` function for truncated remainder operations where the sign follows the dividend.

* **Breaking Changes**
  * `mod` function now uses Euclidean remainder semantics, guaranteeing non-negative results. Previous truncated remainder behavior is available via the new `rem` function.

* **Tests**
  * Updated test coverage for new and modified remainder operations across various sign and edge case scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->