### PR TITLE
ref: apply Code Quality Checklist (openzeppelin_fp_math)

### DIFF
--- a/math/fixed_point/sources/internal/common.move
+++ b/math/fixed_point/sources/internal/common.move
@@ -6,6 +6,8 @@
 /// bounds, sign handling, and terminology consistent across the package.
 module openzeppelin_fp_math::common;
 
+// === Package Functions ===
+
 /// Returns the raw fixed-point scale shared by `UD30x9` and `SD29x9`.
 ///
 /// #### Returns

--- a/math/fixed_point/sources/sd29x9/conversions.move
+++ b/math/fixed_point/sources/sd29x9/conversions.move
@@ -31,6 +31,8 @@ const ENegativeValue: vector<u8> =
 #[error(code = 2)]
 const EIntegerOverflow: vector<u8> = "Truncated whole part does not fit in u64";
 
+// === Public Functions ===
+
 // === Integer -> Fixed-Point ===
 
 /// Converts a whole `u64` magnitude into `SD29x9` by multiplying it by `10^9`

--- a/math/fixed_point/sources/sd29x9/sd29x9.move
+++ b/math/fixed_point/sources/sd29x9/sd29x9.move
@@ -17,14 +17,16 @@ module openzeppelin_fp_math::sd29x9;
 
 use openzeppelin_fp_math::common;
 
-/// The `SD29x9` decimal fixed-point type.
-public struct SD29x9(u128) has copy, drop, store;
-
 // === Errors ===
 
 /// Value cannot be represented as `SD29x9`
 #[error(code = 0)]
 const EOverflow: vector<u8> = "Value overflows SD29x9 (must fit in 2^127 signed range)";
+
+// === Structs ===
+
+/// The `SD29x9` decimal fixed-point type.
+public struct SD29x9(u128) has copy, drop, store;
 
 // === Method Exports ===
 
@@ -66,6 +68,8 @@ public use fun openzeppelin_fp_math::sd29x9_convert::to_u128_trunc as SD29x9.to_
 public use fun openzeppelin_fp_math::sd29x9_convert::try_to_u128_trunc as SD29x9.try_to_u128_trunc;
 public use fun openzeppelin_fp_math::sd29x9_convert::to_u64_trunc as SD29x9.to_u64_trunc;
 public use fun openzeppelin_fp_math::sd29x9_convert::try_to_u64_trunc as SD29x9.try_to_u64_trunc;
+
+// === Public Functions ===
 
 /// Constructs the zero value in `SD29x9` representation.
 ///
@@ -148,7 +152,7 @@ public fun unwrap(x: SD29x9): u128 {
     x.0
 }
 
-// ==== Internal Functions ====
+// === Package Functions ===
 
 /// Compute the two's complement of a `u128` bit pattern.
 ///

--- a/math/fixed_point/sources/sd29x9/sd29x9_base.move
+++ b/math/fixed_point/sources/sd29x9/sd29x9_base.move
@@ -21,6 +21,15 @@ const ECannotBeConvertedToUD30x9: vector<u8> = "Value cannot be converted to UD3
 #[error(code = 2)]
 const EDivideByZero: vector<u8> = "Divisor must be non-zero";
 
+// === Structs ===
+
+public struct Components has copy, drop {
+    neg: bool,
+    mag: u256,
+}
+
+// === Public Functions ===
+
 // === Conversion ===
 
 /// Converts a `SD29x9` value to a `UD30x9` value.
@@ -54,8 +63,6 @@ public fun try_into_UD30x9(x: SD29x9): Option<UD30x9> {
         option::some(ud30x9::wrap(mag as u128))
     }
 }
-
-// === Public Functions ===
 
 /// Returns the absolute value of a `SD29x9`.
 ///
@@ -530,12 +537,7 @@ public fun unchecked_sub(x: SD29x9, y: SD29x9): SD29x9 {
     from_bits(wrapping_sub_bits(x.unwrap(), y.unwrap()))
 }
 
