### PR TITLE
docs: repo coding-conventions standard + code-quality command

### DIFF
--- a/.claude/commands/code-quality.md
+++ b/.claude/commands/code-quality.md
@@ -1,0 +1,198 @@
+---
+name: code-quality
+description: >
+  Review and (optionally) fix Move source files against this repository's
+  STYLEGUIDE.md. Use this command whenever the user wants to audit, review, or
+  improve code quality of a Sui Move module, or mentions "/code-quality".
+  Triggers on phrases like "check code quality", "review move style", "apply the
+  style guide", "fix move conventions".
+user_invocable: true
+---
+
+# OpenZeppelin Contracts for Sui — Code Quality Checklist
+
+Reviews `.move` files in this repository for convention violations and either
+reports them or fixes them in place — the user picks.
+
+This is a local maintainer tool. It is not wired into CI.
+
+**The rules are not in this file.** They live in
+[`STYLEGUIDE.md`](../../STYLEGUIDE.md) at the repository root — the single source
+of truth for our conventions (design rationale in
+[`ARCHITECTURE.md`](../../ARCHITECTURE.md)). This command is procedure only: it
+reads `STYLEGUIDE.md` and checks code against it, so the rules can never drift
+from the file every human and agent already follows.
+
+## Usage
+
+- `/code-quality` — review the file(s) changed on the current branch
+  (`git diff main...HEAD --name-only`, plus any uncommitted edits).
+- `/code-quality <path>` — review a specific file or directory.
+- `/code-quality <package-name>` — review a package by name (e.g.
+  `openzeppelin_access`).
+
+## Workflow
+
+### 1. Check working tree
+
+```bash
+git rev-parse --abbrev-ref HEAD
+git status --short
+```
+
+If the working tree is dirty, warn the user and ask whether to:
+
+- Continue (the quality-fix commit will mix with their unrelated changes).
+- Stash first, run the command, then unstash.
+- Abort.
+
+Do not silently mix unrelated changes. If the current branch is `main`, do not
+commit there — require a new branch.
+
+### 2. Discover the file set
+
+If a path or package name was provided, expand it:
+
+- **Path** → glob `**/*.move` under it, excluding `build/`.
+- **Package name** → find the `Move.toml` whose `[package] name` matches, then
+  glob `**/*.move` under its `sources/`, `tests/`, and `examples/`.
+
+If no argument was given, derive the file set from git:
+
+```bash
+git merge-base main HEAD                                          # base
+git diff $(git merge-base main HEAD) HEAD --name-only             # committed
+git diff --name-only ; git ls-files --others --exclude-standard   # uncommitted
+```
+
+Filter to `*.move` under `contracts/` and `math/`, excluding `build/`,
+`vendor/`, and `.claude/`. If empty, report "no Move files in scope" and stop.
+
+**Edition check.** For each package in scope, parse `edition` from the
+`[package]` table of its `Move.toml`. These conventions target **Move 2024**. If
+a package is `edition = "legacy"` (or the field is missing/unknown), stop and
+tell the user — running 2024 rules on a legacy package produces misleading
+findings. Do not proceed on that package unless the user explicitly overrides.
+
+Read every file in scope before checking rules — partial reads produce partial
+reviews. **Also read [`STYLEGUIDE.md`](../../STYLEGUIDE.md) now** (and
+[`ARCHITECTURE.md`](../../ARCHITECTURE.md) for design constraints it references).
+
+### 3. Identify violations
+
+Walk the file set against the rules in [`STYLEGUIDE.md`](../../STYLEGUIDE.md) —
+the codified conventions are explicit, named, and stable there. Check every file
+against every rule the style guide defines. Do not invent rules that are not in
+`STYLEGUIDE.md`; if the code does something the style guide does not cover, that
+is not a violation.
+
+Build a numbered list of findings. Each entry has:
+
+- **file path** (repo-relative)
+- **line number** (or line range)
+- **rule** — the `STYLEGUIDE.md` section it violates (e.g. `Naming`,
+  `Section ordering`, `Idiomatic Move 2024`)
+- **finding** — what differs and why it matters
+- **fix** — one or two sentences describing what should change
+
+**Borderline findings** — a rule may apply literally but be overridden by design
+intent (e.g. `transfer::transfer` inside a function whose semantic *is*
+transferring). Do not put these in the numbered list; print them in a separate
+"Borderline (review and decide)" section so the user is not forced to reject
+them repeatedly.
+
+### 4. Choose an action
+
+Tell the user how many findings were collected and ask which mode to run in:
+
+1. **Apply all** — apply every fix in one pass without further prompts. Stop only
+   on a tool error or a finding the command cannot fix on its own.
+2. **One-by-one** — walk the findings in order. For each, describe it (file,
+   line, what's wrong, what the edit would do), then ask the user to approve
+   before editing. Skipped findings are recorded in the final report.
+3. **Report only** — print the full list and stop. Do not edit anything. Skip to
+   step 7.
+
+The user may also cancel entirely; in that case stop without further action.
+
+If the list is empty, say so plainly and stop:
+
+> ✅ No violations found in <N> file(s).
+
+### 5. Apply fixes
+
+Use the `Edit` tool. After editing, format with prettier so the `.move` files
+match the repo's layout. **Preflight first** (prettier silently skips `.move`
+files when the Move plugin is absent):
+
+- Ensure `<repo_root>/.prettierrc` lists `@mysten/prettier-plugin-move` in
+  `plugins`. If missing, offer to add it (preserve other settings) or skip
+  prettier for this run — do not overwrite a custom config.
+- Ensure the plugin is resolvable (`node_modules/@mysten/prettier-plugin-move`
+  or `package.json` devDependencies); offer to install it with the repo's
+  package manager, else skip.
+
+Then, from the repo root (so the root `.prettierrc` is auto-discovered):
+
+```bash
+npx prettier --write <files>
+```
+
+Do not pass `--config` explicitly. If the user opted out of prettier, note it in
+the step 7 report.
+
+### 6. Build, test, lint
+
+Pick `--build-env` by parsing the package's `Move.toml`: prefer a name from
+`[environments]` (favouring `testnet` → `mainnet`), fall back to `testnet` when
+none is declared. Always pass `--build-env` explicitly — the Sui CLI has no true
+default for env-agnostic packages. Run **both** commands (even if the first
+fails) so the user sees every issue in one pass:
+
+```bash
+# Test-mode compile + lint + run tests
+sui move test  --path <package> --build-env <env> --lint --warnings-are-errors
+
+# Production-mode build + lint (catches dead code only test code references)
+sui move build --path <package> --build-env <env> --lint --warnings-are-errors
+```
+
+**Pre-existing-warning caveat:** `--warnings-are-errors` also fails on warnings
+unrelated to this run. If the output is dominated by pre-existing warnings, ask
+the user whether to fix them too or drop the flag for this run only — do not
+silently swallow the failure.
+
+Coverage gate is defined in [`CONTRIBUTING.md`](../../CONTRIBUTING.md); if a fix
+removes test coverage, restore it before finishing
+(`sui move test --coverage --path <package>`).
+
+### 7. Report
+
+Summarise what changed, grouped by file. If nothing was edited (report-only or
+no violations), say so and stop.
+
+## Rules
+
+This command carries **no rule set of its own**. The conventions live in
+[`STYLEGUIDE.md`](../../STYLEGUIDE.md) (with design rationale in
+[`ARCHITECTURE.md`](../../ARCHITECTURE.md)) — read it at the start of step 2 and
+check every `.move` file against it in step 3. Keeping the rules in the repo (not
+in this command) is deliberate: the same file serves humans and every other agent
+(Codex / Cursor / Copilot / Gemini), and the rules can never drift from the code
+they govern.
+
+The rule categories for step 3 grouping and the step 7 summary are the `##`
+section headings of `STYLEGUIDE.md` (Naming, Module & Package, Section ordering,
+Imports, Structs, Functions, Idiomatic Move 2024, Collections & object size,
+Testing, Lint suppression, Documentation). Use whatever headings `STYLEGUIDE.md`
+actually defines — do not assume a fixed list.
+
+## Important notes
+
+- Commit & PR conventions (Conventional Commits, no `Co-Authored-By` trailer, no
+  "Test plan" section) live in
+  [`CONTRIBUTING.md`](../../CONTRIBUTING.md#commit-and-pr-conventions). A sensible
+  default commit message is `refactor: apply STYLEGUIDE.md (<package>)`.
+- When unsure whether something is "wrong" or just "uncovered", check
+  `STYLEGUIDE.md` — if the rule is not there, it is not a violation. Propose
+  adding the rule to `STYLEGUIDE.md` rather than enforcing an unwritten one.

--- a/.claude/commands/code-quality.md
+++ b/.claude/commands/code-quality.md
@@ -53,7 +53,7 @@ commit there — require a new branch.
 
 If a path or package name was provided, expand it:
 
-- **Path** → glob `**/*.move` under it, excluding `build/`.
+- **Path** → glob `**/*.move` under it, excluding `build/` and `artifacts/`.
 - **Package name** → find the `Move.toml` whose `[package] name` matches, then
   glob `**/*.move` under its `sources/`, `tests/`, and `examples/`.
 
@@ -66,7 +66,11 @@ git diff --name-only ; git ls-files --others --exclude-standard   # uncommitted
 ```
 
 Filter to `*.move` under `contracts/` and `math/`, excluding `build/`,
-`vendor/`, and `.claude/`. If empty, report "no Move files in scope" and stop.
+`vendor/`, `.claude/`, `audits/`, `artifacts/`, and any committed/generated
+`.move` outputs (the `codegen/`-produced tables). These are do-not-touch per
+[`AGENTS.md`](../../AGENTS.md) / [`ARCHITECTURE.md`](../../ARCHITECTURE.md) — the
+command must never "fix" reproducible output. If empty, report "no Move files in
+scope" and stop.
 
 **Edition check.** For each package in scope, parse `edition` from the
 `[package]` table of its `Move.toml`. These conventions target **Move 2024**. If

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# CodeRabbit reads this repo's conventions from STYLEGUIDE.md / ARCHITECTURE.md —
+# the single source of truth. This config only points CodeRabbit at them.
+reviews:
+  path_instructions:
+    - path: "**/*.move"
+      instructions: |
+        Review Move code against the conventions in STYLEGUIDE.md and the design
+        rationale in ARCHITECTURE.md at the repository root — treat them as the
+        single source of truth. Flag deviations from them; do not enforce rules
+        that are not written there. AGENTS.md is the gateway that links both.
+    - path: "**/*.md"
+      instructions: |
+        For STYLEGUIDE.md / ARCHITECTURE.md / AGENTS.md / CONTRIBUTING.md, watch
+        for duplication across files: each fact should have one home and the rest
+        should link to it.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,14 @@
+# GitHub Copilot instructions
+
+This repository keeps its coding conventions as data, in one place. This file
+only points to them — it restates no rules.
+
+- [`STYLEGUIDE.md`](../STYLEGUIDE.md) — single source of truth for conventions
+  (how we write Move: naming, ordering, idioms, testing, documentation).
+- [`ARCHITECTURE.md`](../ARCHITECTURE.md) — design rationale (why), incl. upgrade
+  safety.
+- [`AGENTS.md`](../AGENTS.md) — the gateway for AI agents; start here.
+
+When generating or reviewing Move, follow `STYLEGUIDE.md` exactly. Do not invent
+conventions from generic internet patterns; if a rule is not in `STYLEGUIDE.md`,
+it is not a convention of this repo.

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,10 @@ temp/
 # Everyone uses their own local dev environment config, so we should not force specific VS Code configs
 .vscode/
 
-# Claude Code
-.claude/
+# Claude Code: ignore local config, but track shared commands and skills.
+.claude/*
+!.claude/commands/
+!.claude/skills/
+
+# Git submodules
 .gitmodules

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ single sources of truth and lists the boundaries you need.
   exactly; do not invent conventions from generic internet patterns.
 - [`ARCHITECTURE.md`](./ARCHITECTURE.md) — **why** the library is shaped this
   way: package split, capability-based access control, owned vs. shared objects,
-  PTB composability, bounded state, codegen.
+  PTB composability, bounded state, upgrade safety.
 - [`CONTRIBUTING.md`](./CONTRIBUTING.md) — PR workflow, build/test/lint commands,
   commit & PR conventions, coverage gate, and the dependency/package-split policy.
 
@@ -44,10 +44,9 @@ read the group and package READMEs (the single source of truth):
 ## Boundaries — do not touch
 
 - `**/build/` — compiler output (generated)
-- `**/artifacts/` — generated reference data; regenerate via `codegen/`, never
-  hand-edit
-- generated `.move` lookup tables — change the `codegen/` source instead
-- `audits/` — historical audit reports
+- `**/artifacts/` — generated reference data; never hand-edit
+- `audits/` — published audit reports; adding a new report is fine, but don't
+  modify or delete existing ones
 
 For commit & PR conventions and the dependency/package-split policy, see
 [`CONTRIBUTING.md`](./CONTRIBUTING.md#commit-and-pr-conventions).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# Agent Guide
+
+Lean entry point for AI agents (Codex, Cursor, Copilot, Gemini, Claude Code) and
+new contributors. This file does **not** restate the rules — it points to the
+single sources of truth and lists the boundaries you need.
+
+## Sources of truth — read these first
+
+- [`STYLEGUIDE.md`](./STYLEGUIDE.md) — **how** we write Move: naming, section
+  ordering, imports, idiomatic Move 2024, testing, documentation. Follow it
+  exactly; do not invent conventions from generic internet patterns.
+- [`ARCHITECTURE.md`](./ARCHITECTURE.md) — **why** the library is shaped this
+  way: package split, capability-based access control, owned vs. shared objects,
+  PTB composability, bounded state, codegen.
+- [`CONTRIBUTING.md`](./CONTRIBUTING.md) — PR workflow, build/test/lint commands,
+  commit & PR conventions, coverage gate, and the dependency/package-split policy.
+
+## Build & test
+
+Commands operate **one package at a time** (`--path <package>`, e.g.
+`contracts/access`, `math/core`) — there is no workspace-wide build. The full
+command list (build, test, coverage, lint, doc) is in
+[`CONTRIBUTING.md`](./CONTRIBUTING.md#a-typical-workflow); the required Sui CLI
+version is pinned in [`README.md`](./README.md).
+
+Review changes against the style guide before committing:
+
+- **Claude Code**: run the `/code-quality` command.
+- **Other agents** (Codex / Cursor / Copilot / Gemini): the slash command is
+  Claude-specific, but the procedure is plain markdown — read and follow
+  [`.claude/commands/code-quality.md`](./.claude/commands/code-quality.md).
+
+Either way the rules come from `STYLEGUIDE.md`; the procedure restates none of them.
+
+## Packages
+
+Each `Move.toml` directory under `contracts/` and `math/` is a separate package.
+For the catalog — what each package/module does, install snippets, docs links —
+read the group and package READMEs (the single source of truth):
+
+- [`contracts/README.md`](./contracts/README.md) + each package's `README.md`
+- [`math/README.md`](./math/README.md) + each package's `README.md`
+
+## Boundaries — do not touch
+
+- `**/build/` — compiler output (generated)
+- `**/artifacts/` — generated reference data; regenerate via `codegen/`, never
+  hand-edit
+- generated `.move` lookup tables — change the `codegen/` source instead
+- `audits/` — historical audit reports
+
+For commit & PR conventions and the dependency/package-split policy, see
+[`CONTRIBUTING.md`](./CONTRIBUTING.md#commit-and-pr-conventions).

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -45,8 +45,6 @@ republish of the others — the package boundary is an audit boundary.
 
 - `sources/` — public modules; `sources/internal/` for package-private helpers
 - `tests/` — unit tests (mirrors the `sources/` grouping)
-- `codegen/` — generator for large constant tables, where applicable (math)
-- `artifacts/` — generated reference data, where applicable (math)
 
 ## Core design principles
 
@@ -67,13 +65,19 @@ that grow unboundedly. See `openzeppelin_access` for the canonical pattern.
 
 ### Composability first (PTB-friendly)
 
-- Functions **return objects** instead of self-transferring them. Returning lets
-  the caller chain the result into the next PTB command; an internal
+These are defaults that keep components reusable in PTBs — not absolutes. Some
+functions legitimately transfer (when transferring *is* the operation's
+semantic); treat those as documented exceptions, not reasons to drop the
+guideline.
+
+- Prefer functions that **return objects** over self-transferring them. Returning
+  lets the caller chain the result into the next PTB command; an internal
   `transfer::transfer` ends the value's life and breaks composition.
-- Mint/create functions return the created object, never transfer it internally.
+- Mint/create functions should return the created object rather than transferring
+  it internally.
 - Return excess coins (even zero-value) rather than transferring them internally.
-- Keep core logic **pure**: no `transfer::*` inside the business logic — push
-  transfers to the edges (entry functions / the integrator).
+- Keep core logic mostly free of `transfer::*` — push transfers to the edges
+  (entry functions / the integrator) where practical.
 
 ### Bounded state
 
@@ -110,20 +114,6 @@ be retracted. Design for forward compatibility from day one.
   can reject calls made against a stale version of the object.
 - **Keep extension-package interfaces unchanging** so a change never breaks the
   packages that depend on or extend them.
-
-## Generated code & artifacts (math packages)
-
-The math packages keep two non-Move directories alongside `sources/`:
-
-- `codegen/` — Python that generates Move lookup tables / large constant blocks
-  (e.g. the CDF table in `fixed_point`). The generator is the source of truth;
-  the generated `.move` is committed for reproducible builds.
-- `artifacts/` — generated reference data used to validate the Move
-  implementation against an independent computation.
-
-**Why generate?** Hand-writing large numeric tables is error-prone and
-unreviewable. Generating them from a readable Python spec makes the math
-auditable and lets reviewers regenerate and diff.
 
 ## Testing architecture
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,149 @@
+# Architecture
+
+The design decisions behind OpenZeppelin Contracts for Sui and the reasoning
+that holds them together. This document answers **why** the library is shaped
+the way it is. For **how** to write code that fits — naming, ordering, idioms —
+see [`STYLEGUIDE.md`](./STYLEGUIDE.md).
+
+This file is read by humans and by AI agents (every Dev3 stage, Codex, Cursor,
+Copilot, Gemini) to ground design choices in the project's conventions rather
+than generic internet patterns.
+
+## Overview
+
+OpenZeppelin Contracts for Sui is a collection of secure, reusable Move
+**libraries** — not a dApp. Components are designed to be composed into
+downstream applications via Programmable Transaction Blocks (PTBs), audited
+independently, and adopted piecemeal. Every design choice favours integrator
+safety and composability over end-to-end convenience.
+
+The library targets the Sui CLI version pinned in [`README.md`](./README.md) and
+every package is on **Move 2024** (`edition = "2024"`).
+
+## Repository layout
+
+Packages are grouped by domain (`contracts/`, `math/`). Each leaf directory with
+a `Move.toml` is an independently buildable, independently publishable package.
+
+**The package catalog is owned by the READMEs, not this file.** What each
+package and module does, install snippets, and docs links live in the group
+READMEs and each package's own README — the single source of truth for that
+information:
+
+- [`contracts/README.md`](./contracts/README.md) → per-package READMEs (e.g.
+  [`contracts/access/README.md`](./contracts/access/README.md))
+- [`math/README.md`](./math/README.md) → per-package READMEs
+
+This document covers only the *principles* behind the layout, never the catalog.
+
+**Why split into many small packages?** Each package has its own dependency set,
+its own audit surface, and its own published address. Integrators depend only on
+the components they use, and a vulnerability in one package never forces a
+republish of the others — the package boundary is an audit boundary.
+
+**Conventional package layout.** Every package follows the same internal shape:
+
+- `sources/` — public modules; `sources/internal/` for package-private helpers
+- `tests/` — unit tests (mirrors the `sources/` grouping)
+- `codegen/` — generator for large constant tables, where applicable (math)
+- `artifacts/` — generated reference data, where applicable (math)
+
+## Core design principles
+
+### Capability-based access control
+
+Authorization is carried by **capability objects** (`*Cap`), not by address
+allow-lists stored in shared state. Holding the object *is* the permission. This
+keeps authorization checks local, composable, and free of global mutable lists
+that grow unboundedly. See `openzeppelin_access` for the canonical pattern.
+
+### Owned vs. shared objects
+
+- **Owned objects** for 1-to-1 relationships — cheaper, no consensus ordering.
+- **Shared objects** for multi-user / concurrent access.
+- **Shared-object creation is two functions**: one creates and returns the
+  object, one shares it — so callers can run setup logic before the object
+  becomes shared.
+
+### Composability first (PTB-friendly)
+
+- Functions **return objects** instead of self-transferring them. Returning lets
+  the caller chain the result into the next PTB command; an internal
+  `transfer::transfer` ends the value's life and breaks composition.
+- Mint/create functions return the created object, never transfer it internally.
+- Return excess coins (even zero-value) rather than transferring them internally.
+- Keep core logic **pure**: no `transfer::*` inside the business logic — push
+  transfers to the edges (entry functions / the integrator).
+
+### Bounded state
+
+Sui objects are capped at 250 KB and abort the transaction if exceeded. The
+library therefore:
+
+- uses `vector` / `VecSet` / `VecMap` only for bounded collections (≤ 1000 items),
+- uses `Table` / `Bag` / `ObjectBag` / `ObjectTable` / `LinkedTable` for large or
+  unbounded collections,
+- never embeds an ever-growing vector inside a long-lived object.
+
+## Storage & object model
+
+Prefer explicit, typed storage keys (positional `*Key` structs) for dynamic
+fields over ad-hoc primitive keys — they document intent and prevent key
+collisions across features in the same object.
+
+## Upgrade safety
+
+This is a library: downstream packages depend on published bytecode that cannot
+be retracted. Design for forward compatibility from day one.
+
+- **`public` function signatures are permanent.** Once published, a `public`
+  signature can never change. Expose only the stable external API as `public`;
+  keep anything you may want to evolve `public(package)` or private (the rule
+  lives in [`STYLEGUIDE.md`](./STYLEGUIDE.md#functions)).
+- **Struct types are immutable across upgrades** — they cannot be deleted,
+  redefined, or have their abilities changed once published. Introduce a struct
+  only when its shape is settled.
+- **Error codes are append-only.** Never renumber an existing
+  `#[error(code = N)]` — integrators match on the numeric abort code (the rule
+  lives in [`STYLEGUIDE.md`](./STYLEGUIDE.md#naming)).
+- **Version long-lived shared state** so a module published in a later upgrade
+  can reject calls made against a stale version of the object.
+- **Keep extension-package interfaces unchanging** so a change never breaks the
+  packages that depend on or extend them.
+
+## Generated code & artifacts (math packages)
+
+The math packages keep two non-Move directories alongside `sources/`:
+
+- `codegen/` — Python that generates Move lookup tables / large constant blocks
+  (e.g. the CDF table in `fixed_point`). The generator is the source of truth;
+  the generated `.move` is committed for reproducible builds.
+- `artifacts/` — generated reference data used to validate the Move
+  implementation against an independent computation.
+
+**Why generate?** Hand-writing large numeric tables is error-prone and
+unreviewable. Generating them from a readable Python spec makes the math
+auditable and lets reviewers regenerate and diff.
+
+## Testing architecture
+
+- Unit tests live in `tests/`; in-module test code is limited to `#[test_only]`
+  helpers and `#[test]` functions that reach private items (see
+  [`STYLEGUIDE.md`](./STYLEGUIDE.md#testing)).
+- Property-style tests use Sui's `#[random_test]` attribute (see the
+  `sd29x9` / `ud30x9` test suites for the established pattern).
+- New code must meet the coverage gate in
+  [`CONTRIBUTING.md`](./CONTRIBUTING.md#code-quality-standards).
+
+## AI usage guidelines
+
+When extending this library with AI assistance:
+
+- **Match existing patterns** in the touched package before introducing new ones;
+  consistency across the library outranks local cleverness.
+- **Treat this file and [`STYLEGUIDE.md`](./STYLEGUIDE.md) as authoritative** over
+  generic Move/Sui patterns learned from the wider internet.
+- The package split is an audit boundary, not just an organisational one — which
+  is why changing it (or adding dependencies) requires sign-off; see the policy
+  in [`CONTRIBUTING.md`](./CONTRIBUTING.md#commit-and-pr-conventions).
+- Prefer the boring, explicit solution; this is security-critical library code.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,38 +18,31 @@ As a contributor, you are expected to fork this repository, work on your own for
 
 ## Code Quality Standards
 
-Your contribution must meet these requirements:
+Coding style and conventions for this repository live in
+[`STYLEGUIDE.md`](./STYLEGUIDE.md) (the single source of truth — naming, section
+ordering, idioms, testing, documentation), with the design rationale in
+[`ARCHITECTURE.md`](./ARCHITECTURE.md). Read those before opening a PR; the items
+below are the hard gates your contribution must clear:
 
 - **Test Coverage**: Minimum 90% coverage required
 - **Linting**: All code must pass strict linting (`sui move build --lint --warnings-are-errors`)
-- **Move Conventions**: Follow [Sui Move conventions](https://docs.sui.io/concepts/sui-move-concepts/conventions)
-- **Documentation**: Add inline documentation for public functions and modules
+- **Conventions**: Follow [`STYLEGUIDE.md`](./STYLEGUIDE.md), which builds on the
+  [Sui Move conventions](https://docs.sui.io/concepts/sui-move-concepts/conventions)
+- **Documentation**: Add inline documentation for public functions and modules,
+  formatted per [`STYLEGUIDE.md`](./STYLEGUIDE.md#documentation)
 
-## Documentation Style
+## Commit and PR conventions
 
-Use consistent documentation formatting across modules:
+The single source of truth for how changes land — humans and agents follow the
+same rules:
 
-- Use section headings as `#### Parameters`, `#### Returns`, and `#### Aborts` when relevant.
-- Use `-` for list items in doc comments (not `*`).
-- Prefer documenting public functions with at least `Parameters` and `Returns`.
-- Include an `Aborts` section whenever a function can abort.
-- Keep terminology consistent with implementation (for example, avoid documenting impossible paths).
-
-Example:
-
-```move
-/// Compute something.
-///
-/// #### Parameters
-/// - `value`: Input value.
-/// - `rounding_mode`: Rounding strategy.
-///
-/// #### Returns
-/// - Rounded output value.
-///
-/// #### Aborts
-/// - Aborts if `value` is zero.
-```
+- Use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for
+  commit messages.
+- Never add a `Co-Authored-By` trailer to commits.
+- Do not include a "Test plan" section in PR descriptions.
+- Do not add dependencies or change the package split without explicit sign-off
+  — the package boundary is an audit boundary (see
+  [`ARCHITECTURE.md`](./ARCHITECTURE.md)).
 
 ## A typical workflow
 

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -64,7 +64,7 @@ Every file must use `// === <Name> ===` delimiters in this order:
 Within any section, feature-oriented sub-grouping comments are allowed and must
 be preserved:
 
-```
+```move
 // === Constructors ===
 // === Hot Path ===
 // === Scheduling / delay management ===

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -1,0 +1,256 @@
+# Style Guide
+
+The single source of truth for coding style and conventions in this repository.
+It serves humans and AI agents alike: contributors follow it by hand, and every
+Dev3 stage and code-review tool reads it instead of restating the rules.
+
+> Scope: **how** we write Move in this repo — naming, ordering, idioms, testing,
+> documentation. For **why** the library is shaped the way it is (design
+> decisions, package layout, object model), see [`ARCHITECTURE.md`](./ARCHITECTURE.md).
+
+These conventions target **Move 2024** (module label syntax, receiver syntax,
+`#[error(code = N)]`, macros). Every package in this repo declares
+`edition = "2024"`.
+
+## Naming
+
+- **Error constants**: `EPascalCase`, declared with `#[error(code = N)]`, type
+  `vector<u8>`, plain `"..."` string literal (NOT `b"..."`). Codes are sequential
+  from 0 and **append-only** — never renumber existing errors when adding new
+  ones. Callers (frontends, integrators, tests in other packages) may match on
+  the numeric abort code; renumbering silently breaks them. New errors go at the
+  bottom with `code = N+1`.
+- **Regular constants**: `UPPER_SNAKE_CASE`
+- **Capability structs**: suffix with `Cap` (e.g. `AdminCap`)
+- **Event structs**: past tense (e.g. `RoleGranted`, `TraderAccountCreated`)
+- **Getters**: field name without `get_` prefix; `_mut` suffix for the mutable variant
+- **CRUD**: `new`/`create`, `empty`, `borrow`/`borrow_mut`, `add`/`remove`,
+  `exists`/`contains`, `drop`/`destroy`/`destroy_empty`, `to_name`/`from_name`
+- **Dynamic field keys**: positional struct with `Key` suffix
+- **Generic type parameters**: `T`, `U` — use descriptive names only when they
+  materially aid readability
+- No "Potato" in hot-potato struct names
+
+## Module & Package
+
+- `module my_package::my_module;` — no braces, 2024 edition label syntax
+- One module per object/data structure
+- PascalCase package names, snake_case named addresses; prefix named addresses
+  with the project name (`openzeppelin_*`)
+- Since Sui 1.45, Sui / MoveStdlib / Bridge / SuiSystem are implicitly imported —
+  no manual dep declaration needed
+
+## Section ordering
+
+Every file must use `// === <Name> ===` delimiters in this order:
+
+1. Imports (auto-grouped by prettier)
+2. `// === Errors ===`
+3. `// === Constants ===`
+4. `// === Structs ===`
+5. `// === Events ===` — placed **after** Structs when both are present in the
+   same module; in a dedicated events module, this is the only struct-family
+   section and Structs is omitted
+6. `// === Method Exports ===` (if any) — `public use fun ...` receiver-syntax
+   aliases exposed by this module
+7. `// === Init ===` (if an `init` function is present — place it first)
+8. `// === Public Functions ===`
+9. `// === View helpers ===`
+10. `// === Admin Functions ===` (if any)
+11. `// === Package Functions ===` (if any)
+12. `// === Private Functions ===`
+13. `// === Test-Only Helpers ===`
+
+Within any section, feature-oriented sub-grouping comments are allowed and must
+be preserved:
+
+```
+// === Constructors ===
+// === Hot Path ===
+// === Scheduling / delay management ===
+```
+
+These are intentional organisation aids — do **not** remove them.
+
+Common ordering violations to watch for:
+
+- Constants section appearing before Errors
+- View helpers appearing after Private Functions
+- Witness structs placed in `// === Init ===` instead of `// === Structs ===`
+- `// === Test only helpers ===` (wrong capitalisation — must be
+  `// === Test-Only Helpers ===`)
+
+## Imports
+
+- Don't write `use pkg::mod::{Self};` on its own line when other members of
+  `pkg::mod` are imported elsewhere — merge into a single grouped import:
+  `use pkg::mod::{Self, OtherMember};`. A lone `use pkg::mod;` (without `{}`) is
+  fine when only the module itself is needed.
+
+## Structs
+
+- Declare abilities in order: `key`, `copy`, `drop`, `store`
+
+## Functions
+
+- Use `public` OR `entry` — never combine as `public entry`
+- Write composable functions that return values (for PTB usage); mint/create
+  functions should return the object, not transfer it internally
+- Parameter order: **self (receiver object) first → capability second → other
+  objects → primitives/utilities → Clock → TxContext last**. The capability
+  always sits at position 2 (even with multiple object params) so method-call
+  syntax `self.fn(&cap, other_obj, ...)` keeps the cap visible at the call site.
+
+  ```move
+  // good — self, cap, rest
+  public fun set_name(account: &mut Account, _: &AdminCap, new_name: String) { ... }
+  // call: account.set_name(&cap, new_name)
+
+  // good — self, cap, other object, primitives, Clock, ctx
+  public fun authorize_transfer(
+      pool: &mut Pool,
+      cap: &AdminCap,
+      account: &Account,
+      amount: u64,
+      clock: &Clock,
+      ctx: &mut TxContext,
+  ) { ... }
+  // call: pool.authorize_transfer(&cap, &account, amount, &clock, ctx)
+
+  // bad — reversed associativity, reads backwards at the call site
+  public fun update(_: &AdminCap, account: &mut Account, new_name: String) { ... }
+  // call: cap.update(&mut account, new_name)
+  ```
+
+- Keep functions pure — avoid `transfer::transfer` inside core logic; return
+  objects instead
+- Accept payment by value — `fun pay(payment: Coin<SUI>)`, not
+  `&mut Coin<SUI>` plus an `amount` — so the caller hands over exactly what they
+  intend; a `&mut Coin` lets the callee draw an unbounded amount.
+- Use `public(package)` or private visibility liberally — only expose the stable
+  external API as `public`. A `public` signature is permanent across package
+  upgrades (see [`ARCHITECTURE.md`](./ARCHITECTURE.md#upgrade-safety)).
+
+## Idiomatic Move 2024
+
+### Receiver syntax
+
+Prefer `obj.fn(arg1, arg2)` over `module::fn(obj, arg1, arg2)` whenever the
+function's first parameter is the object (by value, `&`, or `&mut`). Apply this
+to all functions **and** tests.
+
+Examples of required rewrites:
+
+- `balance::join(&mut bal, b)` → `bal.join(b)`
+- `table::add(&mut t, key, val)` → `t.add(key, val)`
+- `object::delete(id)` → `id.delete()`
+- `tx_context::sender(ctx)` → `ctx.sender()`
+- `coin::split(&mut c, amount, ctx)` → `c.split(amount, ctx)`
+- `option::is_none(&opt)` → `opt.is_none()`
+- `string::length(&s)` → `s.length()`
+- `vector::length(&v)` → `v.length()`
+
+**Cases that CANNOT use receiver syntax — keep the module-qualified form:**
+
+- `event::emit(e)` — generic function with no native method binding; always
+  write `event::emit(e)`
+- `transfer::transfer(obj, recipient)` / `transfer::public_transfer(...)` /
+  `transfer::share_object(obj)` / `transfer::freeze_object(obj)` — Sui transfer
+  builtins have no method aliases by default; keep module-qualified
+- `object::id(&obj)` / `object::id_address(&obj)` — no method alias is
+  registered for these generic `key` functions; keep as `object::id(&obj)`
+- `dynamic_field::add/borrow/borrow_mut/remove` and
+  `dynamic_object_field::*` — no method alias is registered on `UID`; keep
+  module-qualified (e.g. `dof::add(&mut uid, key, val)`)
+- Constructor / factory free functions where no instance exists yet (e.g.
+  `MyStruct::new(...)`)
+- Any free function whose first parameter is a primitive (`u8`..`u256`, `bool`,
+  `address`) — `public use fun fn as u64.method` is rejected by the compiler when
+  the type is from a different package (stdlib). There is no correct workaround
+  short of the function being defined in stdlib itself. Do NOT add non-public
+  `use fun` workarounds in test modules as a substitute.
+- Cross-module calls where the type's defining module does not expose the
+  function and no `use fun` alias is in scope
+
+### Other idioms
+
+- String: `b"hello".to_string()` not `std::string::utf8(...)`
+- Struct field shorthand: `MyStruct { id, caps, balance_manager }` not
+  `balance_manager: balance_manager`
+- Vectors: `vector[...]` literal, `.length()` method, `&x[&key]` indexing
+- Option macros: `opt.do!(|v| ...)`, `opt.destroy_or!(default)`,
+  `opt.destroy_or!(abort EFoo)`
+- Loop macros: `n.do!(|_| ...)`, `vector::tabulate!(n, |i| i)`,
+  `vec.do_ref!(|e| ...)`, `vec.destroy!(|e| ...)`, `.fold!()`, `.filter!()`
+- Struct unpacking: `let MyStruct { id, .. } = value;`
+
+## Collections & object size
+
+- Objects max 250 KB — transactions abort if exceeded
+- Use `vector` / `VecSet` / `VecMap` only for bounded collections ≤ 1000 items
+- Use `Table` / `Bag` / `ObjectBag` / `ObjectTable` / `LinkedTable` for large or
+  unbounded collections
+- Never put ever-growing vectors inside objects
+
+## Testing
+
+- New code must meet the coverage gate defined in
+  [`CONTRIBUTING.md`](./CONTRIBUTING.md#code-quality-standards)
+  (`sui move test --coverage`).
+- Test cases belong in `tests/`. In-module test code should be limited to
+  `#[test_only]` helpers (compiled only in test mode) and `#[test]` functions
+  that exercise private items unreachable from `tests/`. Place all `#[test_only]`
+  and `#[test]` items under the `// === Test-Only Helpers ===` section (item 13).
+- Combine attributes: `#[test, expected_failure(abort_code = EMyError)]` —
+  **always reference the error constant by name**, never by numeric literal.
+  `abort_code = 5` is brittle: renumbering the error const breaks the test
+  silently.
+- Prefer pinning exact values: `assert_eq!(result, exact)` over bound-only
+  assertions (`assert!(r >= lo && r <= hi)`). For genuine property tests, use
+  Sui's `#[random_test]` attribute.
+- Prefer `assert!(cond)` over `assert!(cond, 0)` — Move 2024 auto-assigns abort
+  codes when omitted; a literal `0` is meaningless boilerplate.
+- No cleanup in expected-failure tests — just `abort` at the failure boundary.
+- In `_tests` modules: no `test_` prefix on function names; use descriptive names.
+- Use `tx_context::dummy()` for simple tests instead of TestScenario overhead.
+- Use `assert_eq!` (from `std::unit_test`) not `assert!` with abort codes (abort
+  codes collide with app errors). Import with `use std::unit_test::assert_eq;`.
+- Use `use std::unit_test::destroy` as the black hole instead of
+  `destroy_for_testing()` (note: `sui::test_utils::destroy` is deprecated — the
+  current Sui compiler emits `E04037` and points to `std::unit_test::destroy`).
+
+## Lint suppression
+
+- **Do not add `#[allow(lint(...))]` attributes.** Every lint warning must be
+  resolved by fixing the underlying code, not by silencing it.
+- If a lint warning cannot be addressed, stop and escalate — do not suppress.
+- An existing `#[allow(lint(...))]` is itself a violation: remove the attribute
+  and fix the code it was hiding. If the fix is non-trivial, surface it.
+- `#[allow(...)]` for non-lint diagnostics (e.g. `unused_const`, `unused_use`) is
+  similarly disallowed — fix or remove the offending item.
+
+## Documentation
+
+- `///` for doc comments (renders in IDEs), `//` for inline technical notes
+- No JavaDoc-style `/** */`
+- Document struct fields, complex params, and return values
+- Use section headings `#### Parameters`, `#### Returns`, and `#### Aborts` when
+  relevant; use `-` for list items (not `*`)
+- Document public functions with at least `Parameters` and `Returns`; include an
+  `Aborts` section whenever a function can abort
+- Keep terminology consistent with the implementation (e.g. avoid documenting
+  impossible paths)
+
+  ```move
+  /// Compute something.
+  ///
+  /// #### Parameters
+  /// - `value`: Input value.
+  /// - `rounding_mode`: Rounding strategy.
+  ///
+  /// #### Returns
+  /// - Rounded output value.
+  ///
+  /// #### Aborts
+  /// - Aborts if `value` is zero.
+  ```

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -122,8 +122,10 @@ Common ordering violations to watch for:
   // call: cap.update(&mut account, new_name)
   ```
 
-- Keep functions pure — avoid `transfer::transfer` inside core logic; return
-  objects instead
+- Prefer keeping core logic free of `transfer::*` — return objects instead and
+  push transfers to the edges. Exceptions exist where transferring *is* the
+  operation's semantic; document them rather than working around the guideline
+  (see [`ARCHITECTURE.md`](./ARCHITECTURE.md#core-design-principles)).
 - Accept payment by value — `fun pay(payment: Coin<SUI>)`, not
   `&mut Coin<SUI>` plus an `amount` — so the caller hands over exactly what they
   intend; a `&mut Coin` lets the callee draw an unbounded amount.


### PR DESCRIPTION
Agents (and new humans) can't reliably discover and apply a repo's coding style
without re-teaching it every session. **Principle: code style is data (one source
of truth); the review procedure only references it.**

This PR makes `contracts-sui` the reference implementation of that standard.

### What's here

- **`STYLEGUIDE.md`** — single source of truth for conventions (how we write Move).
- **`ARCHITECTURE.md`** — design rationale (why), incl. an **Upgrade safety** section.
- **`AGENTS.md`** — lean gateway read natively by Codex / Cursor / Copilot / Gemini;
  links to the sources of truth + boundaries, and points every agent at the review
  procedure.
- **`CLAUDE.md`** — one line `@AGENTS.md` (Claude Code doesn't read `AGENTS.md` yet).
- **`.claude/commands/code-quality.md`** — review command; the rules are
  **referenced** from `STYLEGUIDE.md` rather than inlined, so the procedure can
  never drift from the conventions.
- **`.github/copilot-instructions.md`** and **`.coderabbit.yaml`** — point GitHub
  Copilot and CodeRabbit at `STYLEGUIDE.md`; both link, neither restates rules.
- **`CONTRIBUTING.md`** — de-duplicated; now references `STYLEGUIDE.md` and owns the
  commit/PR conventions, coverage gate, commands, and dependency policy.

### SSOT design

Each fact has exactly one home and everything else links to it: the package catalog
stays in the per-package READMEs; rules in `STYLEGUIDE.md`; design rationale in
`ARCHITECTURE.md`; contribution policy in `CONTRIBUTING.md`. The `code-quality`
command, the gateway, and the Copilot/CodeRabbit pointers restate none of them.

#### PR Checklist

- [ ] Tests
- [x] Documentation
- [ ] Changelog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Introduced a comprehensive Move 2024 style guide and an expanded architecture/design reference as canonical sources.
  * Added contributor and AI-agent onboarding guides and updated contributor rules, PR/commit conventions, and brief tooling guidance pointing to the canonical docs.

* **Chores**
  * Added a local code-quality command specification for auditing and optionally fixing Move files against the style guide.
  * Adjusted ignore/configuration and review tooling settings to preserve agent/command resources and align reviews with the docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->