### PR TITLE
test: remove #[test_only] from *_tests modules

### DIFF
--- a/contracts/access/tests/access_control_tests.move
+++ b/contracts/access/tests/access_control_tests.move
@@ -38,7 +38,6 @@ public struct RoleY {}
 /// Deploys an `AccessControl` rooted at `ACCESS_CONTROL_TESTS`, shares it,
 /// and advances to a fresh transaction so `take_shared` is immediately
 /// available.
-#[test_only]
 #[allow(lint(share_owned))]
 fun setup(deployer: address, delay: u64): Scenario {
     let mut scenario = test_scenario::begin(deployer);
@@ -54,7 +53,6 @@ fun setup(deployer: address, delay: u64): Scenario {
 
 /// Convenience: take the singleton registry from the current transaction.
 /// Wraps `test_scenario::take_shared` to keep test bodies tight.
-#[test_only]
 fun take_ac(scenario: &Scenario): AccessControl<ACCESS_CONTROL_TESTS> {
     scenario.take_shared<AccessControl<ACCESS_CONTROL_TESTS>>()
 }

--- a/contracts/access/tests/access_control_tests.move
+++ b/contracts/access/tests/access_control_tests.move
@@ -3,6 +3,12 @@
 // to satisfy the type checker on the `ac` / `clk` bindings without rewriting
 // every test as a by-value helper. Suppressed module-wide so individual
 // tests stay clean.
+// `#[test_only]` is required here, not redundant: this module constructs its
+// own OTW (`ACCESS_CONTROL_TESTS {}`) in `setup`. The Sui verifier only allows
+// manual OTW construction when the enclosing module/function carries the
+// `#[test]`/`#[test_only]` attribute - it keys off the attribute, not the
+// `tests/` directory - so dropping it reintroduces the "Invalid one-time
+// witness construction" error.
 #[test_only, allow(lint(abort_without_constant))]
 module openzeppelin_access::access_control_tests;
 

--- a/contracts/access/tests/delayed_tests.move
+++ b/contracts/access/tests/delayed_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_access::delayed_tests;
 
 use openzeppelin_access::delayed_transfer;
@@ -7,12 +6,10 @@ use sui::clock;
 use sui::event;
 use sui::test_scenario;
 
-#[test_only]
 public struct DummyCap has key, store {
     id: object::UID,
 }
 
-#[test_only]
 fun new_cap(ctx: &mut TxContext): DummyCap {
     DummyCap { id: object::new(ctx) }
 }

--- a/contracts/access/tests/foreign_role.move
+++ b/contracts/access/tests/foreign_role.move
@@ -3,7 +3,6 @@
 /// address with `access_control_tests` but differs in `module_string`, which
 /// is exactly the case the library's home-module check (`assert_home_module`)
 /// rejects with `EForeignRole`.
-#[test_only]
 module openzeppelin_access::foreign_role;
 
 public struct ForeignRole {}

--- a/contracts/access/tests/two_step_tests.move
+++ b/contracts/access/tests/two_step_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_access::two_step_tests;
 
 use openzeppelin_access::two_step_transfer;
@@ -6,18 +5,15 @@ use std::unit_test::assert_eq;
 use sui::event;
 use sui::test_scenario;
 
-#[test_only]
 public struct DummyCap has key, store {
     id: object::UID,
 }
 
-#[test_only]
 public fun dummy_ctx_with_sender(sender: address): TxContext {
     let tx_hash = x"3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532";
     tx_context::new(sender, tx_hash, 0, 0, 0)
 }
 
-#[test_only]
 fun new_cap(ctx: &mut TxContext): DummyCap {
     DummyCap { id: object::new(ctx) }
 }

--- a/contracts/utils/examples/rate_limiter/tests/faucet_tests.move
+++ b/contracts/utils/examples/rate_limiter/tests/faucet_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_utils::faucet_tests;
 
 use openzeppelin_utils::faucet::{new, issue_claim_cap, Faucet, ClaimCap};

--- a/contracts/utils/examples/rate_limiter/tests/mage_duel_tests.move
+++ b/contracts/utils/examples/rate_limiter/tests/mage_duel_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_utils::mage_duel_tests;
 
 use openzeppelin_utils::mage_duel::{Self, challenge, Duel, ChallengerCap, OpponentCap};

--- a/contracts/utils/examples/rate_limiter/tests/rare_coin_tests.move
+++ b/contracts/utils/examples/rate_limiter/tests/rare_coin_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_utils::rare_coin_tests;
 
 use openzeppelin_utils::rare_coin::{Self, RARE_COIN};

--- a/contracts/utils/examples/rate_limiter/tests/staking_vault_tests.move
+++ b/contracts/utils/examples/rate_limiter/tests/staking_vault_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_utils::staking_vault_tests;
 
 use openzeppelin_utils::rate_limiter;

--- a/contracts/utils/tests/rate_limiter_tests.move
+++ b/contracts/utils/tests/rate_limiter_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_utils::rate_limiter_tests;
 
 use openzeppelin_utils::rate_limiter;

--- a/math/core/tests/common_tests.move
+++ b/math/core/tests/common_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_math::common_tests;
 
 use openzeppelin_math::common;

--- a/math/core/tests/decimal_scaling_tests.move
+++ b/math/core/tests/decimal_scaling_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_math::decimal_scaling_tests;
 
 use openzeppelin_math::decimal_scaling;

--- a/math/core/tests/macros/is_power_of_ten.move
+++ b/math/core/tests/macros/is_power_of_ten.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_math::is_power_of_ten;
 
 use openzeppelin_math::macros;

--- a/math/core/tests/macros/math_ops.move
+++ b/math/core/tests/macros/math_ops.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_math::math_ops;
 
 use openzeppelin_math::macros;

--- a/math/core/tests/macros/median.move
+++ b/math/core/tests/macros/median.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_math::median;
 
 use openzeppelin_math::macros;

--- a/math/core/tests/macros/quick_sort.move
+++ b/math/core/tests/macros/quick_sort.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_math::quick_sort;
 
 use openzeppelin_math::vector;
@@ -500,7 +499,6 @@ fun quick_sort_by_descending_already_sorted() {
     assert_eq!(vec, vector[10u32, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
 }
 
-#[test_only]
 public struct Transfer has copy, drop {
     id: u8, // Transfer identifier
     value: u64, // Transfer value in smallest unit

--- a/math/core/tests/u128_tests.move
+++ b/math/core/tests/u128_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_math::u128_tests;
 
 use openzeppelin_math::macros;

--- a/math/core/tests/u16_tests.move
+++ b/math/core/tests/u16_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_math::u16_tests;
 
 use openzeppelin_math::macros;

--- a/math/core/tests/u256_tests.move
+++ b/math/core/tests/u256_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_math::u256_tests;
 
 use openzeppelin_math::macros;

--- a/math/core/tests/u32_tests.move
+++ b/math/core/tests/u32_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_math::u32_tests;
 
 use openzeppelin_math::macros;

--- a/math/core/tests/u512_tests.move
+++ b/math/core/tests/u512_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_math::u512_tests;
 
 use openzeppelin_math::u512::{Self, U512};

--- a/math/core/tests/u64_tests.move
+++ b/math/core/tests/u64_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_math::u64_tests;
 
 use openzeppelin_math::macros;

--- a/math/core/tests/u8_tests.move
+++ b/math/core/tests/u8_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_math::u8_tests;
 
 use openzeppelin_math::macros;

--- a/math/fixed_point/tests/internal/raw_log2_tests.move
+++ b/math/fixed_point/tests/internal/raw_log2_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::raw_log2_tests;
 
 use openzeppelin_fp_math::common;

--- a/math/fixed_point/tests/sd29x9_tests/abs_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/abs_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::sd29x9_abs_tests;
 
 use openzeppelin_fp_math::sd29x9;

--- a/math/fixed_point/tests/sd29x9_tests/arithmetic_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/arithmetic_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::sd29x9_arithmetic_tests;
 
 use openzeppelin_fp_math::sd29x9;

--- a/math/fixed_point/tests/sd29x9_tests/casting_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/casting_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::sd29x9_casting_tests;
 
 use openzeppelin_fp_math::sd29x9;

--- a/math/fixed_point/tests/sd29x9_tests/ceil_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/ceil_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::sd29x9_ceil_tests;
 
 use openzeppelin_fp_math::sd29x9;

--- a/math/fixed_point/tests/sd29x9_tests/comparison_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/comparison_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::sd29x9_comparison_tests;
 
 use openzeppelin_fp_math::sd29x9;

--- a/math/fixed_point/tests/sd29x9_tests/conversion_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/conversion_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::sd29x9_conversion_tests;
 
 use openzeppelin_fp_math::sd29x9;

--- a/math/fixed_point/tests/sd29x9_tests/div_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/div_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::sd29x9_div_tests;
 
 use openzeppelin_fp_math::sd29x9;

--- a/math/fixed_point/tests/sd29x9_tests/floor_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/floor_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::sd29x9_floor_tests;
 
 use openzeppelin_fp_math::sd29x9;

--- a/math/fixed_point/tests/sd29x9_tests/helpers.move
+++ b/math/fixed_point/tests/sd29x9_tests/helpers.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::sd29x9_test_helpers;
 
 use openzeppelin_fp_math::sd29x9::{Self, SD29x9};

--- a/math/fixed_point/tests/sd29x9_tests/ln_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/ln_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::sd29x9_ln_tests;
 
 use openzeppelin_fp_math::sd29x9;

--- a/math/fixed_point/tests/sd29x9_tests/log10_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/log10_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::sd29x9_log10_tests;
 
 use openzeppelin_fp_math::sd29x9;

--- a/math/fixed_point/tests/sd29x9_tests/log2_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/log2_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::sd29x9_log2_tests;
 
 use openzeppelin_fp_math::sd29x9;

--- a/math/fixed_point/tests/sd29x9_tests/mod_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/mod_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::sd29x9_mod_tests;
 
 use openzeppelin_fp_math::sd29x9;

--- a/math/fixed_point/tests/sd29x9_tests/mul_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/mul_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::sd29x9_mul_tests;
 
 use openzeppelin_fp_math::sd29x9;

--- a/math/fixed_point/tests/sd29x9_tests/negate_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/negate_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::sd29x9_negate_tests;
 
 use openzeppelin_fp_math::sd29x9::{Self, from_bits};

--- a/math/fixed_point/tests/sd29x9_tests/pow_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/pow_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::sd29x9_pow_tests;
 
 use openzeppelin_fp_math::sd29x9;

--- a/math/fixed_point/tests/sd29x9_tests/rem_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/rem_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::sd29x9_rem_tests;
 
 use openzeppelin_fp_math::sd29x9;

--- a/math/fixed_point/tests/sd29x9_tests/sqrt_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/sqrt_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::sd29x9_sqrt_tests;
 
 use openzeppelin_fp_math::sd29x9;

--- a/math/fixed_point/tests/sd29x9_tests/unchecked_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/unchecked_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::sd29x9_unchecked_tests;
 
 use openzeppelin_fp_math::sd29x9;

--- a/math/fixed_point/tests/sd29x9_tests/wrap_tests.move
+++ b/math/fixed_point/tests/sd29x9_tests/wrap_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::sd29x9_wrap_tests;
 
 use openzeppelin_fp_math::sd29x9::{Self, from_bits, two_complement};

--- a/math/fixed_point/tests/ud30x9_tests/abs_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/abs_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::ud30x9_abs_tests;
 
 use openzeppelin_fp_math::ud30x9;

--- a/math/fixed_point/tests/ud30x9_tests/arithmetic_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/arithmetic_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::ud30x9_arithmetic_tests;
 
 use openzeppelin_fp_math::ud30x9_base;

--- a/math/fixed_point/tests/ud30x9_tests/bitwise_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/bitwise_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::ud30x9_bitwise_tests;
 
 use openzeppelin_fp_math::ud30x9_base;

--- a/math/fixed_point/tests/ud30x9_tests/casting_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/casting_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::ud30x9_casting_tests;
 
 use openzeppelin_fp_math::sd29x9;

--- a/math/fixed_point/tests/ud30x9_tests/ceil_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/ceil_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::ud30x9_ceil_tests;
 
 use openzeppelin_fp_math::ud30x9;

--- a/math/fixed_point/tests/ud30x9_tests/comparison_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/comparison_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::ud30x9_comparison_tests;
 
 use openzeppelin_fp_math::ud30x9_test_helpers::{fixed, pair, unpack};

--- a/math/fixed_point/tests/ud30x9_tests/conversion_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/conversion_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::ud30x9_conversion_tests;
 
 use openzeppelin_fp_math::ud30x9;

--- a/math/fixed_point/tests/ud30x9_tests/div_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/div_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::ud30x9_div_tests;
 
 use openzeppelin_fp_math::ud30x9;

--- a/math/fixed_point/tests/ud30x9_tests/floor_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/floor_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::ud30x9_floor_tests;
 
 use openzeppelin_fp_math::ud30x9;

--- a/math/fixed_point/tests/ud30x9_tests/helpers.move
+++ b/math/fixed_point/tests/ud30x9_tests/helpers.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::ud30x9_test_helpers;
 
 use openzeppelin_fp_math::ud30x9::{Self, UD30x9};

--- a/math/fixed_point/tests/ud30x9_tests/ln_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/ln_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::ud30x9_ln_tests;
 
 use openzeppelin_fp_math::ud30x9;

--- a/math/fixed_point/tests/ud30x9_tests/log10_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/log10_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::ud30x9_log10_tests;
 
 use openzeppelin_fp_math::ud30x9;

--- a/math/fixed_point/tests/ud30x9_tests/log2_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/log2_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::ud30x9_log2_tests;
 
 use openzeppelin_fp_math::ud30x9;

--- a/math/fixed_point/tests/ud30x9_tests/mul_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/mul_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::ud30x9_mul_tests;
 
 use openzeppelin_fp_math::ud30x9;

--- a/math/fixed_point/tests/ud30x9_tests/pow_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/pow_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::ud30x9_pow_tests;
 
 use openzeppelin_fp_math::ud30x9;

--- a/math/fixed_point/tests/ud30x9_tests/sqrt_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/sqrt_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::ud30x9_sqrt_tests;
 
 use openzeppelin_fp_math::ud30x9;

--- a/math/fixed_point/tests/ud30x9_tests/unchecked_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/unchecked_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::ud30x9_unchecked_tests;
 
 use openzeppelin_fp_math::ud30x9_test_helpers::fixed;

--- a/math/fixed_point/tests/ud30x9_tests/wrap_tests.move
+++ b/math/fixed_point/tests/ud30x9_tests/wrap_tests.move
@@ -1,4 +1,3 @@
-#[test_only]
 module openzeppelin_fp_math::ud30x9_wrap_tests;
 
 use openzeppelin_fp_math::ud30x9;


### PR DESCRIPTION
As per [docs](https://move-book.com/testing/testing-basics#test-only-code), the `#[test_only]` attribute is used to only include the annotated code in the final bytecode output if the `mode` is set to `test`, i.e. `sui move build --mode test` or `sui move test` (uses `--mode test` by default).
This is used when some module in the `sources/*` contains test-specific code (see [move best practices](https://docs.sui.io/develop/write-move/move-best-practices#body))

However, any module inside the `tests/*` directory is by default _only ever included_ in the final bytecode if `--mode test` is set (see [Move Book > Packages](https://move-book.com/reference/packages#package-layout-and-manifest-syntax)).
Confirmed this claim locally.

Removing the attribute from modules inside `tests/*` results in no bytecode changes in any mode.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Removed test-only compilation restrictions across many Move test suites and helper utilities, making these modules available outside test-only build contexts.
  * Updated select test helper constructs to remove test-only gating (including module/fixture annotations), without changing any test logic or assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->