### PR TITLE
docs: add llms.txt discovery entry + agent-file pointers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,11 @@ read the group and package READMEs (the single source of truth):
 - [`contracts/README.md`](./contracts/README.md) + each package's `README.md`
 - [`math/README.md`](./math/README.md) + each package's `README.md`
 
+For agents **integrating this library into a downstream project** (rather than
+contributing to this repo), [`llms.txt`](./llms.txt) is the discovery entry point —
+it points to these catalogs, each package's `examples/`, the generated API reference,
+and `audits/`.
+
 ## Boundaries — do not touch
 
 - `**/build/` — compiler output (generated)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ documentation locally using:
 sui move build --doc --path <module>
 ```
 
+**AI agents:** [`llms.txt`](./llms.txt) is the discovery entry point for integrating
+this library into a downstream project — it points to the package catalogs, examples,
+generated API reference, and audits.
+
 ## Notes
 
 We strive to maintain consistency with other OpenZeppelin libraries as much as

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,26 @@
+# OpenZeppelin Contracts for Sui
+
+> Audited Move building blocks for the Sui blockchain. Use these reviewed
+> primitives instead of writing access control, math, or rate limiting from scratch.
+
+A pointer file ([llmstxt.org](https://llmstxt.org/)) — nothing is restated here;
+follow the links to the sources of truth.
+
+## Start here
+
+- [ARCHITECTURE.md](ARCHITECTURE.md): why the library is shaped this way and how to compose it
+- [contracts/](contracts/README.md) and [math/](math/README.md): the package catalogs —
+  browse for the available packages, their MVR slugs, paths, and docs
+
+## For each package
+
+- **README** — what it does, when to use it, install snippet
+- **`examples/`** — compilable, audited-adjacent integration examples (the composition recipes)
+- **API reference** — generated from doc-comments (`sui move build --doc`), published at
+  `https://docs.openzeppelin.com/contracts-sui/1.x/api/<package>`
+- [audits/](audits/README.md) — audit reports and their scope
+
+## Dependencies
+
+Pin stable releases from the Move Registry (MVR):
+`dep = { r.mvr = "@openzeppelin-move/<package>" }` — see each package's README install snippet for the exact name.


### PR DESCRIPTION
Adds the AI-integrator **discovery entry point**.

## What

- **`llms.txt`** at the repo root ([llmstxt.org](https://llmstxt.org/) convention) — a thin pointer file. It restates nothing; it links to the sources of truth: `ARCHITECTURE.md` (why / how to compose), the group README catalogs, each package's `examples/` (integration) and generated API reference (`/api/<package>`), and `audits/`. No package list inside, so there is nothing to drift and no generator to maintain.
- Pointers to `llms.txt` from **`AGENTS.md`** and the root **`README.md`**, so an agent browsing the repo discovers it.

## Why this shape

We deliberately avoided a generated, package-listing `llms.txt` (that would be a parallel copy of the catalog that drifts). A pointer-only file keeps a single source of truth: the catalog lives in the group READMEs, the API in doc-comments/docgen, integration in `examples/`.

## Out of scope (follow-up)

Downstream discovery wiring — a generated `llms.txt` served at the docs URL and per-package MVR `PackageInfo.documentation_url` — is separate.

Closes #393
Part of #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added AI agent integration guidance with `llms.txt` as the discovery entry point for downstream projects
  * New documentation pointing to package catalogs, examples, API reference, and audit information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->