### PR TITLE
ref: apply Code Quality Checklist (openzeppelin_fp_math)

### DIFF
--- a/math/fixed_point/sources/sd29x9/sd29x9_base.move
+++ b/math/fixed_point/sources/sd29x9/sd29x9_base.move
@@ -38,6 +38,8 @@ public struct Components has copy, drop {
     mag: u256,
 }
 
+// === Public Functions ===
+
 // === Conversion ===
 
 /// Converts a `SD29x9` value to a `UD30x9` value.
@@ -71,8 +73,6 @@ public fun try_into_UD30x9(x: SD29x9): Option<UD30x9> {
         option::some(ud30x9::wrap(mag as u128))
     }
 }
-
-// === Public Functions ===
 
 /// Returns the absolute value of a `SD29x9`.
 ///

--- a/math/fixed_point/tests/internal/raw_log2_tests.move
+++ b/math/fixed_point/tests/internal/raw_log2_tests.move
@@ -2,20 +2,21 @@
 module openzeppelin_fp_math::raw_log2_tests;
 
 use openzeppelin_fp_math::common;
+use std::unit_test::assert_eq;
 
 const SCALE: u128 = 1_000_000_000;
 const INTERNAL: u128 = 1_000_000_000_000_000_000;
 
-// ==== Boundary ====
+// === Boundary ===
 
 #[test]
 fun raw_log2_of_one_is_zero() {
     let (neg, mag) = common::raw_log2(SCALE);
     assert!(!neg);
-    assert!(mag == 0);
+    assert_eq!(mag, 0);
 }
 
-// ==== Positive branch: exact integer logs ====
+// === Positive branch: exact integer logs ===
 
 #[test]
 fun raw_log2_of_positive_powers_of_two_is_exact() {
@@ -24,12 +25,12 @@ fun raw_log2_of_positive_powers_of_two_is_exact() {
         let x_raw = SCALE << k;
         let (neg, mag) = common::raw_log2(x_raw);
         assert!(!neg);
-        assert!(mag == (k as u128) * INTERNAL);
+        assert_eq!(mag, (k as u128) * INTERNAL);
         k = k + 1;
     };
 }
 
-// ==== Negative branch: exact integer logs (k <= 9 because SCALE = 2^9 * 5^9) ====
+// === Negative branch: exact integer logs (k <= 9 because SCALE = 2^9 * 5^9) ===
 
 #[test]
 fun raw_log2_of_negative_powers_of_two_is_exact() {
@@ -38,12 +39,12 @@ fun raw_log2_of_negative_powers_of_two_is_exact() {
         let x_raw = SCALE >> k;
         let (neg, mag) = common::raw_log2(x_raw);
         assert!(neg);
-        assert!(mag == (k as u128) * INTERNAL);
+        assert_eq!(mag, (k as u128) * INTERNAL);
         k = k + 1;
     };
 }
 
