### PR TITLE
[N-03] Access Control Audit

### DIFF
--- a/contracts/access/README.md
+++ b/contracts/access/README.md
@@ -29,7 +29,10 @@ Initialize the registry from the module's `init` function when the package is
 first published. Sui does not run `init` for modules added in a later package
 upgrade, so an already-published package cannot adopt AccessControl by adding a
 new module that expects its OTW to be delivered. Publish a fresh package with
-its own initializing module and AccessControl registry instead.
+its own initializing module and AccessControl registry instead. Use
+`access_control::new` when the publisher should be the default admin, or
+`access_control::new_with_admin` when the initial default admin should be an
+explicit governance or multisig address.
 
 ```move
 use openzeppelin_access::access_control::{Self, AccessControl, Auth};

--- a/contracts/access/sources/access_control.move
+++ b/contracts/access/sources/access_control.move
@@ -344,7 +344,7 @@ public fun new_with_admin<RootRole: drop>(
     assert!(default_admin_delay_ms <= MAX_DEFAULT_ADMIN_DELAY_MS, EDelayTooLarge);
     assert!(initial_admin != @0x0, EZeroAddress);
 
-    let event_sender = ctx.sender();
+    let sender = ctx.sender();
     let root_type = with_original_ids<RootRole>();
 
     let mut ac = AccessControl<RootRole> {
@@ -367,7 +367,7 @@ public fun new_with_admin<RootRole: drop>(
             },
         );
 
-    event::emit(RoleGranted { role: root_type, account: initial_admin, sender: event_sender });
+    event::emit(RoleGranted { role: root_type, account: initial_admin, sender });
 
     ac
 }

--- a/contracts/access/sources/access_control.move
+++ b/contracts/access/sources/access_control.move
@@ -17,7 +17,7 @@
 ///    `set_role_admin`) plus the auth-mint path (`new_auth`) — checks that
 ///    the role type's home module matches the root role's home module.
 ///    Foreign role types are rejected at the boundary; they cannot be
-///    introduced into the bag. The check uses `type_name::with_original_ids`,
+///    introduced into the role map. The check uses `type_name::with_original_ids`,
 ///    which compares the package's *original* publish address — so role
 ///    types introduced in later upgrades to the same module in the same
 ///    package pass the check too. The home-module rule restricts roles to the
@@ -48,9 +48,9 @@
 module openzeppelin_access::access_control;
 
 use std::type_name::{TypeName, with_original_ids};
-use sui::bag::{Self, Bag};
 use sui::clock::Clock;
 use sui::event;
+use sui::table::{Self, Table};
 use sui::types;
 use sui::vec_set::{Self, VecSet};
 
@@ -79,43 +79,39 @@ const ENotPendingAdmin: vector<u8> = "Caller is not the pending admin";
 #[error(code = 4)]
 const EDelayNotElapsed: vector<u8> = "Pending action's timelock has not elapsed";
 
-/// Role renounce attempted for an account other than the transaction sender.
-#[error(code = 5)]
-const ECannotRenounceForOtherAccount: vector<u8> = "Can only renounce role for own account";
-
 /// Default admin delay value exceeds the allowed maximum.
-#[error(code = 6)]
+#[error(code = 5)]
 const EDelayTooLarge: vector<u8> = "Admin delay exceeds the maximum allowed value";
 
 /// Root role value is not a genuine One-Time Witness.
-#[error(code = 7)]
+#[error(code = 6)]
 const ENotOneTimeWitness: vector<u8> = "Root role must be a One-Time Witness";
 
 /// A role type from a module other than the root role's home module was used
 /// in a write path.
-#[error(code = 8)]
+#[error(code = 7)]
 const EForeignRole: vector<u8> = "Role type must be defined in the same module as the root role";
 
 /// Pending root role action is a renounce, not a transfer.
-#[error(code = 9)]
+#[error(code = 8)]
 const ENotPendingTransfer: vector<u8> = "Pending action is a renounce, not a transfer";
 
 /// Pending root role action is a transfer, not a renounce.
-#[error(code = 10)]
+#[error(code = 9)]
 const ENotPendingRenounce: vector<u8> = "Pending action is not a renounce";
 
 /// No pending default admin delay change exists.
-#[error(code = 11)]
+#[error(code = 10)]
 const ENoPendingDelayChange: vector<u8> = "No pending default admin delay change";
 
 /// Zero address was used as a role holder or root transfer target. The zero
 /// address has no signing key, so a role granted to it can never be exercised
 /// and a transfer scheduled to it can never be accepted.
-#[error(code = 12)]
+#[error(code = 11)]
 const EZeroAddress: vector<u8> = "Cannot use the zero address as a role holder or transfer target";
 
 /// The current root holder tried to schedule a no-op transfer to itself.
-#[error(code = 13)]
+#[error(code = 12)]
 const EDefaultAdminTransferToSelf: vector<u8> = "Cannot transfer default admin to self";
 
 // === Constants ===
@@ -166,7 +162,7 @@ public struct AccessControl<phantom RootRole> has key, store {
     id: UID,
     /// Per-role membership and admin mapping. Keyed by `TypeName`.
     /// Entries are created lazily on first grant or `set_role_admin`.
-    roles: Bag,
+    roles: Table<TypeName, RoleData>,
     /// `TypeName` of the root role (= `RootRole`'s OTW). Direct
     /// `grant_role` / `revoke_role` / `renounce_role` / `set_role_admin` on
     /// this role is blocked (`ECannotManageRootRole`); use the timelocked
@@ -280,12 +276,15 @@ public struct DefaultAdminDelayChangeCancelled has copy, drop {}
 
 // === Constructor ===
 
-/// Create the singleton `AccessControl` for a module.
+/// Create the singleton `AccessControl` for a module, with the transaction
+/// sender as the initial root role holder.
 ///
 /// The caller passes their module's One-Time Witness as `otw`. The runtime
 /// `is_one_time_witness` check confirms the value is genuine — this is what
 /// enforces Invariant 1 (one registry per module, initialized at first
 /// publish). The transaction sender automatically becomes the root role holder.
+/// Prefer this constructor when the initial admin should be the caller; it
+/// avoids copy-pasting an address into `init`.
 ///
 /// The expected call site is the consumer module's `init` function, where
 /// the VM has already produced exactly one OTW value. That `init` function is
@@ -310,15 +309,47 @@ public fun new<RootRole: drop>(
     default_admin_delay_ms: u64,
     ctx: &mut TxContext,
 ): AccessControl<RootRole> {
+    new_with_admin(otw, ctx.sender(), default_admin_delay_ms, ctx)
+}
+
+/// Create the singleton `AccessControl` for a module, with an explicit initial
+/// root role holder.
+///
+/// Use this variant only when the initial admin intentionally differs from the
+/// publishing transaction sender, for example a multisig or governance address.
+/// Otherwise prefer `new`, which uses `ctx.sender()` and avoids address
+/// copy-paste mistakes in package initialization code.
+///
+/// #### Parameters
+/// - `otw`: a VM-issued One-Time Witness of type `RootRole`. Consumed by the call.
+/// - `initial_admin`: the address that receives the root role.
+/// - `default_admin_delay_ms`: timelock (ms) that applies to root role transfer and renounce. Mutable post-creation via `begin_default_admin_delay_change`.
+/// - `ctx`: transaction context.
+///
+/// #### Returns
+/// - The freshly-minted singleton `AccessControl<RootRole>` registry. The caller
+/// is responsible for sharing, embedding, or otherwise positioning it.
+///
+/// #### Aborts
+/// - `ENotOneTimeWitness` if `otw` is not a true One-Time Witness.
+/// - `EDelayTooLarge` if `default_admin_delay_ms` exceeds `MAX_DEFAULT_ADMIN_DELAY_MS`.
+/// - `EZeroAddress` if `initial_admin` is `@0x0`.
+public fun new_with_admin<RootRole: drop>(
+    otw: RootRole,
+    initial_admin: address,
+    default_admin_delay_ms: u64,
+    ctx: &mut TxContext,
+): AccessControl<RootRole> {
     assert!(types::is_one_time_witness(&otw), ENotOneTimeWitness);
     assert!(default_admin_delay_ms <= MAX_DEFAULT_ADMIN_DELAY_MS, EDelayTooLarge);
+    assert!(initial_admin != @0x0, EZeroAddress);
 
-    let sender = ctx.sender();
+    let event_sender = ctx.sender();
     let root_type = with_original_ids<RootRole>();
 
     let mut ac = AccessControl<RootRole> {
         id: object::new(ctx),
-        roles: bag::new(ctx),
+        roles: table::new(ctx),
         protected_root: root_type,
         pending_default_admin: option::none(),
         pending_default_admin_delay_change: option::none(),
@@ -330,13 +361,13 @@ public fun new<RootRole: drop>(
         .add(
             root_type,
             RoleData {
-                members: vec_set::singleton(sender),
+                members: vec_set::singleton(initial_admin),
                 // Root role is self-administering.
                 admin_role: root_type,
             },
         );
 
-    event::emit(RoleGranted { role: root_type, account: sender, sender });
+    event::emit(RoleGranted { role: root_type, account: initial_admin, sender: event_sender });
 
     ac
 }
@@ -424,7 +455,7 @@ public fun grant_role<RootRole, Role>(
             );
     };
 
-    let role_data = ac.roles.borrow_mut<_, RoleData>(role_name);
+    let role_data = ac.roles.borrow_mut(role_name);
     if (role_data.members.contains(&account)) return;
 
     role_data.members.insert(account);
@@ -456,7 +487,7 @@ public fun revoke_role<RootRole, Role>(
 
     if (!ac.roles.contains(role_name)) return;
 
-    let role_data = ac.roles.borrow_mut<_, RoleData>(role_name);
+    let role_data = ac.roles.borrow_mut(role_name);
     if (!role_data.members.contains(&account)) return;
 
     role_data.members.remove(&account);
@@ -472,31 +503,25 @@ public fun revoke_role<RootRole, Role>(
 /// #### Parameters
 /// - `Role` (type): the role to relinquish.
 /// - `ac`: the registry to mutate.
-/// - `account`: the address relinquishing `Role`.
 /// - `ctx`: transaction context.
 ///
 /// #### Aborts
-/// - `ECannotRenounceForOtherAccount` if `account != ctx.sender()`.
 /// - `EForeignRole` if `Role`'s home module differs from `RootRole`'s.
 /// - `ECannotManageRootRole` if `Role` is the root role.
-public fun renounce_role<RootRole, Role>(
-    ac: &mut AccessControl<RootRole>,
-    account: address,
-    ctx: &mut TxContext,
-) {
-    assert!(account == ctx.sender(), ECannotRenounceForOtherAccount);
+public fun renounce_role<RootRole, Role>(ac: &mut AccessControl<RootRole>, ctx: &mut TxContext) {
     assert_home_module<RootRole, Role>();
 
+    let sender = ctx.sender();
     let role_name = with_original_ids<Role>();
     assert!(role_name != ac.protected_root, ECannotManageRootRole);
 
     if (!ac.roles.contains(role_name)) return;
 
-    let role_data = ac.roles.borrow_mut<_, RoleData>(role_name);
-    if (!role_data.members.contains(&account)) return;
+    let role_data = ac.roles.borrow_mut(role_name);
+    if (!role_data.members.contains(&sender)) return;
 
-    role_data.members.remove(&account);
-    event::emit(RoleRevoked { role: role_name, account, sender: ctx.sender() });
+    role_data.members.remove(&sender);
+    event::emit(RoleRevoked { role: role_name, account: sender, sender });
 }
 
 /// Set the admin role of `Role` to `AdminRole`. Caller must hold the current
@@ -528,7 +553,7 @@ public fun set_role_admin<RootRole, Role, AdminRole>(
     let new_admin_name = with_original_ids<AdminRole>();
 
     if (ac.roles.contains(role_name)) {
-        ac.roles.borrow_mut<_, RoleData>(role_name).admin_role = new_admin_name;
+        ac.roles.borrow_mut(role_name).admin_role = new_admin_name;
     } else {
         ac
             .roles
@@ -621,14 +646,14 @@ public fun accept_default_admin_transfer<RootRole>(
     let root_type = ac.protected_root;
 
     // Root role has at most one holder; find and revoke atomically.
-    let keys = ac.roles.borrow<_, RoleData>(root_type).members.keys();
+    let keys = ac.roles.borrow(root_type).members.keys();
     if (!keys.is_empty()) {
         let old_admin = keys[0];
-        ac.roles.borrow_mut<_, RoleData>(root_type).members.remove(&old_admin);
+        ac.roles.borrow_mut(root_type).members.remove(&old_admin);
         event::emit(RoleRevoked { role: root_type, account: old_admin, sender });
     };
 
-    ac.roles.borrow_mut<_, RoleData>(root_type).members.insert(new_admin);
+    ac.roles.borrow_mut(root_type).members.insert(new_admin);
     event::emit(RoleGranted { role: root_type, account: new_admin, sender });
 }
 
@@ -703,7 +728,7 @@ public fun accept_default_admin_renounce<RootRole>(
     let sender = ctx.sender();
     let root_type = ac.protected_root;
 
-    ac.roles.borrow_mut<_, RoleData>(root_type).members.remove(&sender);
+    ac.roles.borrow_mut(root_type).members.remove(&sender);
     event::emit(RoleRevoked { role: root_type, account: sender, sender });
 }
 
@@ -1011,14 +1036,14 @@ fun has_role_by_name<RootRole>(
     account: address,
 ): bool {
     if (!ac.roles.contains(role)) return false;
-    ac.roles.borrow<_, RoleData>(role).members.contains(&account)
+    ac.roles.borrow(role).members.contains(&account)
 }
 
 /// Returns the admin role `TypeName` of `role`. Defaults to the root role for
 /// roles that have no entry yet.
 fun get_role_admin_name<RootRole>(ac: &AccessControl<RootRole>, role: TypeName): TypeName {
     if (!ac.roles.contains(role)) return ac.protected_root;
-    ac.roles.borrow<_, RoleData>(role).admin_role
+    ac.roles.borrow(role).admin_role
 }
 
 /// Asserts `Role` and `RootRole` come from the same package + module.

--- a/contracts/access/sources/access_control.move
+++ b/contracts/access/sources/access_control.move
@@ -150,6 +150,8 @@ const MAX_DELAY_INCREASE_WAIT_MS: u64 = 48 * 60 * 60 * 1_000;
 /// can ever be registered in it (Invariant 2), every `Auth<Role>` that exists was
 /// produced by that one registry, against a sender that genuinely held `Role`.
 /// Consumers can take `&Auth<Role>` as authorization without any body checks.
+/// This is a PTB-local snapshot: if the holder later renounces `Role` in the
+/// same PTB, the witness remains valid but no longer reflects live membership.
 public struct Auth<phantom Role> has drop {
     addr: address,
 }
@@ -853,7 +855,8 @@ public fun cancel_default_admin_delay_change<RootRole>(
 ///
 /// #### Returns
 /// - An `Auth<Role>` capability bound to `ctx.sender()`. Pass it by reference
-/// to gated functions in the same PTB.
+/// to gated functions in the same PTB. The witness proves membership at mint
+/// time, not after a later same-PTB renounce.
 ///
 /// #### Aborts
 /// - `EForeignRole` if `Role`'s home module differs from `RootRole`'s.

--- a/contracts/access/sources/access_control.move
+++ b/contracts/access/sources/access_control.move
@@ -355,7 +355,7 @@ public fun new_with_admin<RootRole: drop>(
     assert!(default_admin_delay_ms <= MAX_DEFAULT_ADMIN_DELAY_MS, EDelayTooLarge);
     assert!(initial_admin != @0x0, EZeroAddress);
 
-    let event_sender = ctx.sender();
+    let sender = ctx.sender();
     let root_type = with_original_ids<RootRole>();
 
     let ac = AccessControl<RootRole> {
@@ -368,7 +368,7 @@ public fun new_with_admin<RootRole: drop>(
         default_admin_delay_ms,
     };
 
-    event::emit(RoleGranted { role: root_type, account: initial_admin, sender: event_sender });
+    event::emit(RoleGranted { role: root_type, account: initial_admin, sender });
 
     ac
 }

--- a/contracts/access/sources/access_control.move
+++ b/contracts/access/sources/access_control.move
@@ -12,16 +12,17 @@
 ///    that initializes its own registry instead of adding a new module to the
 ///    existing package.
 ///
-/// 2. **Only home-module roles.** Every role-typed entry point — the four
-///    mutating functions (`grant_role`, `revoke_role`, `renounce_role`,
-///    `set_role_admin`) plus the auth-mint path (`new_auth`) — checks that
-///    the role type's home module matches the root role's home module.
+/// 2. **Only home-module roles.** Every role-typed path that mutates state,
+///    mints auth, or queries admin configuration (`grant_role`, `revoke_role`,
+///    `renounce_role`, `set_role_admin`, `new_auth`, `get_role_admin`) checks
+///    that the role type's home module matches the root role's home module.
 ///    Foreign role types are rejected at the boundary; they cannot be
-///    introduced into the role map. The check uses `type_name::with_original_ids`,
-///    which compares the package's *original* publish address — so role
-///    types introduced in later upgrades to the same module in the same
-///    package pass the check too. The home-module rule restricts roles to the
-///    same original package and module, not to the same package version.
+///    introduced into the non-root role map. The check uses
+///    `type_name::with_original_ids`, which compares the package's *original*
+///    publish address — so role types introduced in later upgrades to the same
+///    module in the same package pass the check too. The home-module rule
+///    restricts roles to the same original package and module, not to the same
+///    package version.
 ///
 /// Together these guarantees make `Auth<Role>` a self-validating capability.
 /// `Role` can only live in the registry of its home module, that registry is
@@ -45,6 +46,9 @@
 ///     transfer::public_share_object(registry);
 /// }
 /// ```
