### PR TITLE
ref: apply Code Quality Checklist (openzeppelin_math)

### DIFF
--- a/math/core/sources/decimal_scaling.move
+++ b/math/core/sources/decimal_scaling.move
@@ -151,6 +151,8 @@ public fun safe_upcast_balance(amount: u64, source_decimals: u8, target_decimals
     scale_amount(amount as u256, source_decimals, target_decimals)
 }
 
+// === Private Functions ===
+
 /// Internal helper to scale an amount between different decimal precisions.
 ///
 /// # Truncation Behavior

--- a/math/core/sources/internal/common.move
+++ b/math/core/sources/internal/common.move
@@ -2,6 +2,8 @@
 ///
 module openzeppelin_math::common;
 
+// === Package Functions ===
+
 /// Count the number of leading zeros for one of the package's supported unsigned widths.
 ///
 /// This helper is intended for the power-of-two widths used throughout the package: `8`, `16`, `32`,

--- a/math/core/sources/internal/macros.move
+++ b/math/core/sources/internal/macros.move
@@ -8,10 +8,24 @@ use openzeppelin_math::common;
 use openzeppelin_math::rounding::{Self, RoundingMode};
 use openzeppelin_math::u512;
 
+// === Errors ===
+
 #[error(code = 0)]
 const EDivideByZero: vector<u8> = "Divisor must be non-zero";
 #[error(code = 1)]
 const EZeroModulus: vector<u8> = "Modulus must be non-zero";
+
+// === Constants ===
+
+const MAX_LOG_10: u8 = 77;
+const TEN_POW_2: u256 = 100;
+const TEN_POW_4: u256 = TEN_POW_2 * TEN_POW_2;
+const TEN_POW_8: u256 = TEN_POW_4 * TEN_POW_4;
+const TEN_POW_16: u256 = TEN_POW_8 * TEN_POW_8;
+const TEN_POW_32: u256 = TEN_POW_16 * TEN_POW_16;
+const TEN_POW_64: u256 = TEN_POW_32 * TEN_POW_32;
+
+// === Package Functions ===
 
 /// Compute the arithmetic mean of two unsigned integers with configurable rounding.
 ///
@@ -390,14 +404,6 @@ public(package) macro fun log10<$Int>($value: $Int, $rounding_mode: RoundingMode
     }
 }
 
-const MAX_LOG_10: u8 = 77;
-const TEN_POW_2: u256 = 100;
-const TEN_POW_4: u256 = TEN_POW_2 * TEN_POW_2;
-const TEN_POW_8: u256 = TEN_POW_4 * TEN_POW_4;
-const TEN_POW_16: u256 = TEN_POW_8 * TEN_POW_8;
-const TEN_POW_32: u256 = TEN_POW_16 * TEN_POW_16;
-const TEN_POW_64: u256 = TEN_POW_32 * TEN_POW_32;
-
 /// Compute floor(log10(value)) using binary search over powers of 10.
 ///
 /// This helper uses precomputed constants (`TEN_POW_2`, `TEN_POW_4`, etc.) to efficiently
@@ -442,7 +448,7 @@ public(package) fun log10_floor(value: u256): u8 {
     result
 }
 
-/// === Helper functions ===
+// === Helper functions ===
 
 /// Internal helper for `mul_div` that selects the most efficient implementation based on the input size.
 ///
@@ -910,7 +916,7 @@ public(package) fun round_sqrt_result(
     }
 }
 
-/// === Internal helpers for modular arithmetic ===
+// === Internal helpers for modular arithmetic ===
 
 /// Extended Euclidean algorithm that powers `inv_mod!`.
 ///

--- a/math/core/sources/rounding.move
+++ b/math/core/sources/rounding.move
@@ -5,6 +5,8 @@
 /// integer modules.
 module openzeppelin_math::rounding;
 
+// === Structs ===
+
 /// Enumerates the supported rounding strategies shared by arithmetic helpers in this package.
 /// - Down: Always round the truncated result down towards zero.
 /// - Up: Always round the truncated result up (ceiling).
@@ -14,6 +16,8 @@ public enum RoundingMode has copy, drop {
     Up,
     Nearest,
 }
+
+// === Public Functions ===
 
 /// Helper returning the enum value for downward rounding.
 public fun down(): RoundingMode { RoundingMode::Down }

--- a/math/core/sources/u128.move
+++ b/math/core/sources/u128.move
@@ -8,7 +8,11 @@ module openzeppelin_math::u128;
 use openzeppelin_math::macros;
 use openzeppelin_math::rounding::RoundingMode;
 