-// ==== Spot check against off-chain reference ====
+// === Spot check against off-chain reference ===
 
 #[test]
 fun raw_log2_of_three_matches_reference() {
@@ -71,7 +72,7 @@ fun raw_log2_of_one_third_matches_reference_with_negation() {
     assert!(diff < 100_000);
 }
 
-// ==== Asymmetric inputs near SCALE boundary ====
+// === Asymmetric inputs near SCALE boundary ===
 
 #[test]
 fun raw_log2_just_below_one_is_negative() {
@@ -90,7 +91,7 @@ fun raw_log2_just_above_one_is_positive() {
     assert!(mag < 100_000_000_000);
 }
 
-// ==== Abort ====
+// === Abort ===
 
 #[test, expected_failure(abort_code = common::ELogOfZero)]
 fun raw_log2_of_zero_aborts() {

--- a/math/fixed_point/tests/sd29x9_tests/ln_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/ln_tests.move
@@ -10,14 +10,14 @@ const SCALE: u128 = 1_000_000_000;
 // e at UD30x9 scale: 2.71828182845904523536... -> floor 2_718_281_828
 const E_RAW: u128 = 2_718_281_828;
 
-// ==== Exact value ====
+// === Exact value ===
 
 #[test]
 fun ln_of_one_is_zero() {
     assert_eq!(sd29x9::one().ln(), sd29x9::zero());
 }
 
-// ==== Spot checks ====
+// === Spot checks ===
 
 #[test]
 fun ln_of_positive_two_matches_reference() {
@@ -45,7 +45,7 @@ fun ln_of_half_pins_value() {
     assert_eq!(result, neg(693_147_180));
 }
 
-// ==== Aborts ====
+// === Aborts ===
 
 #[test, expected_failure(abort_code = sd29x9_base::ELogUndefined)]
 fun ln_of_zero_aborts() {

--- a/math/fixed_point/tests/sd29x9_tests/log10_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/log10_tests.move
@@ -8,14 +8,14 @@ use std::unit_test::assert_eq;
 
 const SCALE: u128 = 1_000_000_000;
 
-// ==== Exact value ====
+// === Exact value ===
 
 #[test]
 fun log10_of_one_is_zero() {
     assert_eq!(sd29x9::one().log10(), sd29x9::zero());
 }
 
-// ==== Powers of ten (within 1 ulp at UD30x9 scale) ====
+// === Powers of ten (within 1 ulp at UD30x9 scale) ===
 
 #[test]
 fun log10_of_positive_powers_of_ten_pins_values() {
@@ -50,7 +50,7 @@ fun log10_of_negative_powers_of_ten_pins_values() {
     };
 }
 
-// ==== Spot checks ====
+// === Spot checks ===
 
 #[test]
 fun log10_of_positive_two_matches_reference() {
@@ -58,7 +58,7 @@ fun log10_of_positive_two_matches_reference() {
     assert_eq!(pos(2 * SCALE).log10(), pos(301_029_995));
 }
 
-// ==== Aborts ====
+// === Aborts ===
 
 #[test, expected_failure(abort_code = sd29x9_base::ELogUndefined)]
 fun log10_of_zero_aborts() {
@@ -75,7 +75,7 @@ fun log10_of_min_value_aborts() {
     sd29x9::min().log10();
 }
 
-// ==== Boundary at minimum positive input ====
+// === Boundary at minimum positive input ===
 
 #[test]
 fun log10_of_pos_1_matches_reference() {

--- a/math/fixed_point/tests/sd29x9_tests/log2_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/log2_tests.move
@@ -9,14 +9,14 @@ use std::unit_test::assert_eq;
 const SCALE: u128 = 1_000_000_000;
 const MAX_POSITIVE_VALUE: u128 = 0x7FFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF;
 
-// ==== Boundary ====
+// === Boundary ===
 
 #[test]
 fun log2_of_one_is_zero() {
     assert_eq!(sd29x9::one().log2(), sd29x9::zero());
 }
 
-// ==== Exact positive integer logs ====
+// === Exact positive integer logs ===
 
 #[test]
 fun log2_of_positive_powers_of_two_is_exact() {
@@ -27,7 +27,7 @@ fun log2_of_positive_powers_of_two_is_exact() {
     };
 }
 
-// ==== Exact negative integer logs (k <= 9 because SCALE = 2^9 * 5^9) ====
+// === Exact negative integer logs (k <= 9 because SCALE = 2^9 * 5^9) ===
 
 #[test]
 fun log2_of_negative_powers_of_two_is_exact() {
@@ -38,7 +38,7 @@ fun log2_of_negative_powers_of_two_is_exact() {
     };
 }
 
-// ==== Spot checks ====
+// === Spot checks ===
 
 #[test]
 fun log2_of_three_matches_reference() {
@@ -56,7 +56,7 @@ fun log2_of_one_third_pins_value() {
     assert_eq!(result.abs().unwrap(), 1_584_962_502);
 }
 
-// ==== Aborts ====
+// === Aborts ===
 
 #[test, expected_failure(abort_code = sd29x9_base::ELogUndefined)]
 fun log2_of_zero_aborts() {
@@ -78,7 +78,7 @@ fun log2_of_min_value_aborts() {
     sd29x9::min().log2();
 }
 
-// ==== Extreme and boundary values ====
+// === Extreme and boundary values ===
 
 #[test]
 fun log2_of_max_sd29x9() {
@@ -101,7 +101,7 @@ fun log2_just_above_one_pins_value() {
     assert_eq!(pos(SCALE + 1).log2(), pos(1));
 }
 
-// ==== Random property tests ====
+// === Random property tests ===
 
 #[random_test]
 fun log2_monotonicity_on_positive(a: u128, b: u128) {

--- a/math/fixed_point/tests/sd29x9_tests/sqrt_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/sqrt_tests.move
@@ -9,7 +9,7 @@ use std::unit_test::assert_eq;
 const SCALE: u128 = 1_000_000_000;
 const MAX_POSITIVE_VALUE: u128 = 0x7FFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF;
 
-// ==== Tests ====
+// === Tests ===
 
 #[test]
 fun sqrt_of_zero_is_zero() {

--- a/math/fixed_point/tests/ud30x9_tests/ln_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/ln_tests.move
@@ -15,14 +15,14 @@ const E_RAW: u128 = 2_718_281_828;
 const LOG2_E_HI: u256 = 1_442_695_040_888_963_407;
 const INTERNAL: u256 = 1_000_000_000_000_000_000;
 
-// ==== Exact value ====
+// === Exact value ===
 
 #[test]
 fun ln_of_one_is_zero() {
     assert_eq!(ud30x9::one().ln(), ud30x9::zero());
 }
 
-// ==== Spot checks ====
+// === Spot checks ===
 
 #[test]
 fun ln_of_two_matches_reference() {
@@ -43,7 +43,7 @@ fun ln_of_e_matches_reference() {
     assert_eq!(fixed(E_RAW).ln(), fixed(SCALE - 1));
 }
 
-// ==== Aborts ====
+// === Aborts ===
 
 #[test, expected_failure(abort_code = ud30x9_base::ELogUndefined)]
 fun ln_of_zero_aborts() {
@@ -55,7 +55,7 @@ fun ln_of_sub_one_aborts() {
     fixed(SCALE - 1).ln();
 }
 
-// ==== Random property tests ====
+// === Random property tests ===
 
 #[random_test]
 fun ln_monotonicity(a: u128, b: u128) {

--- a/math/fixed_point/tests/ud30x9_tests/log10_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/log10_tests.move
@@ -8,14 +8,14 @@ use std::unit_test::assert_eq;
 
 const SCALE: u128 = 1_000_000_000;
 
-// ==== Exact value ====
+// === Exact value ===
 
 #[test]
 fun log10_of_one_is_zero() {
     assert_eq!(ud30x9::one().log10(), ud30x9::zero());
 }
 
-// ==== Powers of 10 (algorithm floors at user scale, so k >= 1 lands 1 ulp below) ====
+// === Powers of 10 (algorithm floors at user scale, so k >= 1 lands 1 ulp below) ===
 
 #[test]
 fun log10_of_powers_of_ten_pins_values() {
@@ -32,7 +32,7 @@ fun log10_of_powers_of_ten_pins_values() {
     };
 }
 
-// ==== Spot checks ====
+// === Spot checks ===
 
 #[test]
 fun log10_of_two_matches_reference() {
@@ -40,7 +40,7 @@ fun log10_of_two_matches_reference() {
     assert_eq!(fixed(2 * SCALE).log10(), fixed(301_029_995));
 }
 
-// ==== Aborts ====
+// === Aborts ===
 
 #[test, expected_failure(abort_code = ud30x9_base::ELogUndefined)]
 fun log10_of_zero_aborts() {
@@ -52,7 +52,7 @@ fun log10_of_sub_one_aborts() {
     fixed(SCALE - 1).log10();
 }
 
-// ==== Random property tests ====
+// === Random property tests ===
 
 #[random_test]
 fun log10_monotonicity(a: u128, b: u128) {

--- a/math/fixed_point/tests/ud30x9_tests/log2_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/log2_tests.move
@@ -8,7 +8,7 @@ use std::unit_test::assert_eq;
 
 const SCALE: u128 = 1_000_000_000;
 
-// ==== Exact integer logs ====
+// === Exact integer logs ===
 
 #[test]
 fun log2_of_one_is_zero() {
@@ -24,7 +24,7 @@ fun log2_of_powers_of_two_is_exact() {
     };
 }
 
-// ==== Spot checks against off-chain reference ====
+// === Spot checks against off-chain reference ===
 
 #[test]
 fun log2_of_three_matches_reference() {
@@ -38,7 +38,7 @@ fun log2_of_ten_matches_reference() {
     assert_eq!(fixed(10 * SCALE).log2(), fixed(3_321_928_094));
 }
 
-// ==== Aborts ====
+// === Aborts ===
 
 #[test, expected_failure(abort_code = ud30x9_base::ELogUndefined)]
 fun log2_of_zero_aborts() {
@@ -50,7 +50,7 @@ fun log2_of_sub_one_aborts() {
     fixed(SCALE - 1).log2();
 }
 
-// ==== Extreme values ====
+// === Extreme values ===
 
 #[test]
 fun log2_of_max_ud30x9() {
@@ -59,7 +59,7 @@ fun log2_of_max_ud30x9() {
     assert!(result >= 98 * SCALE && result < 99 * SCALE);
 }
 
-// ==== Random property tests ====
+// === Random property tests ===
 
 #[random_test]
 fun log2_monotonicity(a: u128, b: u128) {

--- a/math/fixed_point/tests/ud30x9_tests/sqrt_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/sqrt_tests.move
@@ -7,7 +7,7 @@ use std::unit_test::assert_eq;
 
 const SCALE: u128 = 1_000_000_000;
 
-// ==== Tests ====
+// === Tests ===
 
 #[test]
 fun sqrt_of_zero_is_zero() {


### PR DESCRIPTION
## Summary

Applies the Move Code Quality Checklist to the `openzeppelin_fp_math` package on top of `fixed-point-logs`.

Fixes:
- **Section ordering** in `sd29x9_base.move`: moved `// === Public Functions ===` to before the `Conversion` subgrouping (which contains public functions) and removed the duplicate header below.
- **Testing rules** in `tests/internal/raw_log2_tests.move`: replaced three `assert!(x == y)` calls with `assert_eq!`, added `use std::unit_test::assert_eq;`.
- **Subsection comment format** across 9 test files under `tests/internal/` and `tests/{sd29x9,ud30x9}_tests/`: normalized 4-equals `// ==== Name ====` subgrouping comments to the spec's 3-equals `// === Name ===`. No comments removed.

Validation: `prettier --check`, `sui move test --lint --warnings-are-errors` (426/426 pass), and `sui move build --lint --warnings-are-errors` all pass on `--build-env testnet`.