+///
+/// Use `new_with_admin` instead when the initial default admin should be an
+/// explicit governance or multisig address rather than `ctx.sender()`.
 module openzeppelin_access::access_control;
 
 use std::type_name::{TypeName, with_original_ids};
@@ -110,7 +114,7 @@ const ENoPendingDelayChange: vector<u8> = "No pending default admin delay change
 #[error(code = 11)]
 const EZeroAddress: vector<u8> = "Cannot use the zero address as a role holder or transfer target";
 
-/// The current root holder tried to schedule a no-op transfer to itself.
+/// The current default admin tried to schedule a no-op transfer to itself.
 #[error(code = 12)]
 const EDefaultAdminTransferToSelf: vector<u8> = "Cannot transfer default admin to self";
 
@@ -124,7 +128,7 @@ const MAX_DEFAULT_ADMIN_DELAY_MS: u64 = 60 * 24 * 60 * 60 * 1_000;
 
 /// Maximum wait before a scheduled delay *increase* takes effect.
 ///
-/// When the root admin schedules an increase via
+/// When the default admin schedules an increase via
 /// `begin_default_admin_delay_change`, the new (larger) delay applies after
 /// a wait of `min(new_delay_ms, MAX_DELAY_INCREASE_WAIT_MS)`. This cap
 /// prevents the wait from being unreasonably long when scheduling a large
