### PR TITLE
Improve `median` macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 #### Added
 
-- `vector::median` macro for unsigned integer vectors (`u8`..`u256`) with configurable rounding for even-length input; returns `Option` to signal empty input. (#135)
+- `vector::median` macro for unsigned integer vectors (`u8`..`u256`) with configurable rounding for even-length input; aborts with `vector::EEmptyVector` on empty input. (#135)
+
 #### Changed
 
 - `u128::is_power_of_ten` and `u256::is_power_of_ten` now compute the result via `log10_floor` and `pow` instead of a hardcoded lookup table. (#323)

--- a/math/core/README.md
+++ b/math/core/README.md
@@ -24,7 +24,7 @@ Operations for `u8`, `u16`, `u32`, `u64`, `u128`, and `u256`, including:
 Generic over `u8`..`u256`:
 
 - `vector::quick_sort` / `vector::quick_sort_by`: In-place iterative quicksort with three-way partitioning
-- `vector::median`: Median of an unsigned integer vector with configurable rounding for even-length input; returns `Option`
+- `vector::median`: Median of an unsigned integer vector with configurable rounding for even-length input; aborts on empty input
 
 ## Rounding modes
 
@@ -52,5 +52,5 @@ let mean = u64::average(5, 6, rounding::down());
 use openzeppelin_math::{vector, rounding};
 
 let med = vector::median!(vector[5u64, 1, 9, 3, 7], rounding::down());
-// med = option::some(5)
+// med = 5
 ```

--- a/math/core/sources/vector.move
+++ b/math/core/sources/vector.move
@@ -3,6 +3,11 @@ module openzeppelin_math::vector;
 use openzeppelin_math::macros;
 use openzeppelin_math::rounding::RoundingMode;
 
+// === Errors ===
+
+#[error(code = 0)]
+const EEmptyVector: vector<u8> = "Median of empty vector is undefined";
+
 // === Public Functions ===
 
 /// Sort an unsigned integer vector in-place using the quicksort algorithm.
@@ -206,6 +211,10 @@ public macro fun quick_sort_by<$T>($vec: &mut vector<$T>, $le: |&$T, &$T| -> boo
 /// For even-length vectors, the median is the arithmetic mean of the two central
 /// values, rounded according to `$rounding_mode`.
 ///
+/// The macro is a thin wrapper that upcasts the input to `vector<u256>` and delegates
+/// to `median_u256`, so the sort and average expansions are paid once inside the
+/// package rather than at every integrator call site.
+///
 /// #### Generics
 /// - `$Int`: Any unsigned integer type (`u8`, `u16`, `u32`, `u64`, `u128`, or `u256`).
 ///
@@ -214,28 +223,47 @@ public macro fun quick_sort_by<$T>($vec: &mut vector<$T>, $le: |&$T, &$T| -> boo
 /// - `$rounding_mode`: Rounding strategy, applied only when the length is even.
 ///
 /// #### Returns
-/// - `option::some(median)` when `$vec` is non-empty.
-/// - `option::none()` when `$vec` is empty — median of empty data is undefined.
-public macro fun median<$Int>($vec: vector<$Int>, $rounding_mode: RoundingMode): Option<$Int> {
-    let mut vec = $vec;
-    let len = vec.length();
+/// - The median of `$vec`.
+///
+/// #### Aborts
+/// - `EEmptyVector` if `$vec` is empty.
+public macro fun median<$Int>($vec: vector<$Int>, $rounding_mode: RoundingMode): $Int {
+    let vec = $vec;
+    let vec_u256 = vec.map!(|x| x as u256);
+    median_u256(vec_u256, $rounding_mode) as $Int
+}
 
-    // Median of empty data is undefined — signal "no value" rather than abort.
-    if (len == 0) {
-        return option::none()
-    };
+// === Package Functions ===
+
+/// Compute the median of a `u256` vector with configurable rounding.
+///
+/// Shared workhorse behind the `median!` macro. Centralises the macro expansions of
+/// `quick_sort!` and `macros::average!` so they are paid once in this package rather
+/// than at every integrator call site.
+///
+/// #### Parameters
+/// - `vec`: Vector whose median is desired (consumed).
+/// - `rounding_mode`: Rounding strategy, applied only when the length is even.
+///
+/// #### Returns
+/// - The median of `vec`.
+///
+/// #### Aborts
+/// - `EEmptyVector` if `vec` is empty.
+public(package) fun median_u256(mut vec: vector<u256>, rounding_mode: RoundingMode): u256 {
+    let len = vec.length();
+    assert!(len != 0, EEmptyVector);
 
     quick_sort!(&mut vec);
 
     let mid = len / 2;
-    let result = if (len % 2 == 1) {
+    if (len % 2 == 1) {
         // Odd length: middle element of the sorted vector.
         vec[mid]
     } else {
         // Even length: rounded mean of the two central order statistics.
         let lower = vec[mid - 1];
         let upper = vec[mid];
-        macros::average!(lower, upper, $rounding_mode)
-    };
-    option::some(result)
+        macros::average!(lower, upper, rounding_mode)
+    }
 }

--- a/math/core/tests/macros/median.move
+++ b/math/core/tests/macros/median.move
@@ -1,227 +1,213 @@
 #[test_only]
 module openzeppelin_math::median;
 
-use openzeppelin_math::rounding::{Self, RoundingMode};
+use openzeppelin_math::rounding;
 use openzeppelin_math::vector;
 use std::unit_test::assert_eq;
 
-// Helpers for the two workhorse widths. Each test that calls a helper avoids inlining
-// `median!`'s body, keeping the test module's total bytecode under Sui's per-package
-// arena limit — every `median!` expansion includes the full `quick_sort_by!` stack
-// loop plus `average!`'s u256-upcast machinery. Widths used by only a couple of tests
-// (`u8`, `u16`, `u32`, `u128`) inline the macro directly.
-
-fun u64_median(vec: vector<u64>, mode: RoundingMode): Option<u64> {
-    vector::median!(vec, mode)
-}
-
-fun u256_median(vec: vector<u256>, mode: RoundingMode): Option<u256> {
-    vector::median!(vec, mode)
-}
-
 // === Empty input ===
 
-#[test]
-fun median_empty_vector_returns_none() {
-    assert!(u64_median(vector<u64>[], rounding::down()).is_none());
+#[test, expected_failure(abort_code = vector::EEmptyVector)]
+fun median_empty_u8_aborts() {
+    vector::median!(vector<u8>[], rounding::down());
 }
 
-#[test]
-fun median_empty_u8_returns_none() {
-    assert!(vector::median!(vector<u8>[], rounding::down()).is_none());
+#[test, expected_failure(abort_code = vector::EEmptyVector)]
+fun median_empty_u16_aborts() {
+    vector::median!(vector<u16>[], rounding::down());
 }
 
-#[test]
-fun median_empty_u16_returns_none() {
-    assert!(vector::median!(vector<u16>[], rounding::down()).is_none());
+#[test, expected_failure(abort_code = vector::EEmptyVector)]
+fun median_empty_u32_aborts() {
+    vector::median!(vector<u32>[], rounding::down());
 }
 
-#[test]
-fun median_empty_u32_returns_none() {
-    assert!(vector::median!(vector<u32>[], rounding::down()).is_none());
+#[test, expected_failure(abort_code = vector::EEmptyVector)]
+fun median_empty_u64_aborts() {
+    vector::median!(vector<u64>[], rounding::down());
 }
 
-#[test]
-fun median_empty_u128_returns_none() {
-    assert!(vector::median!(vector<u128>[], rounding::down()).is_none());
+#[test, expected_failure(abort_code = vector::EEmptyVector)]
+fun median_empty_u128_aborts() {
+    vector::median!(vector<u128>[], rounding::down());
 }
 
-#[test]
-fun median_empty_u256_returns_none() {
-    assert!(u256_median(vector<u256>[], rounding::nearest()).is_none());
+#[test, expected_failure(abort_code = vector::EEmptyVector)]
+fun median_empty_u256_aborts() {
+    vector::median!(vector<u256>[], rounding::nearest());
 }
 
 // === Single-element and small inputs ===
 
 #[test]
 fun median_single_element() {
-    assert_eq!(u64_median(vector[42u64], rounding::down()).destroy_some(), 42u64);
+    assert_eq!(vector::median!(vector[42u64], rounding::down()), 42u64);
 }
 
 #[test]
 fun median_two_elements_unsorted() {
-    assert_eq!(u64_median(vector[9u64, 1], rounding::down()).destroy_some(), 5u64);
+    assert_eq!(vector::median!(vector[9u64, 1], rounding::down()), 5u64);
 }
 
 #[test]
 fun median_two_elements_same_value() {
-    assert_eq!(u64_median(vector[7u64, 7], rounding::down()).destroy_some(), 7u64);
+    assert_eq!(vector::median!(vector[7u64, 7], rounding::down()), 7u64);
 }
 
 // === Odd-length correctness ===
 
 #[test]
 fun median_odd_length_unsorted() {
-    assert_eq!(u64_median(vector[5u64, 1, 9, 3, 7], rounding::down()).destroy_some(), 5u64);
+    assert_eq!(vector::median!(vector[5u64, 1, 9, 3, 7], rounding::down()), 5u64);
 }
 
 #[test]
 fun median_reverse_sorted_odd_length() {
-    assert_eq!(u64_median(vector[9u64, 7, 5, 3, 1], rounding::down()).destroy_some(), 5u64);
+    assert_eq!(vector::median!(vector[9u64, 7, 5, 3, 1], rounding::down()), 5u64);
 }
 
 #[test]
 fun median_already_sorted_odd() {
-    assert_eq!(u64_median(vector[1u64, 2, 3, 4, 5], rounding::down()).destroy_some(), 3u64);
+    assert_eq!(vector::median!(vector[1u64, 2, 3, 4, 5], rounding::down()), 3u64);
 }
 
 #[test]
 fun median_odd_length_rounding_mode_irrelevant_down() {
-    assert_eq!(u64_median(vector[5u64, 1, 9, 3, 7], rounding::down()).destroy_some(), 5u64);
+    assert_eq!(vector::median!(vector[5u64, 1, 9, 3, 7], rounding::down()), 5u64);
 }
 
 #[test]
 fun median_odd_length_rounding_mode_irrelevant_up() {
-    assert_eq!(u64_median(vector[5u64, 1, 9, 3, 7], rounding::up()).destroy_some(), 5u64);
+    assert_eq!(vector::median!(vector[5u64, 1, 9, 3, 7], rounding::up()), 5u64);
 }
 
 #[test]
 fun median_odd_length_rounding_mode_irrelevant_nearest() {
-    assert_eq!(u64_median(vector[5u64, 1, 9, 3, 7], rounding::nearest()).destroy_some(), 5u64);
+    assert_eq!(vector::median!(vector[5u64, 1, 9, 3, 7], rounding::nearest()), 5u64);
 }
 
 // === Even-length correctness and rounding contract ===
 
 #[test]
 fun median_even_length_unsorted() {
-    assert_eq!(u64_median(vector[10u64, 2, 8, 4], rounding::down()).destroy_some(), 6u64);
+    assert_eq!(vector::median!(vector[10u64, 2, 8, 4], rounding::down()), 6u64);
 }
 
 #[test]
 fun median_even_length_rounds_down() {
     // (2 + 5) / 2 = 3.5 -> rounds down to 3
-    assert_eq!(u64_median(vector[6u64, 5, 1, 2], rounding::down()).destroy_some(), 3u64);
+    assert_eq!(vector::median!(vector[6u64, 5, 1, 2], rounding::down()), 3u64);
 }
 
 #[test]
 fun median_even_length_rounds_up() {
     // middles 2 and 3 -> ceil((2+3)/2) = 3
-    assert_eq!(u64_median(vector[1u64, 2, 3, 4], rounding::up()).destroy_some(), 3u64);
+    assert_eq!(vector::median!(vector[1u64, 2, 3, 4], rounding::up()), 3u64);
 }
 
 #[test]
 fun median_even_length_rounds_nearest_half_rounds_up() {
     // (1 + 2) / 2 = 1.5 — rounding::nearest() rounds half-up
-    assert_eq!(u64_median(vector[1u64, 2], rounding::nearest()).destroy_some(), 2u64);
+    assert_eq!(vector::median!(vector[1u64, 2], rounding::nearest()), 2u64);
 }
 
 #[test]
 fun median_even_length_nearest_exact_midpoint_down() {
     // sorted: [2, 4, 8, 10]; middles 4, 8 -> (4+8)/2 = 6 exactly. Every rounding
     // mode returns the exact value.
-    assert_eq!(u64_median(vector[10u64, 2, 8, 4], rounding::down()).destroy_some(), 6u64);
+    assert_eq!(vector::median!(vector[10u64, 2, 8, 4], rounding::down()), 6u64);
 }
 
 #[test]
 fun median_even_length_nearest_exact_midpoint_up() {
-    assert_eq!(u64_median(vector[10u64, 2, 8, 4], rounding::up()).destroy_some(), 6u64);
+    assert_eq!(vector::median!(vector[10u64, 2, 8, 4], rounding::up()), 6u64);
 }
 
 #[test]
 fun median_even_length_nearest_exact_midpoint_nearest() {
-    assert_eq!(u64_median(vector[10u64, 2, 8, 4], rounding::nearest()).destroy_some(), 6u64);
+    assert_eq!(vector::median!(vector[10u64, 2, 8, 4], rounding::nearest()), 6u64);
 }
 
 #[test]
 fun median_sorted_even_length() {
-    assert_eq!(u64_median(vector[1u64, 3, 5, 7], rounding::down()).destroy_some(), 4u64);
+    assert_eq!(vector::median!(vector[1u64, 3, 5, 7], rounding::down()), 4u64);
 }
 
 // === Duplicates ===
 
 #[test]
 fun median_with_duplicates() {
-    assert_eq!(u64_median(vector[2u64, 2, 2, 3, 4], rounding::down()).destroy_some(), 2u64);
+    assert_eq!(vector::median!(vector[2u64, 2, 2, 3, 4], rounding::down()), 2u64);
 }
 
 #[test]
 fun median_with_many_duplicates_even() {
-    assert_eq!(u64_median(vector[4u64, 1, 4, 4, 2, 4], rounding::down()).destroy_some(), 4u64);
+    assert_eq!(vector::median!(vector[4u64, 1, 4, 4, 2, 4], rounding::down()), 4u64);
 }
 
 // === Constant-vector idempotence ===
 
 #[test]
 fun median_constant_vector_down_n3() {
-    assert_eq!(u64_median(vector[7u64, 7, 7], rounding::down()).destroy_some(), 7u64);
+    assert_eq!(vector::median!(vector[7u64, 7, 7], rounding::down()), 7u64);
 }
 
 #[test]
 fun median_constant_vector_down_n4() {
-    assert_eq!(u64_median(vector[7u64, 7, 7, 7], rounding::down()).destroy_some(), 7u64);
+    assert_eq!(vector::median!(vector[7u64, 7, 7, 7], rounding::down()), 7u64);
 }
 
 #[test]
 fun median_constant_vector_down_zeros() {
-    assert_eq!(u64_median(vector[0u64, 0], rounding::down()).destroy_some(), 0u64);
+    assert_eq!(vector::median!(vector[0u64, 0], rounding::down()), 0u64);
 }
 
 #[test]
 fun median_constant_vector_down_u64_max() {
     let max = std::u64::max_value!();
-    assert_eq!(u64_median(vector[max, max], rounding::down()).destroy_some(), max);
+    assert_eq!(vector::median!(vector[max, max], rounding::down()), max);
 }
 
 #[test]
 fun median_constant_vector_up() {
-    assert_eq!(u64_median(vector[42u64, 42], rounding::up()).destroy_some(), 42u64);
+    assert_eq!(vector::median!(vector[42u64, 42], rounding::up()), 42u64);
 }
 
 #[test]
 fun median_constant_vector_nearest() {
-    assert_eq!(u64_median(vector[42u64, 42], rounding::nearest()).destroy_some(), 42u64);
+    assert_eq!(vector::median!(vector[42u64, 42], rounding::nearest()), 42u64);
 }
 
 // === Permutation invariance ===
 
 #[test]
 fun median_permutation_canonical_odd() {
-    assert_eq!(u64_median(vector[1u64, 2, 3, 4, 5], rounding::down()).destroy_some(), 3u64);
+    assert_eq!(vector::median!(vector[1u64, 2, 3, 4, 5], rounding::down()), 3u64);
 }
 
 #[test]
 fun median_permutation_shuffled_odd() {
-    assert_eq!(u64_median(vector[3u64, 1, 5, 2, 4], rounding::down()).destroy_some(), 3u64);
+    assert_eq!(vector::median!(vector[3u64, 1, 5, 2, 4], rounding::down()), 3u64);
 }
 
 #[test]
 fun median_permutation_reversed_odd() {
-    assert_eq!(u64_median(vector[5u64, 4, 3, 2, 1], rounding::down()).destroy_some(), 3u64);
+    assert_eq!(vector::median!(vector[5u64, 4, 3, 2, 1], rounding::down()), 3u64);
 }
 
 #[test]
 fun median_permutation_canonical_even() {
-    assert_eq!(u64_median(vector[1u64, 2, 3, 4], rounding::down()).destroy_some(), 2u64);
+    assert_eq!(vector::median!(vector[1u64, 2, 3, 4], rounding::down()), 2u64);
 }
 
 #[test]
 fun median_permutation_shuffled_even() {
-    assert_eq!(u64_median(vector[4u64, 1, 3, 2], rounding::down()).destroy_some(), 2u64);
+    assert_eq!(vector::median!(vector[4u64, 1, 3, 2], rounding::down()), 2u64);
 }
 
 #[test]
 fun median_permutation_other_shuffle_even() {
-    assert_eq!(u64_median(vector[3u64, 4, 2, 1], rounding::down()).destroy_some(), 2u64);
+    assert_eq!(vector::median!(vector[3u64, 4, 2, 1], rounding::down()), 2u64);
 }
 
 // === Overflow safety on even-length resolution ===
@@ -230,7 +216,7 @@ fun median_permutation_other_shuffle_even() {
 fun median_even_length_zero_and_max() {
     // floor(u64::MAX / 2)
     assert_eq!(
-        u64_median(vector[0, std::u64::max_value!()], rounding::down()).destroy_some(),
+        vector::median!(vector[0, std::u64::max_value!()], rounding::down()),
         std::u64::max_value!() / 2,
     );
 }
@@ -238,19 +224,19 @@ fun median_even_length_zero_and_max() {
 #[test]
 fun median_even_u256_max_max_down() {
     let max = std::u256::max_value!();
-    assert_eq!(u256_median(vector[max, max], rounding::down()).destroy_some(), max);
+    assert_eq!(vector::median!(vector[max, max], rounding::down()), max);
 }
 
 #[test]
 fun median_even_u256_max_max_up() {
     let max = std::u256::max_value!();
-    assert_eq!(u256_median(vector[max, max], rounding::up()).destroy_some(), max);
+    assert_eq!(vector::median!(vector[max, max], rounding::up()), max);
 }
 
 #[test]
 fun median_even_u256_max_max_nearest() {
     let max = std::u256::max_value!();
-    assert_eq!(u256_median(vector[max, max], rounding::nearest()).destroy_some(), max);
+    assert_eq!(vector::median!(vector[max, max], rounding::nearest()), max);
 }
 
 #[test]
@@ -258,7 +244,7 @@ fun median_even_u256_zero_and_max_down() {
     // floor(MAX/2) = 2^255 - 1
     let max = std::u256::max_value!();
     let half_floor = std::u256::max_value!() / 2;
-    assert_eq!(u256_median(vector[0, max], rounding::down()).destroy_some(), half_floor);
+    assert_eq!(vector::median!(vector[0, max], rounding::down()), half_floor);
 }
 
 #[test]
@@ -266,7 +252,7 @@ fun median_even_u256_zero_and_max_up() {
     // ceil(MAX/2) = 2^255
     let max = std::u256::max_value!();
     let half_ceil = std::u256::max_value!() / 2 + 1;
-    assert_eq!(u256_median(vector[0, max], rounding::up()).destroy_some(), half_ceil);
+    assert_eq!(vector::median!(vector[0, max], rounding::up()), half_ceil);
 }
 
 #[test]
@@ -274,25 +260,25 @@ fun median_even_u256_zero_and_max_nearest() {
     // 0.5 tie -> nearest rounds up -> 2^255
     let max = std::u256::max_value!();
     let half_ceil = std::u256::max_value!() / 2 + 1;
-    assert_eq!(u256_median(vector[0, max], rounding::nearest()).destroy_some(), half_ceil);
+    assert_eq!(vector::median!(vector[0, max], rounding::nearest()), half_ceil);
 }
 
 // === Per-width sanity checks ===
 
 #[test]
 fun median_supports_u8() {
-    assert_eq!(vector::median!(vector[5u8, 1, 9], rounding::down()).destroy_some(), 5u8);
+    assert_eq!(vector::median!(vector[5u8, 1, 9], rounding::down()), 5u8);
 }
 
 #[test]
 fun median_u16_even_length() {
-    assert_eq!(vector::median!(vector[100u16, 200, 1, 3], rounding::down()).destroy_some(), 51u16);
+    assert_eq!(vector::median!(vector[100u16, 200, 1, 3], rounding::down()), 51u16);
 }
 
 #[test]
 fun median_u32_odd_length() {
     assert_eq!(
-        vector::median!(vector[1000u32, 1, 500, 3, 7], rounding::down()).destroy_some(),
+        vector::median!(vector[1000u32, 1, 500, 3, 7], rounding::down()),
         7u32,
     );
 }
@@ -300,7 +286,7 @@ fun median_u32_odd_length() {
 #[test]
 fun median_u128_even_length_large_values() {
     assert_eq!(
-        vector::median!(vector[std::u128::max_value!(), 0], rounding::down()).destroy_some(),
+        vector::median!(vector[std::u128::max_value!(), 0], rounding::down()),
         std::u128::max_value!() / 2,
     );
 }
@@ -309,10 +295,10 @@ fun median_u128_even_length_large_values() {
 fun median_u256_odd_length_large_values() {
     let u128_max_as_u256 = std::u128::max_value!() as u256;
     assert_eq!(
-        u256_median(
+        vector::median!(
             vector[0, std::u256::max_value!(), u128_max_as_u256],
             rounding::down(),
-        ).destroy_some(),
+        ),
         u128_max_as_u256,
     );
 }
@@ -328,5 +314,5 @@ fun median_large_odd_length() {
         vec.push_back(i);
         i = i + 1;
     };
-    assert_eq!(u64_median(vec, rounding::down()).destroy_some(), 500u64);
+    assert_eq!(vector::median!(vec, rounding::down()), 500u64);
 }


### PR DESCRIPTION
## Problem
`vector::median!` is a macro, so every integrator call site inlines the full `quick_sort_by!` body (~125 lines of bytecode) plus `macros::average!`'s u256 machinery. The PR #135 test module already had to add wrapper functions to stay under Sui's per-module bytecode limit at ~50 call sites — integrators using `median!` for two widths in one module would hit the same limit with no documented reason.

## Changes
- Move the `sort` + `average` expansions into a shared `public(package) fun median_u256` so they're paid **once in the package** instead of at every call site. The public `median!` macro is now a thin upcast → delegate → downcast wrapper
- Switch the empty-vector contract from `option::none()` to `abort(EEmptyVector)`, matching the package's convention for undefined-domain inputs (`EDivideByZero`, `EZeroModulus`). Return type drops from `Option<$Int>` to `$Int`