-// === Internal helpers ===
-
-public struct Components has copy, drop {
-    neg: bool,
-    mag: u256,
-}
+// === Private Functions ===
 
 fun decompose(bits: u128): Components {
     if ((bits & common::sign_bit!()) != 0) {

--- a/math/fixed_point/sources/ud30x9/conversions.move
+++ b/math/fixed_point/sources/ud30x9/conversions.move
@@ -22,6 +22,8 @@ const EOverflow: vector<u8> = "Whole integer overflows UD30x9 once scaled by 10^
 #[error(code = 1)]
 const EIntegerOverflow: vector<u8> = "Truncated whole part does not fit in u64";
 
+// === Public Functions ===
+
 // === Integer -> Fixed-Point ===
 
 /// Converts a whole `u64` integer into `UD30x9` by multiplying it by `10^9`.

--- a/math/fixed_point/sources/ud30x9/ud30x9.move
+++ b/math/fixed_point/sources/ud30x9/ud30x9.move
@@ -17,6 +17,8 @@ module openzeppelin_fp_math::ud30x9;
 
 use openzeppelin_fp_math::common;
 
+// === Structs ===
+
 /// The `UD30x9` decimal fixed-point type.
 public struct UD30x9(u128) has copy, drop, store;
 
@@ -67,6 +69,8 @@ public use fun openzeppelin_fp_math::ud30x9_base::try_into_SD29x9 as UD30x9.try_
 public use fun openzeppelin_fp_math::ud30x9_convert::to_u128_trunc as UD30x9.to_u128_trunc;
 public use fun openzeppelin_fp_math::ud30x9_convert::to_u64_trunc as UD30x9.to_u64_trunc;
 public use fun openzeppelin_fp_math::ud30x9_convert::try_to_u64_trunc as UD30x9.try_to_u64_trunc;
+
+// === Public Functions ===
 
 /// Constructs the zero value in `UD30x9` representation.
 ///

--- a/math/fixed_point/sources/ud30x9/ud30x9_base.move
+++ b/math/fixed_point/sources/ud30x9/ud30x9_base.move
@@ -27,6 +27,8 @@ const ECannotBeConvertedToSD29x9: vector<u8> = "Value cannot be converted to SD2
 #[error(code = 4)]
 const EInvalidShiftSize: vector<u8> = "Shift size is out of range (must be less than 128)";
 
+// === Public Functions ===
+
 // === Conversion ===
 
 /// Converts a `UD30x9` value to a `SD29x9` value.
@@ -60,8 +62,6 @@ public fun try_into_SD29x9(x: UD30x9): Option<SD29x9> {
         option::some(sd29x9::wrap(value, false))
     }
 }
-
-// === Public Functions ===
 
 /// Adds two `UD30x9` values.
 ///
@@ -593,7 +593,7 @@ public fun xor(x: UD30x9, y: UD30x9): UD30x9 {
     wrap(x.unwrap() ^ y.unwrap())
 }
 
-// === Internal Functions ===
+// === Private Functions ===
 
 fun wrap_u256(value: u256): UD30x9 {
     assert!(value <= std::u128::max_value!() as u256, EOverflow);

--- a/math/fixed_point/tests/sd29x9_tests/casting_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/casting_tests.move
@@ -142,6 +142,6 @@ fun try_into_ud30x9_matches_into_ud30x9_on_convertible_values() {
 
     samples.destroy!(|raw| {
         let x = pos(raw);
-        assert_eq!(sd29x9_base::try_into_UD30x9(x), option::some(x.into_UD30x9()));
+        assert_eq!(x.try_into_UD30x9(), option::some(x.into_UD30x9()));
     });
 }

--- a/math/fixed_point/tests/ud30x9_tests/abs_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/abs_tests.move
@@ -8,8 +8,6 @@ use std::unit_test::assert_eq;
 const MAX_VALUE: u128 = 0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF;
 const SCALE: u128 = 1_000_000_000;
 
-// ==== Tests ====
-
 #[test]
 fun abs_returns_same_value_for_unsigned() {
     // 5.0 -> 5.0

--- a/math/fixed_point/tests/ud30x9_tests/bitwise_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/bitwise_tests.move
@@ -7,8 +7,6 @@ use std::unit_test::assert_eq;
 
 const MAX_VALUE: u128 = 0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF;
 
-// ==== Tests ====
-
 #[test]
 fun bitwise_and_shift_helpers_behave_like_u128() {
     let raw = 0xF0F0;

--- a/math/fixed_point/tests/ud30x9_tests/casting_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/casting_tests.move
@@ -10,8 +10,6 @@ use std::unit_test::assert_eq;
 const MAX_POSITIVE_SD29X9: u128 = 0x7FFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF;
 const SCALE: u128 = 1_000_000_000;
 
-// ==== Tests ====
-
 #[test]
 fun into_sd29x9_converts_zero() {
     let zero = ud30x9::zero();
@@ -134,6 +132,6 @@ fun try_into_sd29x9_matches_into_sd29x9_on_convertible_values() {
 
     samples.destroy!(|raw| {
         let x = fixed(raw);
-        assert_eq!(ud30x9_base::try_into_SD29x9(x), option::some(x.into_SD29x9()));
+        assert_eq!(x.try_into_SD29x9(), option::some(x.into_SD29x9()));
     });
 }

--- a/math/fixed_point/tests/ud30x9_tests/ceil_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/ceil_tests.move
@@ -8,8 +8,6 @@ use std::unit_test::assert_eq;
 
 const SCALE: u128 = 1_000_000_000;
 
-// ==== Tests ====
-
 #[test]
 fun ceil_rounds_up_fractional_values() {
     // 5.3 -> 6.0

--- a/math/fixed_point/tests/ud30x9_tests/div_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/div_tests.move
@@ -8,8 +8,6 @@ use std::unit_test::assert_eq;
 
 const SCALE: u128 = 1_000_000_000;
 
-// ==== Tests ====
-
 #[test]
 fun div_handles_zero_and_identity_cases() {
     let zero = fixed(0);

--- a/math/fixed_point/tests/ud30x9_tests/floor_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/floor_tests.move
@@ -8,8 +8,6 @@ use std::unit_test::assert_eq;
 const MAX_VALUE: u128 = 0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF;
 const SCALE: u128 = 1_000_000_000;
 
-// ==== Tests ====
-
 #[test]
 fun floor_truncates_fractional_values() {
     // 5.3 -> 5.0

--- a/math/fixed_point/tests/ud30x9_tests/mul_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/mul_tests.move
@@ -9,8 +9,6 @@ use std::unit_test::assert_eq;
 const MAX_VALUE: u128 = 0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF;
 const SCALE: u128 = 1_000_000_000;
 
-// ==== Tests ====
-
 #[test]
 fun mul_handles_multiplication_by_zero() {
     let zero = fixed(0);

--- a/math/fixed_point/tests/ud30x9_tests/pow_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/pow_tests.move
@@ -8,8 +8,6 @@ use std::unit_test::assert_eq;
 
 const SCALE: u128 = 1_000_000_000;
 
-// ==== Tests ====
-
 #[test]
 fun pow_handles_zero_and_one_exponents() {
     let x = fixed(12 * SCALE + 345_678_901);

--- a/math/fixed_point/tests/ud30x9_tests/unchecked_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/unchecked_tests.move
@@ -6,8 +6,6 @@ use std::unit_test::assert_eq;
 
 const MAX_VALUE: u128 = 0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF;
 
-// ==== Tests ====
-
 #[test]
 fun unchecked_add_wraps_on_overflow() {
     let a = fixed(5);

--- a/math/fixed_point/tests/ud30x9_tests/wrap_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/wrap_tests.move
@@ -8,8 +8,6 @@ use std::unit_test::assert_eq;
 const MAX_VALUE: u128 = 0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF;
 const SCALE: u128 = 1_000_000_000;
 
-// ==== Tests ====
-
 #[test]
 fun wrap_and_unwrap_roundtrip() {
     let raw = 123_456_789u128;


### PR DESCRIPTION
## Summary

Applies the Move Code Quality Checklist to the `openzeppelin_fp_math` package. No behavior changes; style and section-ordering fixes only.

### Sources
- `common.move` — add `// === Package Functions ===` header.
- `ud30x9/ud30x9.move` — add `// === Structs ===` and `// === Public Functions ===` headers.
- `ud30x9/conversions.move` — insert `// === Public Functions ===` parent above the existing `Integer -> Fixed-Point` / `Fixed-Point -> Integer` feature subgroups.
- `ud30x9/ud30x9_base.move` — collapse the standalone `// === Conversion ===` section under a single `// === Public Functions ===`; rename `// === Internal Functions ===` → `// === Private Functions ===`.
- `sd29x9/sd29x9.move` — reorder so `// === Errors ===` precedes `// === Structs ===`; add `// === Public Functions ===` before constructors; normalize `// ==== Internal Functions ====` (4-equals) → `// === Package Functions ===`.
- `sd29x9/conversions.move` — insert `// === Public Functions ===` parent above feature subgroups.
- `sd29x9/sd29x9_base.move` — lift the `Components` struct into a new `// === Structs ===` section; collapse `// === Conversion ===` as a feature subgroup under Public Functions; rename `// === Internal helpers ===` → `// === Private Functions ===`.

### Tests
- Remove redundant non-standard `// ==== Tests ====` (4-equals) headers from 10 `ud30x9_tests/*` files.
- Use receiver syntax in two cross-casting round-trip tests: `sd29x9_base::try_into_UD30x9(x)` → `x.try_into_UD30x9()`; `ud30x9_base::try_into_SD29x9(x)` → `x.try_into_SD29x9()`.

All 341 tests pass with `--lint --warnings-are-errors` in both prod and test builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized fixed-point math modules with section headers for improved code structure and readability.
  * Made the `Components` struct publicly accessible.
  * Updated test methods to use direct method calls instead of module function calls.

* **Style**
  * Removed redundant comment headers from test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->