### PR TITLE
docs: package catalog table + per-package install/learn more

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -6,7 +6,7 @@ OpenZeppelin building blocks for Sui smart contracts development.
 
 ## Packages
 
-| Path | Highlights |
-|------|---------|
-| [`access/`](access/) | Transfer policies that wrap privileged capabilities and guard ownership handoffs (two-step approvals and time-locked transfers). |
-| [`utils/`](utils/) | Embeddable primitives for everyday module logic, starting with a unified rate-limiter (token bucket, fixed window, cooldown). See [`utils/examples/rate_limiter/`](utils/examples/rate_limiter) for integration examples. |
+| Package | MVR slug | Move package | Docs | Highlights |
+|---------|----------|--------------|------|-----------|
+| [`access/`](access/) | [`@openzeppelin-move/access`](https://www.moveregistry.com/package/@openzeppelin-move/access) | `openzeppelin_access` | [docs](https://docs.openzeppelin.com/contracts-sui/1.x/access) | Transfer policies that wrap privileged capabilities and guard ownership handoffs (two-step approvals and time-locked transfers). |
+| [`utils/`](utils/) | [`@openzeppelin-move/utils`](https://www.moveregistry.com/package/@openzeppelin-move/utils) | `openzeppelin_utils` | [docs](https://docs.openzeppelin.com/contracts-sui/1.x/utils) | Embeddable primitives for everyday module logic, starting with a unified rate-limiter (token bucket, fixed window, cooldown). See [`utils/examples/rate_limiter/`](utils/examples/rate_limiter) for integration examples. |

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -6,7 +6,7 @@ OpenZeppelin building blocks for Sui smart contracts development.
 
 ## Packages
 
-| Package | MVR slug | Move package | Docs | Highlights |
+| Package | MVR | Move package | Docs | Highlights |
 |---------|----------|--------------|------|-----------|
 | [`access/`](access/) | [`@openzeppelin-move/access`](https://www.moveregistry.com/package/@openzeppelin-move/access) | `openzeppelin_access` | [docs](https://docs.openzeppelin.com/contracts-sui/1.x/access) | Transfer policies that wrap privileged capabilities and guard ownership handoffs (two-step approvals and time-locked transfers). |
 | [`utils/`](utils/) | [`@openzeppelin-move/utils`](https://www.moveregistry.com/package/@openzeppelin-move/utils) | `openzeppelin_utils` | [docs](https://docs.openzeppelin.com/contracts-sui/1.x/utils) | Embeddable primitives for everyday module logic, starting with a unified rate-limiter (token bucket, fixed window, cooldown). See [`utils/examples/rate_limiter/`](utils/examples/rate_limiter) for integration examples. |

--- a/contracts/utils/README.md
+++ b/contracts/utils/README.md
@@ -2,6 +2,13 @@
 
 Embeddable primitives for Sui smart contract development.
 
+## Install
+
+```toml
+[dependencies]
+openzeppelin_utils = { r.mvr = "@openzeppelin-move/utils" }
+```
+
 ## Module Snapshot
 
 | Module | Summary |
@@ -90,3 +97,9 @@ Complete integration examples live in [`examples/rate_limiter/`](examples/rate_l
 - [`faucet`](examples/rate_limiter/faucet.move) - two limiters of different variants composed across two objects: a per-holder token bucket layered on top of a global fixed window shared by all claimers.
 - [`staking_vault`](examples/rate_limiter/staking_vault.move) - a cooldown used as a one-shot timelock: unstaking arms a gate that releases after an unbonding delay, so the claim aborts until the delay has elapsed.
 - [`mage_duel`](examples/rate_limiter/mage_duel.move) - rate limiting can be used outside of DeFi; this example showcases many limiters of mixed variants packed into one type: a mage holds buckets for health and mana plus per-spell cooldowns, with limiters carried inside `store` structs.
+
+## Learn More
+
+- [Utils package overview](https://docs.openzeppelin.com/contracts-sui/1.x/utils)
+- [Utils API reference](https://docs.openzeppelin.com/contracts-sui/1.x/api/utils)
+- [OpenZeppelin Contracts for Sui](https://docs.openzeppelin.com/contracts-sui)

--- a/math/README.md
+++ b/math/README.md
@@ -4,7 +4,7 @@ Math primitives for Sui DeFi, implemented as pure functions (no on-chain storage
 
 ## Packages
 
-| Name | Path | Highlights |
-|------|------|------------|
-| `openzeppelin_math` | [`core/`](core/) | Overflow-safe unsigned integer arithmetic with configurable rounding. |
-| `openzeppelin_fp_math` | [`fixed_point/`](fixed_point/) | Fixed-point decimal types (`UD30x9`, `SD29x9`) with 9 decimals; arithmetic and comparison ops, plus bitwise helpers on `UD30x9`. |
+| Package | MVR slug | Move package | Docs | Highlights |
+|---------|----------|--------------|------|-----------|
+| [`core/`](core/) | [`@openzeppelin-move/integer-math`](https://www.moveregistry.com/package/@openzeppelin-move/integer-math) | `openzeppelin_math` | [docs](https://docs.openzeppelin.com/contracts-sui/1.x/math) | Overflow-safe unsigned integer arithmetic with configurable rounding. |
+| [`fixed_point/`](fixed_point/) | [`@openzeppelin-move/fixed-point-math`](https://www.moveregistry.com/package/@openzeppelin-move/fixed-point-math) | `openzeppelin_fp_math` | [docs](https://docs.openzeppelin.com/contracts-sui/1.x/fixed-point) | Fixed-point decimal types (`UD30x9`, `SD29x9`) with 9 decimals; arithmetic and comparison ops, plus bitwise helpers on `UD30x9`. |

--- a/math/README.md
+++ b/math/README.md
@@ -4,7 +4,7 @@ Math primitives for Sui DeFi, implemented as pure functions (no on-chain storage
 
 ## Packages
 
-| Package | MVR slug | Move package | Docs | Highlights |
+| Package | MVR | Move package | Docs | Highlights |
 |---------|----------|--------------|------|-----------|
 | [`core/`](core/) | [`@openzeppelin-move/integer-math`](https://www.moveregistry.com/package/@openzeppelin-move/integer-math) | `openzeppelin_math` | [docs](https://docs.openzeppelin.com/contracts-sui/1.x/math) | Overflow-safe unsigned integer arithmetic with configurable rounding. |
 | [`fixed_point/`](fixed_point/) | [`@openzeppelin-move/fixed-point-math`](https://www.moveregistry.com/package/@openzeppelin-move/fixed-point-math) | `openzeppelin_fp_math` | [docs](https://docs.openzeppelin.com/contracts-sui/1.x/fixed-point) | Fixed-point decimal types (`UD30x9`, `SD29x9`) with 9 decimals; arithmetic and comparison ops, plus bitwise helpers on `UD30x9`. |

--- a/math/core/README.md
+++ b/math/core/README.md
@@ -2,6 +2,13 @@
 
 Overflow-safe arithmetic helpers for unsigned integers with configurable rounding.
 
+## Install
+
+```toml
+[dependencies]
+openzeppelin_math = { r.mvr = "@openzeppelin-move/integer-math" }
+```
+
 ## What it provides
 
 Operations for `u8`, `u16`, `u32`, `u64`, `u128`, and `u256`, including:
@@ -58,3 +65,9 @@ use openzeppelin_math::vector;
 let med = vector::median!(&vector[5u64, 1, 9, 3, 7], rounding::down());
 // med = 5
 ```
+
+## Learn More
+
+- [Integer math package overview](https://docs.openzeppelin.com/contracts-sui/1.x/math)
+- [Integer math API reference](https://docs.openzeppelin.com/contracts-sui/1.x/api/math)
+- [OpenZeppelin Contracts for Sui](https://docs.openzeppelin.com/contracts-sui)

--- a/math/fixed_point/README.md
+++ b/math/fixed_point/README.md
@@ -2,6 +2,13 @@
 
 Fixed-point decimal types with 9 decimals (10^9), matching Sui coin precision.
 
+## Install
+
+```toml
+[dependencies]
+openzeppelin_fp_math = { r.mvr = "@openzeppelin-move/fixed-point-math" }
+```
+
 ## Types
 
 - `UD30x9`: Unsigned decimal fixed-point (internal: 0 to 2^128 - 1; decimal: 0 to ~3.4e29)
@@ -130,3 +137,9 @@ let one = ud30x9::wrap(1000000000); // 1.0
 let third_down = one.div_trunc(ud30x9::wrap(3000000000)); // 0.333333333
 let third_up = one.div_away(ud30x9::wrap(3000000000)); // 0.333333334
 ```
+
+## Learn More
+
+- [Fixed-point math package overview](https://docs.openzeppelin.com/contracts-sui/1.x/fixed-point)
+- [Fixed-point math API reference](https://docs.openzeppelin.com/contracts-sui/1.x/api/fixed-point)
+- [OpenZeppelin Contracts for Sui](https://docs.openzeppelin.com/contracts-sui)


### PR DESCRIPTION
## What

- **Group READMEs** (`contracts/`, `math/`): a canonical package catalog table — `Package (→ dir) | MVR slug (→ MVR) | Move package | Docs | Highlights`. This is the source of truth for the `MVR slug ↔ Move package ↔ path ↔ docs` mapping (slug ≠ package name ≠ dir) that the AI metadata layer (#375), Contracts MCP (#376), and Skills + CLI (#377) build on.
- **Per-package READMEs** (`utils`, `core`, `fixed_point`): add `## Install` (MVR dependency snippet) and `## Learn More` (docs overview + API reference + root), matching the existing `access` README.

## Notes

- All links verified live: MVR package pages, docs overview pages (`/1.x/{access,utils,math,fixed-point}`), and API reference pages.
- Package names taken from each `Move.toml` (note `openzeppelin_math` for core, `openzeppelin_fp_math` for fixed_point).
- No validator added for the table — it is plain, human + machine readable content.

Closes #380
Part of #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced package documentation across contracts and math modules with clearer installation instructions for multiple packages
  * Expanded package tables with improved organization, including package identifiers and documentation references
  * Added "Learn More" sections linking to additional resources and API references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->