### PR TITLE
fix: `N-03` error `ELogResultUnrepresentable` for `UD30x9` log fns

### DIFF
--- a/math/fixed_point/sources/ud30x9/ud30x9_base.move
+++ b/math/fixed_point/sources/ud30x9/ud30x9_base.move
@@ -29,10 +29,14 @@ const ECannotBeConvertedToSD29x9: vector<u8> = "Value cannot be converted to SD2
 #[error(code = 4)]
 const EInvalidShiftSize: vector<u8> = "Shift size is out of range (must be less than 128)";
 
-/// Logarithm is undefined: input must be greater than or equal to one
+/// Logarithm is undefined: input must be non-zero
 #[error(code = 5)]
-const ELogUndefined: vector<u8> =
-    "Logarithm is undefined: input must be greater than or equal to one";
+const ELogUndefined: vector<u8> = "Logarithm is undefined: input must be non-zero";
+
+/// Logarithm result would be negative and is unrepresentable in `UD30x9`
+#[error(code = 6)]
+const ELogResultUnrepresentable: vector<u8> =
+    "Logarithm result would be negative and is unrepresentable in UD30x9";
 
 // === Public Functions ===
 
@@ -260,10 +264,13 @@ public fun unchecked_lshift(x: UD30x9, bits: u8): UD30x9 {
 /// - `ln(x)`, rounded down to the nearest representable `UD30x9` value.
 ///
 /// #### Aborts
-/// - `ELogUndefined` if `x` is less than one.
+/// - `ELogUndefined` if `x` is zero.
+/// - `ELogResultUnrepresentable` if `x` is in `(0, 1)` (the result would be negative
+///   and cannot be represented in `UD30x9` — use `SD29x9` instead).
 public fun ln(x: UD30x9): UD30x9 {
     let raw = x.unwrap();
-    assert!(raw >= common::scale!(), ELogUndefined);
+    assert!(raw > 0, ELogUndefined);
+    assert!(raw >= common::scale!(), ELogResultUnrepresentable);
     // The `raw >= scale` precondition guarantees `raw_log2` returns a
     // non-negative sign, so the discarded sign flag is provably `false`.
     let (_, mag) = common::raw_log2(raw);
@@ -284,10 +291,13 @@ public fun ln(x: UD30x9): UD30x9 {
 /// - `log10(x)`, rounded down to the nearest representable `UD30x9` value.
 ///
 /// #### Aborts
-/// - `ELogUndefined` if `x` is less than one.
+/// - `ELogUndefined` if `x` is zero.
+/// - `ELogResultUnrepresentable` if `x` is in `(0, 1)` (the result would be negative
+///   and cannot be represented in `UD30x9` — use `SD29x9` instead).
 public fun log10(x: UD30x9): UD30x9 {
     let raw = x.unwrap();
-    assert!(raw >= common::scale!(), ELogUndefined);
+    assert!(raw > 0, ELogUndefined);
+    assert!(raw >= common::scale!(), ELogResultUnrepresentable);
     // The `raw >= scale` precondition guarantees `raw_log2` returns a
     // non-negative sign, so the discarded sign flag is provably `false`.
     let (_, mag) = common::raw_log2(raw);
@@ -306,10 +316,13 @@ public fun log10(x: UD30x9): UD30x9 {
 /// - `log2(x)`, rounded down to the nearest representable `UD30x9` value.
 ///
 /// #### Aborts
-/// - `ELogUndefined` if `x` is less than one (result would be negative or undefined).
+/// - `ELogUndefined` if `x` is zero.
+/// - `ELogResultUnrepresentable` if `x` is in `(0, 1)` (the result would be negative
+///   and cannot be represented in `UD30x9` — use `SD29x9` instead).
 public fun log2(x: UD30x9): UD30x9 {
     let raw = x.unwrap();
-    assert!(raw >= common::scale!(), ELogUndefined);
+    assert!(raw > 0, ELogUndefined);
+    assert!(raw >= common::scale!(), ELogResultUnrepresentable);
     // The `raw >= scale` precondition guarantees `raw_log2` returns a
     // non-negative sign, so the discarded sign flag is provably `false`.
     let (_, mag) = common::raw_log2(raw);

--- a/math/fixed_point/tests/ud30x9_tests/ln_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/ln_tests.move
@@ -50,7 +50,7 @@ fun ln_of_zero_aborts() {
     ud30x9::zero().ln();
 }
 
-#[test, expected_failure(abort_code = ud30x9_base::ELogUndefined)]
+#[test, expected_failure(abort_code = ud30x9_base::ELogResultUnrepresentable)]
 fun ln_of_sub_one_aborts() {
     fixed(SCALE - 1).ln();
 }

--- a/math/fixed_point/tests/ud30x9_tests/log10_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/log10_tests.move
@@ -47,7 +47,7 @@ fun log10_of_zero_aborts() {
     ud30x9::zero().log10();
 }
 
-#[test, expected_failure(abort_code = ud30x9_base::ELogUndefined)]
+#[test, expected_failure(abort_code = ud30x9_base::ELogResultUnrepresentable)]
 fun log10_of_sub_one_aborts() {
     fixed(SCALE - 1).log10();
 }

--- a/math/fixed_point/tests/ud30x9_tests/log2_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/log2_tests.move
@@ -45,7 +45,7 @@ fun log2_of_zero_aborts() {
     ud30x9::zero().log2();
 }
 
-#[test, expected_failure(abort_code = ud30x9_base::ELogUndefined)]
+#[test, expected_failure(abort_code = ud30x9_base::ELogResultUnrepresentable)]
 fun log2_of_sub_one_aborts() {
     fixed(SCALE - 1).log2();
 }


### PR DESCRIPTION
Fixes [N-03](https://audits.openzeppelin.com/sui-contracts/sui-01-07-fixed-point-math-diff-audit/issue/ud30x9-logarithm-error-name-conflates-undefined-input-with-unrepresentable-result-08f8ab6e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced logarithm function error reporting to distinguish between invalid zero input and unrepresentable result conditions.
  * Added a new error code for improved error identification when logarithm calculations cannot be properly represented.

* **Tests**
  * Updated test expectations to align with new error handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->