+// === Constants ===
+
 const BIT_WIDTH: u8 = 128;
+
+// === Public Functions ===
 
 /// Compute the arithmetic mean of two `u128` values with configurable rounding.
 ///

--- a/math/core/sources/u16.move
+++ b/math/core/sources/u16.move
@@ -8,7 +8,11 @@ module openzeppelin_math::u16;
 use openzeppelin_math::macros;
 use openzeppelin_math::rounding::RoundingMode;
 
+// === Constants ===
+
 const BIT_WIDTH: u8 = 16;
+
+// === Public Functions ===
 
 /// Compute the arithmetic mean of two `u16` values with configurable rounding.
 ///

--- a/math/core/sources/u256.move
+++ b/math/core/sources/u256.move
@@ -8,10 +8,14 @@ module openzeppelin_math::u256;
 use openzeppelin_math::macros;
 use openzeppelin_math::rounding::RoundingMode;
 
+// === Constants ===
+
 /// Bit width for `u256`.
 ///
 /// Stored as `u16` because 256 cannot be represented as `u8`.
 const BIT_WIDTH: u16 = 256;
+
+// === Public Functions ===
 
 /// Compute the arithmetic mean of two `u256` values with configurable rounding.
 ///

--- a/math/core/sources/u32.move
+++ b/math/core/sources/u32.move
@@ -8,7 +8,11 @@ module openzeppelin_math::u32;
 use openzeppelin_math::macros;
 use openzeppelin_math::rounding::RoundingMode;
 
+// === Constants ===
+
 const BIT_WIDTH: u8 = 32;
+
+// === Public Functions ===
 
 /// Compute the arithmetic mean of two `u32` values with configurable rounding.
 ///

--- a/math/core/sources/u512.move
+++ b/math/core/sources/u512.move
@@ -6,14 +6,7 @@ module openzeppelin_math::u512;
 
 use openzeppelin_math::common;
 
-/// Represents a 512-bit unsigned integer as two 256-bit words.
-public struct U512 has copy, drop, store {
-    hi: u256,
-    lo: u256,
-}
-
-const HALF_BITS: u8 = 128;
-const HALF_MASK: u256 = (1u256 << HALF_BITS) - 1;
+// === Errors ===
 
 #[error(code = 0)]
 const ECarryOverflow: vector<u8> = "Cross-limb addition overflowed";
@@ -23,6 +16,21 @@ const EUnderflow: vector<u8> = "Borrow underflowed high limb";
 const EDivideByZero: vector<u8> = "Divisor must be non-zero";
 #[error(code = 3)]
 const EInvalidRemainder: vector<u8> = "High remainder bits must be zero";
+
+// === Constants ===
+
+const HALF_BITS: u8 = 128;
+const HALF_MASK: u256 = (1u256 << HALF_BITS) - 1;
+
+// === Structs ===
+
+/// Represents a 512-bit unsigned integer as two 256-bit words.
+public struct U512 has copy, drop, store {
+    hi: u256,
+    lo: u256,
+}
+
+// === Public Functions ===
 
 /// Construct a `U512` from its high and low 256-bit components.
 ///
@@ -205,7 +213,7 @@ public fun div_rem_u256(numerator: U512, divisor: u256): (bool, u256, u256) {
     if (overflow) (true, 0, remainder.lo) else (false, quotient, remainder.lo)
 }
 
-/// === Internal helpers ===
+// === Private Functions ===
 
 /// Check whether `value` is greater than or equal to a `u256` scalar.
 ///
@@ -327,6 +335,8 @@ fun msb(value: &U512): u16 {
         common::msb(value.lo, 256) as u16
     }
 }
