### PR TITLE
build: bump sui version to 1.70.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ permissions:
   pull-requests: write
 
 env:
-  SUI_VERSION: "1.69.2"
+  SUI_VERSION: "1.70.2"
 
 jobs:
   setup:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Sui smart contracts are written in Move leveraging the Sui Move framework.
 
 Follow the installation guide in the [Sui documentation](https://docs.sui.io/guides/developer/getting-started/sui-install).
 
-**Required version**: Sui CLI [1.69.2](https://github.com/MystenLabs/sui/releases/tag/mainnet-v1.69.2).
+**Required version**: Sui CLI [1.70.2](https://github.com/MystenLabs/sui/releases/tag/mainnet-v1.70.2).
 
 ## Docs
 


### PR DESCRIPTION
https://github.com/MystenLabs/sui/releases/tag/mainnet-v1.70.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Sui CLI requirement from version 1.69.2 to 1.70.2 in project configuration and testing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->