### PR TITLE
chore: Add Pub.local.toml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ sui.keystore
 .trace
 .coverage_map.mvcov
 
+# Local node publish artifact
+Pub.local.toml
+
 # OS generated files
 .DS_Store
 ._*


### PR DESCRIPTION
This artifact is created for local deployment during development, and we needed to remember to manually remove it before committing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to exclude local publish artifacts from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->