### PR TITLE
ci: add docgen-clean gate (sui move build --doc)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,6 +95,10 @@ jobs:
         run: sui move build --test --lint --warnings-are-errors
         working-directory: ./${{ matrix.package }}
 
+      - name: Docgen clean
+        run: sui move build --doc
+        working-directory: ./${{ matrix.package }}
+
   test:
     name: Test ${{ matrix.package }}
     needs: [setup, lint]


### PR DESCRIPTION
## What

Add a **docgen-clean gate** to CI: the `lint` job now runs `sui move build --doc` per package. A docgen panic (e.g. an unmatched backtick in a `///` doc comment — a [known docgen failure mode](https://github.com/MystenLabs/sui/issues/23125)) now fails CI instead of silently breaking the generated API reference.

## Why

The AI metadata layer (#375) derives the API surface (types / functions / errors) from doc-comments via `sui move build --doc` rather than hand-copying it. That makes docgen reliability load-bearing — this gate guards it.

## Notes

- Added as a step in the existing per-package `lint` matrix job; reuses the Sui CLI restore. No new job.
- A static scan of every doc-comment block across all four packages found **no unbalanced backticks / unclosed fences**, so no source fixes were needed — the gate is purely a regression guard.

Closes #381
Part of #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to automatically generate documentation during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->