@@ -162,14 +166,20 @@ public struct AccessControl<phantom RootRole> has key, store {
     id: UID,
     /// Per-role membership and admin mapping. Keyed by `TypeName`.
     /// Entries are created lazily on first grant or `set_role_admin`.
+    /// Does NOT contain an entry for the root role; see `default_admin`.
     roles: Table<TypeName, RoleData>,
     /// `TypeName` of the root role (= `RootRole`'s OTW). Direct
     /// `grant_role` / `revoke_role` / `renounce_role` / `set_role_admin` on
     /// this role is blocked (`ECannotManageRootRole`); use the timelocked
     /// transfer or renounce flow.
     protected_root: TypeName,
-    /// Pending change to the root role holder — either a transfer to a
-    /// specific new admin or a renounce. See `PendingAdminTransfer`.
+    /// The current default admin, or `none` after a renounce.
+    /// This address is the sole holder of the root role.
+    /// Stored as a dedicated field (not inside `roles`) to express the
+    /// singleton constraint directly and simplify transfer and renounce paths.
+    default_admin: Option<address>,
+    /// Pending change to the default admin — either a transfer to a specific
+    /// new admin or a renounce. See `PendingAdminTransfer`.
     pending_default_admin: Option<PendingAdminTransfer>,
     /// Pending change to `default_admin_delay_ms`. The change becomes
     /// effective only after `accept_default_admin_delay_change` is called
@@ -188,12 +198,12 @@ public struct RoleData has store {
     admin_role: TypeName,
 }
 
-/// Snapshot of a pending change to the root role holder.
+/// Snapshot of a pending change to the default admin.
 ///
 /// `new_admin = some(addr)` represents a pending transfer — `addr` accepts
 /// after the delay via `accept_default_admin_transfer`.
 ///
-/// `new_admin = none` represents a pending renounce — the current root holder
+/// `new_admin = none` represents a pending renounce — the current default admin
 /// finalizes after the delay via `accept_default_admin_renounce`. The same
 /// pending slot is reused so a transfer and a renounce are mutually
 /// exclusive: scheduling either overwrites the other.
@@ -277,14 +287,15 @@ public struct DefaultAdminDelayChangeCancelled has copy, drop {}
 // === Constructor ===
 
 /// Create the singleton `AccessControl` for a module, with the transaction
-/// sender as the initial root role holder.
+/// sender as the initial default admin.
 ///
 /// The caller passes their module's One-Time Witness as `otw`. The runtime
 /// `is_one_time_witness` check confirms the value is genuine — this is what
 /// enforces Invariant 1 (one registry per module, initialized at first
-/// publish). The transaction sender automatically becomes the root role holder.
-/// Prefer this constructor when the initial admin should be the caller; it
-/// avoids copy-pasting an address into `init`.
+/// publish). The transaction sender automatically becomes the default admin.
+/// Prefer this constructor when the publishing transaction sender should be the
+/// initial default admin. It derives the admin from `ctx.sender()`, so `init`
+/// does not need to hard-code or forward an explicit address.
 ///
 /// The expected call site is the consumer module's `init` function, where
 /// the VM has already produced exactly one OTW value. That `init` function is
@@ -313,16 +324,16 @@ public fun new<RootRole: drop>(
 }
 
 /// Create the singleton `AccessControl` for a module, with an explicit initial
-/// root role holder.
+/// default admin.
 ///
-/// Use this variant only when the initial admin intentionally differs from the
-/// publishing transaction sender, for example a multisig or governance address.
-/// Otherwise prefer `new`, which uses `ctx.sender()` and avoids address
-/// copy-paste mistakes in package initialization code.
+/// Use this variant only when the initial default admin intentionally differs
+/// from the publishing transaction sender, for example a multisig or governance
+/// address. Otherwise prefer `new`, which derives the default admin from
+/// `ctx.sender()`.
 ///
 /// #### Parameters
 /// - `otw`: a VM-issued One-Time Witness of type `RootRole`. Consumed by the call.
-/// - `initial_admin`: the address that receives the root role.
+/// - `initial_admin`: the address that receives the root role and becomes the default admin.
 /// - `default_admin_delay_ms`: timelock (ms) that applies to root role transfer and renounce. Mutable post-creation via `begin_default_admin_delay_change`.
 /// - `ctx`: transaction context.
 ///
@@ -344,30 +355,20 @@ public fun new_with_admin<RootRole: drop>(
     assert!(default_admin_delay_ms <= MAX_DEFAULT_ADMIN_DELAY_MS, EDelayTooLarge);
     assert!(initial_admin != @0x0, EZeroAddress);
 
-    let sender = ctx.sender();
+    let event_sender = ctx.sender();
     let root_type = with_original_ids<RootRole>();
 
-    let mut ac = AccessControl<RootRole> {
+    let ac = AccessControl<RootRole> {
         id: object::new(ctx),
         roles: table::new(ctx),
         protected_root: root_type,
+        default_admin: option::some(initial_admin),
         pending_default_admin: option::none(),
         pending_default_admin_delay_change: option::none(),
         default_admin_delay_ms,
     };
 
-    ac
-        .roles
-        .add(
-            root_type,
-            RoleData {
-                members: vec_set::singleton(initial_admin),
-                // Root role is self-administering.
-                admin_role: root_type,
-            },
-        );
-
-    event::emit(RoleGranted { role: root_type, account: initial_admin, sender });
+    event::emit(RoleGranted { role: root_type, account: initial_admin, sender: event_sender });
 
     ac
 }
@@ -382,8 +383,9 @@ public fun new_with_admin<RootRole: drop>(
 /// - `account`: the address being checked.
 ///
 /// #### Returns
-/// - `true` if `account` currently holds `Role`, `false` otherwise. Returns
-/// `false` for roles that have never been registered.
+/// - `true` if `account` currently holds `Role`, `false` otherwise. Root role
+/// membership is read from the dedicated `default_admin` field; non-root roles
+/// that have never been registered return `false`.
 public fun has_role<RootRole, Role>(ac: &AccessControl<RootRole>, account: address): bool {
     ac.has_role_by_name(with_original_ids<Role>(), account)
 }
@@ -396,7 +398,9 @@ public fun has_role<RootRole, Role>(ac: &AccessControl<RootRole>, account: addre
 ///
 /// #### Returns
 /// - The `TypeName` of `Role`'s admin role. Defaults to the root role's
-/// `TypeName` for roles that have no entry yet.
+/// `TypeName` for roles that have no entry yet. The root role itself is
+/// self-administering, so calling this with `Role = RootRole` also returns the
+/// root role's `TypeName`.
 ///
 /// #### Aborts
 /// - `EForeignRole` if `Role`'s home module differs from `RootRole`'s.
@@ -588,7 +592,7 @@ public fun set_role_admin<RootRole, Role, AdminRole>(
 /// #### Aborts
 /// - `EUnauthorized` if the caller does not hold the root role.
 /// - `EZeroAddress` if `new_admin` is `@0x0`. Use `begin_default_admin_renounce` to lock the registry permanently.
-/// - `EDefaultAdminTransferToSelf` if `new_admin` is the current root holder.
+/// - `EDefaultAdminTransferToSelf` if `new_admin` is the current default admin.
 public fun begin_default_admin_transfer<RootRole>(
     ac: &mut AccessControl<RootRole>,
     new_admin: address,
@@ -645,15 +649,9 @@ public fun accept_default_admin_transfer<RootRole>(
     let sender = ctx.sender();
     let root_type = ac.protected_root;
 
-    // Root role has at most one holder; find and revoke atomically.
-    let keys = ac.roles.borrow(root_type).members.keys();
-    if (!keys.is_empty()) {
-        let old_admin = keys[0];
-        ac.roles.borrow_mut(root_type).members.remove(&old_admin);
-        event::emit(RoleRevoked { role: root_type, account: old_admin, sender });
-    };
-
-    ac.roles.borrow_mut(root_type).members.insert(new_admin);
+    let old_admin = *ac.default_admin.borrow();
+    event::emit(RoleRevoked { role: root_type, account: old_admin, sender });
+    ac.default_admin = option::some(new_admin);
     event::emit(RoleGranted { role: root_type, account: new_admin, sender });
 }
 
@@ -728,7 +726,7 @@ public fun accept_default_admin_renounce<RootRole>(
     let sender = ctx.sender();
     let root_type = ac.protected_root;
 
-    ac.roles.borrow_mut(root_type).members.remove(&sender);
+    ac.default_admin = option::none();
     event::emit(RoleRevoked { role: root_type, account: sender, sender });
 }
 
@@ -814,7 +812,7 @@ public fun begin_default_admin_delay_change<RootRole>(
 
 /// Apply a pending delay change once its schedule has elapsed.
 ///
-/// No authorization required — the schedule was committed by the root admin
+/// No authorization required — the schedule was committed by the default admin
 /// at `begin` time; `accept` is just the state transition. Anyone can call
 /// it.
 ///
@@ -911,6 +909,14 @@ public fun auth_addr<Role>(auth: &Auth<Role>): address {
 /// - `ac`: the registry to query.
 public fun protected_root<RootRole>(ac: &AccessControl<RootRole>): TypeName {
     ac.protected_root
+}
+
+/// The current default admin, or `none` if the root role has been renounced.
+///
+/// #### Parameters
+/// - `ac`: the registry to query.
+public fun default_admin<RootRole>(ac: &AccessControl<RootRole>): Option<address> {
+    ac.default_admin
 }
 
 /// Upper bound on `default_admin_delay_ms`.
@@ -1029,12 +1035,16 @@ public fun pending_default_admin_delay_change_schedule_after_ms<RootRole>(
 // === Internal Helpers ===
 
 /// Membership check by `TypeName` — used internally when the admin role is
-/// known only as a `TypeName` value, not as a type parameter.
+/// known only as a `TypeName` value, not as a type parameter. Root role
+/// membership is stored separately as the current default admin.
 fun has_role_by_name<RootRole>(
     ac: &AccessControl<RootRole>,
     role: TypeName,
     account: address,
 ): bool {
+    if (role == ac.protected_root) {
+        return ac.default_admin == option::some(account)
+    };
     if (!ac.roles.contains(role)) return false;
     ac.roles.borrow(role).members.contains(&account)
 }

--- a/contracts/access/tests/access_control_tests.move
+++ b/contracts/access/tests/access_control_tests.move
@@ -91,6 +91,36 @@ fun test_new_with_otw_succeeds() {
     scenario.end();
 }
 
+#[test]
+#[allow(lint(share_owned))]
+fun test_new_with_admin_sets_explicit_root_holder() {
+    let deployer = @0xA;
+    let initial_admin = @0xB;
+    let mut scenario = test_scenario::begin(deployer);
+    let ac = access_control::new_with_admin<ACCESS_CONTROL_TESTS>(
+        ACCESS_CONTROL_TESTS {},
+        initial_admin,
+        0,
+        scenario.ctx(),
+    );
+
+    assert!(!ac.has_role<_, ACCESS_CONTROL_TESTS>(deployer));
+    assert!(ac.has_role<_, ACCESS_CONTROL_TESTS>(initial_admin));
+    assert_eq!(ac.protected_root(), with_original_ids<ACCESS_CONTROL_TESTS>());
+
+    let granted = event::events_by_type<access_control::RoleGranted>();
+    assert_eq!(granted.length(), 1);
+    let expected = access_control::test_new_role_granted(
+        with_original_ids<ACCESS_CONTROL_TESTS>(),
+        initial_admin,
+        deployer,
+    );
+    assert_eq!(granted[0], expected);
+
+    transfer::public_share_object(ac);
+    scenario.end();
+}
+
 #[test, expected_failure(abort_code = access_control::ENotOneTimeWitness)]
 fun test_new_rejects_non_otw() {
     let deployer = @0xA;
@@ -106,6 +136,19 @@ fun test_new_rejects_excessive_delay() {
     let _ac = access_control::new<ACCESS_CONTROL_TESTS>(
         ACCESS_CONTROL_TESTS {},
         access_control::max_default_admin_delay_ms() + 1,
+        scenario.ctx(),
+    );
+    abort 999
+}
+
+#[test, expected_failure(abort_code = access_control::EZeroAddress)]
+fun test_new_with_admin_rejects_zero_address() {
+    let deployer = @0xA;
+    let mut scenario = test_scenario::begin(deployer);
+    let _ac = access_control::new_with_admin<ACCESS_CONTROL_TESTS>(
+        ACCESS_CONTROL_TESTS {},
+        @0x0,
+        0,
         scenario.ctx(),
     );
     abort 999
@@ -365,7 +408,7 @@ fun test_renounce_role_happy_path() {
 
     scenario.next_tx(alice);
     let mut ac = take_ac(&scenario);
-    ac.renounce_role<_, AdminA>(alice, scenario.ctx());
+    ac.renounce_role<_, AdminA>(scenario.ctx());
     assert!(!ac.has_role<_, AdminA>(alice));
 
     let revoked = event::events_by_type<access_control::RoleRevoked>();
@@ -391,7 +434,7 @@ fun test_renounce_role_rejects_root() {
     let deployer = @0xA;
     let mut scenario = setup(deployer, 0);
     let mut ac = take_ac(&scenario);
-    ac.renounce_role<_, ACCESS_CONTROL_TESTS>(deployer, scenario.ctx());
+    ac.renounce_role<_, ACCESS_CONTROL_TESTS>(scenario.ctx());
     abort 999
 }
 
@@ -404,16 +447,16 @@ fun test_renounce_role_idempotent_non_member() {
     let mut ac = take_ac(&scenario);
 
     // alice never held AdminA — renounce is a no-op, no event.
-    ac.renounce_role<_, AdminA>(alice, scenario.ctx());
+    ac.renounce_role<_, AdminA>(scenario.ctx());
     assert_eq!(event::events_by_type<access_control::RoleRevoked>().length(), 0);
 
     test_scenario::return_shared(ac);
     scenario.end();
 }
 
-// Renounce idempotency: account == sender, role in bag, but the caller is not
-// a member — the second early-return path. Distinct from the "role not in bag"
-// path covered by the test above.
+// Renounce idempotency: role in bag, but the caller is not a member — the
+// second early-return path. Distinct from the "role not in bag" path covered
+// by the test above.
 #[test]
 fun test_renounce_role_idempotent_role_in_bag_non_member() {
     let deployer = @0xA;
@@ -430,21 +473,11 @@ fun test_renounce_role_idempotent_role_in_bag_non_member() {
     // member" early-return branch.
     scenario.next_tx(carol);
     let mut ac = take_ac(&scenario);
-    ac.renounce_role<_, AdminA>(carol, scenario.ctx());
+    ac.renounce_role<_, AdminA>(scenario.ctx());
     assert_eq!(event::events_by_type<access_control::RoleRevoked>().length(), 0);
 
     test_scenario::return_shared(ac);
     scenario.end();
-}
-
-#[test, expected_failure(abort_code = access_control::ECannotRenounceForOtherAccount)]
-fun test_renounce_role_rejects_other_account() {
-    let deployer = @0xA;
-    let mut scenario = setup(deployer, 0);
-    let mut ac = take_ac(&scenario);
-    // Sender is deployer; trying to renounce on behalf of @0xB must abort.
-    ac.renounce_role<_, AdminA>(@0xB, scenario.ctx());
-    abort 999
 }
 
 #[test, expected_failure(abort_code = access_control::EForeignRole)]
@@ -452,7 +485,7 @@ fun test_renounce_role_rejects_foreign() {
     let deployer = @0xA;
     let mut scenario = setup(deployer, 0);
     let mut ac = take_ac(&scenario);
-    ac.renounce_role<_, ForeignRole>(deployer, scenario.ctx());
+    ac.renounce_role<_, ForeignRole>(scenario.ctx());
     abort 999
 }
 

--- a/contracts/access/tests/access_control_tests.move
+++ b/contracts/access/tests/access_control_tests.move
@@ -72,11 +72,12 @@ fun test_new_with_otw_succeeds() {
         scenario.ctx(),
     );
 
-    // Sender becomes the root holder.
+    // Sender becomes the default admin.
     assert!(ac.has_role<_, ACCESS_CONTROL_TESTS>(deployer));
+    assert_eq!(ac.default_admin(), option::some(deployer));
     // Protected root TypeName matches the OTW type.
     assert_eq!(ac.protected_root(), with_original_ids<ACCESS_CONTROL_TESTS>());
-    // RoleGranted emitted for the root holder. Asserted in the same tx as
+    // RoleGranted emitted for the default admin. Asserted in the same tx as
     // construction because `events_by_type` is per-transaction.
     let granted = event::events_by_type<access_control::RoleGranted>();
     assert_eq!(granted.length(), 1);
@@ -106,6 +107,7 @@ fun test_new_with_admin_sets_explicit_root_holder() {
 
     assert!(!ac.has_role<_, ACCESS_CONTROL_TESTS>(deployer));
     assert!(ac.has_role<_, ACCESS_CONTROL_TESTS>(initial_admin));
+    assert_eq!(ac.default_admin(), option::some(initial_admin));
     assert_eq!(ac.protected_root(), with_original_ids<ACCESS_CONTROL_TESTS>());
 
     let granted = event::events_by_type<access_control::RoleGranted>();
@@ -240,9 +242,9 @@ fun test_grant_role_idempotent() {
     scenario.end();
 }
 
-// Non-root roles have no membership cap (unlike root, which is capped at one
-// holder by `accept_default_admin_transfer`'s revoke-then-grant logic). Pin
-// that two distinct accounts can simultaneously hold the same non-root role.
+// Non-root roles have no membership cap (unlike root, which is stored as a
+// single `Option<address>` holder). Pin that two distinct accounts can
+// simultaneously hold the same non-root role.
 #[test]
 fun test_grant_role_multiple_holders() {
     let deployer = @0xA;
@@ -458,7 +460,7 @@ fun test_renounce_role_idempotent_non_member() {
 // the second early-return path. Distinct from the "no role entry" path covered
 // by the test above.
 #[test]
-fun test_renounce_role_idempotent_role_in_bag_non_member() {
+fun test_renounce_role_idempotent_existing_role_non_member() {
     let deployer = @0xA;
     let alice = @0xB;
     let carol = @0xC;
@@ -813,6 +815,7 @@ fun test_begin_admin_transfer_happy_path() {
     assert!(ac.has_pending_default_admin_transfer());
     assert_eq!(ac.pending_default_admin_new_admin(), option::some(new_admin));
     assert_eq!(ac.pending_default_admin_execute_after_ms(), option::some(delay));
+    assert_eq!(ac.default_admin(), option::some(deployer));
 
     let scheduled = event::events_by_type<access_control::DefaultAdminTransferScheduled>();
     assert_eq!(scheduled.length(), 1);
@@ -902,6 +905,9 @@ fun test_accept_admin_transfer_happy_path() {
     // Atomic rotation: old admin lost root, new admin gained it.
     assert!(!ac.has_role<_, ACCESS_CONTROL_TESTS>(deployer));
     assert!(ac.has_role<_, ACCESS_CONTROL_TESTS>(new_admin));
+    assert_eq!(ac.default_admin(), option::some(new_admin));
+    let auth = ac.new_auth<_, ACCESS_CONTROL_TESTS>(scenario.ctx());
+    assert_eq!(access_control::auth_addr(&auth), new_admin);
     // Pending state cleared.
     assert!(!ac.has_pending_default_admin_transfer());
     assert!(ac.pending_default_admin_new_admin().is_none());
@@ -937,6 +943,54 @@ fun test_accept_admin_transfer_happy_path() {
     clock::destroy_for_testing(clk);
     test_scenario::return_shared(ac);
     scenario.end();
+}
+
+#[test]
+fun test_transferred_admin_can_manage_root_role_administered_roles() {
+    let deployer = @0xA;
+    let new_admin = @0xB;
+    let user = @0xC;
+    let mut scenario = setup(deployer, 0);
+    let mut ac = take_ac(&scenario);
+    let clk = clock::create_for_testing(scenario.ctx());
+
+    ac.begin_default_admin_transfer(new_admin, &clk, scenario.ctx());
+    test_scenario::return_shared(ac);
+
+    scenario.next_tx(new_admin);
+    let mut ac = take_ac(&scenario);
+    ac.accept_default_admin_transfer(&clk, scenario.ctx());
+    ac.grant_role<_, AdminA>(user, scenario.ctx());
+
+    assert!(ac.has_role<_, AdminA>(user));
+    assert_eq!(ac.get_role_admin<_, AdminA>(), with_original_ids<ACCESS_CONTROL_TESTS>());
+
+    clock::destroy_for_testing(clk);
+    test_scenario::return_shared(ac);
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = access_control::EUnauthorized)]
+fun test_old_admin_cannot_manage_root_role_administered_roles_after_transfer() {
+    let deployer = @0xA;
+    let new_admin = @0xB;
+    let user = @0xC;
+    let mut scenario = setup(deployer, 0);
+    let mut ac = take_ac(&scenario);
+    let clk = clock::create_for_testing(scenario.ctx());
+
+    ac.begin_default_admin_transfer(new_admin, &clk, scenario.ctx());
+    test_scenario::return_shared(ac);
+
+    scenario.next_tx(new_admin);
+    let mut ac = take_ac(&scenario);
+    ac.accept_default_admin_transfer(&clk, scenario.ctx());
+    test_scenario::return_shared(ac);
+
+    scenario.next_tx(deployer);
+    let mut ac = take_ac(&scenario);
+    ac.grant_role<_, AdminA>(user, scenario.ctx());
+    abort 999
 }
 
 #[test, expected_failure(abort_code = access_control::ENoPendingAdminTransfer)]
@@ -1025,6 +1079,7 @@ fun test_cancel_admin_transfer_happy_path() {
 
     assert!(!ac.has_pending_default_admin_transfer());
     assert!(ac.pending_default_admin_new_admin().is_none());
+    assert_eq!(ac.default_admin(), option::some(deployer));
     let cancelled = event::events_by_type<access_control::DefaultAdminTransferCancelled>();
     assert_eq!(cancelled.length(), 1);
     let expected = access_control::test_new_default_admin_transfer_cancelled();
@@ -1204,6 +1259,7 @@ fun test_begin_admin_renounce_happy_path() {
 
     assert!(ac.has_pending_default_admin_transfer());
     assert!(ac.is_pending_default_admin_renounce());
+    assert_eq!(ac.default_admin(), option::some(deployer));
     // Renounce has no incoming admin — `pending_default_admin_new_admin`
     // returns `none` for both "no pending" and "pending renounce". Use
     // `is_pending_default_admin_renounce` to disambiguate (above).
@@ -1218,6 +1274,20 @@ fun test_begin_admin_renounce_happy_path() {
     clock::destroy_for_testing(clk);
     test_scenario::return_shared(ac);
     scenario.end();
+}
+
+#[test, expected_failure(abort_code = access_control::EUnauthorized)]
+fun test_renounced_admin_cannot_manage_root_role_administered_roles() {
+    let deployer = @0xA;
+    let user = @0xB;
+    let mut scenario = setup(deployer, 0);
+    let mut ac = take_ac(&scenario);
+    let clk = clock::create_for_testing(scenario.ctx());
+
+    ac.begin_default_admin_renounce(&clk, scenario.ctx());
+    ac.accept_default_admin_renounce(&clk, scenario.ctx());
+    ac.grant_role<_, AdminA>(user, scenario.ctx());
+    abort 999
 }
 
 #[test, expected_failure(abort_code = access_control::EUnauthorized)]
@@ -1318,8 +1388,9 @@ fun test_accept_admin_renounce_happy_path() {
     let granted_before = event::events_by_type<access_control::RoleGranted>().length();
     ac.accept_default_admin_renounce(&clk, scenario.ctx());
 
-    // Caller (current root) is removed from the root role; pending cleared.
+    // Caller (current default admin) is removed from the root role; pending cleared.
     assert!(!ac.has_role<_, ACCESS_CONTROL_TESTS>(deployer));
+    assert!(ac.default_admin().is_none());
     assert!(!ac.has_pending_default_admin_transfer());
     assert!(!ac.is_pending_default_admin_renounce());
 

--- a/contracts/access/tests/access_control_tests.move
+++ b/contracts/access/tests/access_control_tests.move
@@ -352,7 +352,7 @@ fun test_revoke_role_idempotent_unknown_role() {
     let mut scenario = setup(deployer, 0);
     let mut ac = take_ac(&scenario);
 
-    // RoleY was never granted, so it has no bag entry. Revoking is a no-op.
+    // RoleY was never granted, so it has no role entry. Revoking is a no-op.
     ac.revoke_role<_, RoleY>(@0xB, scenario.ctx());
     assert_eq!(event::events_by_type<access_control::RoleRevoked>().length(), 0);
 
@@ -454,8 +454,8 @@ fun test_renounce_role_idempotent_non_member() {
     scenario.end();
 }
 
-// Renounce idempotency: role in bag, but the caller is not a member — the
-// second early-return path. Distinct from the "role not in bag" path covered
+// Renounce idempotency: role entry exists, but the caller is not a member —
+// the second early-return path. Distinct from the "no role entry" path covered
 // by the test above.
 #[test]
 fun test_renounce_role_idempotent_role_in_bag_non_member() {
@@ -465,11 +465,11 @@ fun test_renounce_role_idempotent_role_in_bag_non_member() {
     let mut scenario = setup(deployer, 0);
     let mut ac = take_ac(&scenario);
 
-    // Grant AdminA to alice — the role's bag entry now exists.
+    // Grant AdminA to alice — the role entry now exists.
     ac.grant_role<_, AdminA>(alice, scenario.ctx());
     test_scenario::return_shared(ac);
 
-    // Carol is not a member of AdminA — exercises the "role in bag, not
+    // Carol is not a member of AdminA — exercises the "role entry exists, not
     // member" early-return branch.
     scenario.next_tx(carol);
     let mut ac = take_ac(&scenario);
@@ -542,7 +542,7 @@ fun test_set_role_admin_lazy_create() {
     scenario.end();
 }
 
-// set_role_admin against a role that already has a bag entry — exercises
+// set_role_admin against a role that already has an entry — exercises
 // the "update existing admin_role" branch (the lazy-create branch is covered
 // by the test above) and asserts the event reports previous = old admin
 // rather than empty / fresh-default.
@@ -553,7 +553,7 @@ fun test_set_role_admin_updates_existing_role() {
     let mut scenario = setup(deployer, 0);
     let mut ac = take_ac(&scenario);
 
-    // First grant of RoleX creates the bag entry with admin = root.
+    // First grant of RoleX creates the role entry with admin = root.
     ac.grant_role<_, RoleX>(alice, scenario.ctx());
     assert_eq!(ac.get_role_admin<_, RoleX>(), with_original_ids<ACCESS_CONTROL_TESTS>());
 
@@ -669,7 +669,7 @@ fun test_has_role_unknown_role_returns_false() {
     let deployer = @0xA;
     let scenario = setup(deployer, 0);
     let ac = take_ac(&scenario);
-    // RoleX has no bag entry at all.
+    // RoleX has no role entry at all.
     assert!(!ac.has_role<_, RoleX>(deployer));
     test_scenario::return_shared(ac);
     scenario.end();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Updated `renounce_role` signature: the account parameter has been removed. Callers must now rely on the transaction context instead of specifying an explicit account.

* **New Features**
  * Enhanced `new_with_admin` constructor to properly initialize with the provided initial administrator address and emit corresponding events.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenZeppelin/contracts-sui/pull/337?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->