+
+// === Test-Only Helpers ===
 
 #[test_only]
 public fun sub_u256_for_testing(value: U512, other: u256): U512 {

--- a/math/core/sources/u64.move
+++ b/math/core/sources/u64.move
@@ -8,7 +8,11 @@ module openzeppelin_math::u64;
 use openzeppelin_math::macros;
 use openzeppelin_math::rounding::RoundingMode;
 
+// === Constants ===
+
 const BIT_WIDTH: u8 = 64;
+
+// === Public Functions ===
 
 /// Compute the arithmetic mean of two `u64` values with configurable rounding.
 ///

--- a/math/core/sources/u8.move
+++ b/math/core/sources/u8.move
@@ -7,9 +7,12 @@ module openzeppelin_math::u8;
 
 use openzeppelin_math::macros;
 use openzeppelin_math::rounding::RoundingMode;
-use std::u256::try_as_u8;
+
+// === Constants ===
 
 const BIT_WIDTH: u8 = 8;
+
+// === Public Functions ===
 
 /// Compute the arithmetic mean of two `u8` values with configurable rounding.
 ///

--- a/math/core/sources/vector.move
+++ b/math/core/sources/vector.move
@@ -1,5 +1,7 @@
 module openzeppelin_math::vector;
 
+// === Public Functions ===
+
 /// Sort an unsigned integer vector in-place using the quicksort algorithm.
 ///
 /// NOTE: This is an unstable in-place sort.

--- a/math/core/tests/u512_tests.move
+++ b/math/core/tests/u512_tests.move
@@ -8,18 +8,18 @@ use std::unit_test::assert_eq;
 fun constructors_and_accessors() {
     // `new` should store exactly the values we pass in.
     let value = u512::new(5, 7);
-    assert_eq!(u512::hi(&value), 5);
-    assert_eq!(u512::lo(&value), 7);
+    assert_eq!(value.hi(), 5);
+    assert_eq!(value.lo(), 7);
 
     // `zero` returns the additive identity.
     let zero = u512::zero();
-    assert_eq!(u512::hi(&zero), 0);
-    assert_eq!(u512::lo(&zero), 0);
+    assert_eq!(zero.hi(), 0);
+    assert_eq!(zero.lo(), 0);
 
     // `from_u256` lifts into the low limb and clears the high one.
     let lifted = u512::from_u256(42);
-    assert_eq!(u512::hi(&lifted), 0);
-    assert_eq!(u512::lo(&lifted), 42);
+    assert_eq!(lifted.hi(), 0);
+    assert_eq!(lifted.lo(), 42);
 }
 
 #[test]
@@ -27,9 +27,9 @@ fun sub_u256_without_borrow_keeps_high_limb() {
     let original = u512::new(3, 50);
     let subtrahend = 7u256;
 
-    let result = u512::sub_u256_for_testing(original, subtrahend);
-    assert_eq!(u512::hi(&result), 3);
-    assert_eq!(u512::lo(&result), 43);
+    let result = original.sub_u256_for_testing(subtrahend);
+    assert_eq!(result.hi(), 3);
+    assert_eq!(result.lo(), 43);
 
     let rebuild = add_u512(result, u512::from_u256(subtrahend));
     assert_u512_eq(rebuild, original);
@@ -38,12 +38,12 @@ fun sub_u256_without_borrow_keeps_high_limb() {
 #[test]
 fun sub_u256_with_borrow_reduces_high_limb() {
     let original = u512::new(9, 4);
-    let original_hi = u512::hi(&original);
-    let original_lo = u512::lo(&original);
+    let original_hi = original.hi();
+    let original_lo = original.lo();
     let subtrahend = 10u256;
 
-    let result = u512::sub_u256_for_testing(original, subtrahend);
-    assert_eq!(u512::hi(&result), original_hi - 1);
+    let result = original.sub_u256_for_testing(subtrahend);
+    assert_eq!(result.hi(), original_hi - 1);
     let complement = (std::u256::max_value!() - subtrahend) + 1;
     let expected = u512::new(original_hi - 1, original_lo + complement);
     assert_u512_eq(result, expected);
@@ -52,15 +52,15 @@ fun sub_u256_with_borrow_reduces_high_limb() {
 #[test, expected_failure(abort_code = u512::EUnderflow)]
 fun sub_u256_rejects_borrow_without_high_limb() {
     let original = u512::new(0, 1);
-    let _unused = u512::sub_u256_for_testing(original, 2u256);
+    let _unused = original.sub_u256_for_testing(2u256);
 }
 
 #[test]
 fun mul_u256_handles_small_operands() {
     // Simple multiplication stays entirely in the low limb.
     let result = u512::mul_u256(2, 3);
-    assert_eq!(u512::hi(&result), 0);
-    assert_eq!(u512::lo(&result), 6);
+    assert_eq!(result.hi(), 0);
+    assert_eq!(result.lo(), 6);
 }
 
 #[test]
@@ -68,8 +68,8 @@ fun mul_u256_handles_max_operands() {
     // Multiplying the largest possible operands should produce hi = (2^256 - 2) and lo = 1.
     let max = std::u256::max_value!();
     let result = u512::mul_u256(max, max);
-    assert_eq!(u512::hi(&result), max - 1);
-    assert_eq!(u512::lo(&result), 1);
+    assert_eq!(result.hi(), max - 1);
+    assert_eq!(result.lo(), 1);
 }
 
 #[test]
@@ -77,8 +77,8 @@ fun mul_u256_combines_high_bits_correctly() {
     // Squaring a value made only of high bits should land entirely in the high limb afterwards.
     let operand = 1u256 << 200;
     let result = u512::mul_u256(operand, operand);
-    assert_eq!(u512::hi(&result), (1u256 << 144));
-    assert_eq!(u512::lo(&result), 0);
+    assert_eq!(result.hi(), (1u256 << 144));
+    assert_eq!(result.lo(), 0);
 }
 
 #[test]
@@ -87,8 +87,8 @@ fun mul_u256_carries_across_diagonals() {
     let high_bit = 1u256 << 255;
     let operand = high_bit + 1;
     let result = u512::mul_u256(operand, operand);
-    assert_eq!(u512::hi(&result), ((1u256 << 254) + 1));
-    assert_eq!(u512::lo(&result), 1);
+    assert_eq!(result.hi(), ((1u256 << 254) + 1));
+    assert_eq!(result.lo(), 1);
 }
 
 #[test]
@@ -96,10 +96,7 @@ fun div_rem_exact_no_overflow() {
     // Exact division should produce a zero remainder and no overflow.
     let numerator = u512::new(0, 84);
     let divisor = 7;
-    let (overflow, quotient, remainder) = u512::div_rem_u256(
-        numerator,
-        divisor,
-    );
+    let (overflow, quotient, remainder) = numerator.div_rem_u256(divisor);
     assert_eq!(overflow, false);
     assert_eq!(remainder, 0);
     // Verify quotient * divisor + remainder reconstructs the starting numerator.
@@ -115,10 +112,7 @@ fun div_rem_with_remainder() {
     // Non-zero remainder stays below the divisor while still rebuilding the numerator.
     let numerator = u512::new(0, 100);
     let divisor = 7;
-    let (overflow, quotient, remainder) = u512::div_rem_u256(
-        numerator,
-        divisor,
-    );
+    let (overflow, quotient, remainder) = numerator.div_rem_u256(divisor);
     assert_eq!(overflow, false);
     assert_eq!(remainder, 2);
     let rebuild = add_u512(
@@ -133,10 +127,7 @@ fun div_rem_large_low_limb_uses_native_u256_division() {
     // A numerator that stays entirely in the low limb should match native u256 division.
     let numerator = u512::new(0, 1u256 << 200);
     let divisor = 3u256;
-    let (overflow, quotient, remainder) = u512::div_rem_u256(
-        numerator,
-        divisor,
-    );
+    let (overflow, quotient, remainder) = numerator.div_rem_u256(divisor);
     assert_eq!(overflow, false);
     assert_eq!(quotient, (1u256 << 200) / divisor);
     assert_eq!(remainder, (1u256 << 200) % divisor);
@@ -147,10 +138,7 @@ fun div_rem_handles_high_limb_without_overflow() {
     // Dividing a value with both limbs populated exercises the borrow path inside subtraction.
     let numerator = u512::new(2, 123);
     let divisor = 3;
-    let (overflow, quotient, remainder) = u512::div_rem_u256(
-        numerator,
-        divisor,
-    );
+    let (overflow, quotient, remainder) = numerator.div_rem_u256(divisor);
     assert_eq!(overflow, false);
     assert!(remainder < divisor);
 
@@ -164,7 +152,7 @@ fun div_rem_handles_high_limb_without_overflow() {
 fun div_rem_flags_overflow_when_quotient_exceeds_u256() {
     // Any quotient that would spill beyond 256 bits must flip the overflow flag.
     let numerator = u512::new(1, 0);
-    let (overflow, quotient, remainder) = u512::div_rem_u256(numerator, 1);
+    let (overflow, quotient, remainder) = numerator.div_rem_u256(1);
     assert_eq!(overflow, true);
     assert_eq!(quotient, 0);
     assert_eq!(remainder, 0);
@@ -174,7 +162,7 @@ fun div_rem_flags_overflow_when_quotient_exceeds_u256() {
 fun div_rem_overflow_preserves_remainder() {
     // When the quotient overflows, remainder should still be computed correctly.
     let numerator = u512::new(3, 1);
-    let (overflow, quotient, remainder) = u512::div_rem_u256(numerator, 3);
+    let (overflow, quotient, remainder) = numerator.div_rem_u256(3);
     assert_eq!(overflow, true);
     assert_eq!(quotient, 0);
     assert_eq!(remainder, 1);
@@ -185,7 +173,7 @@ fun div_rem_large_operands_trigger_overflow_flag() {
     // Dividing 2^512 - 1 by (2^256 - 1) should overflow because the true quotient is 2^256 + 1.
     let max = std::u256::max_value!();
     let numerator = u512::new(max, max);
-    let (overflow, quotient, remainder) = u512::div_rem_u256(numerator, max);
+    let (overflow, quotient, remainder) = numerator.div_rem_u256(max);
     assert_eq!(overflow, true);
     assert_eq!(quotient, 0);
     assert_eq!(remainder, 0);
@@ -194,28 +182,25 @@ fun div_rem_large_operands_trigger_overflow_flag() {
 #[test, expected_failure(abort_code = u512::EDivideByZero)]
 fun div_rem_rejects_zero_divisor() {
     // Division by zero should trap immediately.
-    let (_overflow, _quotient, _remainder) = u512::div_rem_u256(
-        u512::zero(),
-        0,
-    );
+    let (_overflow, _quotient, _remainder) = u512::zero().div_rem_u256(0);
 }
 
-/// === Helpers ===
+// === Test-Only Helpers ===
 
 /// Simple helper to compare two `U512` values.
 fun assert_u512_eq(left: U512, right: U512) {
-    assert_eq!(u512::hi(&left), u512::hi(&right));
-    assert_eq!(u512::lo(&left), u512::lo(&right));
+    assert_eq!(left.hi(), right.hi());
+    assert_eq!(left.lo(), right.lo());
 }
 
 /// Adds two `U512` values (small helper for test expectations).
 fun add_u512(a: U512, b: U512): U512 {
     // Core addition happens on the low limb; track wraparound to detect the carry.
-    let a_lo = u512::lo(&a);
-    let b_lo = u512::lo(&b);
+    let a_lo = a.lo();
+    let b_lo = b.lo();
     let lo_sum = a_lo + b_lo;
     let carry = if (lo_sum < a_lo) 1u256 else 0u256;
     // High limb gets the incoming carry plus both high words.
-    let hi_sum = u512::hi(&a) + u512::hi(&b) + carry;
+    let hi_sum = a.hi() + b.hi() + carry;
     u512::new(hi_sum, lo_sum)
 }


### PR DESCRIPTION
## Summary

Applies the Move Code Quality Checklist to the `openzeppelin_math` package.

### Changes

- **Section delimiters** (`// === ... ===`) added / corrected across `sources/` and one test file so every file follows the canonical ordering (Errors → Constants → Structs → Public Functions → Private Functions → Test-Only Helpers).
- **`u512.move`** reordered: errors and constants moved above the struct; replaced `///` section headers with `//`; added `// === Test-Only Helpers ===` before the `#[test_only]` helper.
- **`macros.move`**: moved `MAX_LOG_10` and `TEN_POW_*` constants from the middle of the file up into a proper `// === Constants ===` section; added `// === Errors ===` and `// === Package Functions ===`; fixed two `///` section comments.
- **`u*.move`** (u8, u16, u32, u64, u128, u256): added `// === Constants ===` and `// === Public Functions ===` dividers.
- **`decimal_scaling.move`**: added `// === Private Functions ===` before the private helpers.
- **`rounding.move`**, **`common.move`**, **`vector.move`**: added missing section dividers.
- **`u8.move`**: removed unused `use std::u256::try_as_u8;` import (receiver syntax resolves via the stdlib method alias).
- **`u512_tests.move`**: rewrote module-qualified `u512::hi(&x)` / `u512::lo(&x)` / `u512::sub_u256_for_testing(x, y)` / `u512::div_rem_u256(x, y)` to receiver syntax (`x.hi()`, `x.lo()`, `x.sub_u256_for_testing(y)`, `x.div_rem_u256(y)`); renamed `/// === Helpers ===` to `// === Test-Only Helpers ===`.

No functional changes; build + lint + 689 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code organization with section headers for better readability across multiple modules.
  * Consolidated and reorganized constant definitions and internal function groupings.
  * Removed unused internal imports for cleaner dependencies.

* **Tests**
  * Updated test suite to use modern accessor methods, improving test maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->