### PR TITLE
fix: restore the em-dash example in the no-em-dash STYLEGUIDE rule

### DIFF
--- a/.claude/commands/code-quality.md
+++ b/.claude/commands/code-quality.md
@@ -9,15 +9,15 @@ description: >
 user_invocable: true
 ---
 
-# OpenZeppelin Contracts for Sui — Code Quality Checklist
+# OpenZeppelin Contracts for Sui - Code Quality Checklist
 
 Reviews `.move` files in this repository for convention violations and either
-reports them or fixes them in place — the user picks.
+reports them or fixes them in place - the user picks.
 
 This is a local maintainer tool. It is not wired into CI.
 
 **The rules are not in this file.** They live in
-[`STYLEGUIDE.md`](../../STYLEGUIDE.md) at the repository root — the single source
+[`STYLEGUIDE.md`](../../STYLEGUIDE.md) at the repository root - the single source
 of truth for our conventions (design rationale in
 [`ARCHITECTURE.md`](../../ARCHITECTURE.md)). This command is procedure only: it
 reads `STYLEGUIDE.md` and checks code against it, so the rules can never drift
@@ -25,10 +25,10 @@ from the file every human and agent already follows.
 
 ## Usage
 
-- `/code-quality` — review the file(s) changed on the current branch
+- `/code-quality` - review the file(s) changed on the current branch
   (`git diff main...HEAD --name-only`, plus any uncommitted edits).
-- `/code-quality <path>` — review a specific file or directory.
-- `/code-quality <package-name>` — review a package by name (e.g.
+- `/code-quality <path>` - review a specific file or directory.
+- `/code-quality <package-name>` - review a package by name (e.g.
   `openzeppelin_access`).
 
 ## Workflow
@@ -47,7 +47,7 @@ If the working tree is dirty, warn the user and ask whether to:
 - Abort.
 
 Do not silently mix unrelated changes. If the current branch is `main`, do not
-commit there — require a new branch.
+commit there - require a new branch.
 
 ### 2. Discover the file set
 
@@ -68,23 +68,23 @@ git diff --name-only ; git ls-files --others --exclude-standard   # uncommitted
 Filter to `*.move` under `contracts/` and `math/`, excluding `build/`,
 `vendor/`, `.claude/`, `audits/`, `artifacts/`, and any committed/generated
 `.move` outputs (the `codegen/`-produced tables). These are do-not-touch per
-[`AGENTS.md`](../../AGENTS.md) / [`ARCHITECTURE.md`](../../ARCHITECTURE.md) — the
+[`AGENTS.md`](../../AGENTS.md) / [`ARCHITECTURE.md`](../../ARCHITECTURE.md) - the
 command must never "fix" reproducible output. If empty, report "no Move files in
 scope" and stop.
 
 **Edition check.** For each package in scope, parse `edition` from the
 `[package]` table of its `Move.toml`. These conventions target **Move 2024**. If
 a package is `edition = "legacy"` (or the field is missing/unknown), stop and
-tell the user — running 2024 rules on a legacy package produces misleading
+tell the user - running 2024 rules on a legacy package produces misleading
 findings. Do not proceed on that package unless the user explicitly overrides.
 
-Read every file in scope before checking rules — partial reads produce partial
+Read every file in scope before checking rules - partial reads produce partial
 reviews. **Also read [`STYLEGUIDE.md`](../../STYLEGUIDE.md) now** (and
 [`ARCHITECTURE.md`](../../ARCHITECTURE.md) for design constraints it references).
 
 ### 3. Identify violations
 
-Walk the file set against the rules in [`STYLEGUIDE.md`](../../STYLEGUIDE.md) —
+Walk the file set against the rules in [`STYLEGUIDE.md`](../../STYLEGUIDE.md) -
 the codified conventions are explicit, named, and stable there. Check every file
 against every rule the style guide defines. Do not invent rules that are not in
 `STYLEGUIDE.md`; if the code does something the style guide does not cover, that
@@ -94,12 +94,12 @@ Build a numbered list of findings. Each entry has:
 
 - **file path** (repo-relative)
 - **line number** (or line range)
-- **rule** — the `STYLEGUIDE.md` section it violates (e.g. `Naming`,
+- **rule** - the `STYLEGUIDE.md` section it violates (e.g. `Naming`,
   `Section ordering`, `Idiomatic Move 2024`)
-- **finding** — what differs and why it matters
-- **fix** — one or two sentences describing what should change
+- **finding** - what differs and why it matters
+- **fix** - one or two sentences describing what should change
 
-**Borderline findings** — a rule may apply literally but be overridden by design
+**Borderline findings** - a rule may apply literally but be overridden by design
 intent (e.g. `transfer::transfer` inside a function whose semantic *is*
 transferring). Do not put these in the numbered list; print them in a separate
 "Borderline (review and decide)" section so the user is not forced to reject
@@ -109,12 +109,12 @@ them repeatedly.
 
 Tell the user how many findings were collected and ask which mode to run in:
 
-1. **Apply all** — apply every fix in one pass without further prompts. Stop only
+1. **Apply all** - apply every fix in one pass without further prompts. Stop only
    on a tool error or a finding the command cannot fix on its own.
-2. **One-by-one** — walk the findings in order. For each, describe it (file,
+2. **One-by-one** - walk the findings in order. For each, describe it (file,
    line, what's wrong, what the edit would do), then ask the user to approve
    before editing. Skipped findings are recorded in the final report.
-3. **Report only** — print the full list and stop. Do not edit anything. Skip to
+3. **Report only** - print the full list and stop. Do not edit anything. Skip to
    step 7.
 
 The user may also cancel entirely; in that case stop without further action.
@@ -131,7 +131,7 @@ files when the Move plugin is absent):
 
 - Ensure `<repo_root>/.prettierrc` lists `@mysten/prettier-plugin-move` in
   `plugins`. If missing, offer to add it (preserve other settings) or skip
-  prettier for this run — do not overwrite a custom config.
+  prettier for this run - do not overwrite a custom config.
 - Ensure the plugin is resolvable (`node_modules/@mysten/prettier-plugin-move`
   or `package.json` devDependencies); offer to install it with the repo's
   package manager, else skip.
@@ -149,7 +149,7 @@ the step 7 report.
 
 Pick `--build-env` by parsing the package's `Move.toml`: prefer a name from
 `[environments]` (favouring `testnet` → `mainnet`), fall back to `testnet` when
-none is declared. Always pass `--build-env` explicitly — the Sui CLI has no true
+none is declared. Always pass `--build-env` explicitly - the Sui CLI has no true
 default for env-agnostic packages. Run **both** commands (even if the first
 fails) so the user sees every issue in one pass:
 
@@ -163,7 +163,7 @@ sui move build --path <package> --build-env <env> --lint --warnings-are-errors
 
 **Pre-existing-warning caveat:** `--warnings-are-errors` also fails on warnings
 unrelated to this run. If the output is dominated by pre-existing warnings, ask
-the user whether to fix them too or drop the flag for this run only — do not
+the user whether to fix them too or drop the flag for this run only - do not
 silently swallow the failure.
 
 Coverage gate is defined in [`CONTRIBUTING.md`](../../CONTRIBUTING.md); if a fix
@@ -179,7 +179,7 @@ no violations), say so and stop.
 
 This command carries **no rule set of its own**. The conventions live in
 [`STYLEGUIDE.md`](../../STYLEGUIDE.md) (with design rationale in
-[`ARCHITECTURE.md`](../../ARCHITECTURE.md)) — read it at the start of step 2 and
+[`ARCHITECTURE.md`](../../ARCHITECTURE.md)) - read it at the start of step 2 and
 check every `.move` file against it in step 3. Keeping the rules in the repo (not
 in this command) is deliberate: the same file serves humans and every other agent
 (Codex / Cursor / Copilot / Gemini), and the rules can never drift from the code
@@ -189,7 +189,7 @@ The rule categories for step 3 grouping and the step 7 summary are the `##`
 section headings of `STYLEGUIDE.md` (Naming, Module & Package, Section ordering,
 Imports, Structs, Functions, Idiomatic Move 2024, Collections & object size,
 Testing, Lint suppression, Documentation). Use whatever headings `STYLEGUIDE.md`
-actually defines — do not assume a fixed list.
+actually defines - do not assume a fixed list.
 
 ## Important notes
 
@@ -198,5 +198,5 @@ actually defines — do not assume a fixed list.
   [`CONTRIBUTING.md`](../../CONTRIBUTING.md#commit-and-pr-conventions). A sensible
   default commit message is `refactor: apply STYLEGUIDE.md (<package>)`.
 - When unsure whether something is "wrong" or just "uncovered", check
-  `STYLEGUIDE.md` — if the rule is not there, it is not a violation. Propose
+  `STYLEGUIDE.md` - if the rule is not there, it is not a violation. Propose
   adding the rule to `STYLEGUIDE.md` rather than enforcing an unwritten one.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,12 +1,12 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
-# CodeRabbit reads this repo's conventions from STYLEGUIDE.md / ARCHITECTURE.md —
+# CodeRabbit reads this repo's conventions from STYLEGUIDE.md / ARCHITECTURE.md -
 # the single source of truth. This config only points CodeRabbit at them.
 reviews:
   path_instructions:
     - path: "**/*.move"
       instructions: |
         Review Move code against the conventions in STYLEGUIDE.md and the design
-        rationale in ARCHITECTURE.md at the repository root — treat them as the
+        rationale in ARCHITECTURE.md at the repository root - treat them as the
         single source of truth. Flag deviations from them; do not enforce rules
         that are not written there. AGENTS.md is the gateway that links both.
     - path: "**/*.md"

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,13 +1,13 @@
 # GitHub Copilot instructions
 
 This repository keeps its coding conventions as data, in one place. This file
-only points to them — it restates no rules.
+only points to them - it restates no rules.
 
-- [`STYLEGUIDE.md`](../STYLEGUIDE.md) — single source of truth for conventions
+- [`STYLEGUIDE.md`](../STYLEGUIDE.md) - single source of truth for conventions
   (how we write Move: naming, ordering, idioms, testing, documentation).
-- [`ARCHITECTURE.md`](../ARCHITECTURE.md) — design rationale (why), incl. upgrade
+- [`ARCHITECTURE.md`](../ARCHITECTURE.md) - design rationale (why), incl. upgrade
   safety.
-- [`AGENTS.md`](../AGENTS.md) — the gateway for AI agents; start here.
+- [`AGENTS.md`](../AGENTS.md) - the gateway for AI agents; start here.
 
 When generating or reviewing Move, follow `STYLEGUIDE.md` exactly. Do not invent
 conventions from generic internet patterns; if a rule is not in `STYLEGUIDE.md`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,24 +1,24 @@
 # Agent Guide
 
 Lean entry point for AI agents (Codex, Cursor, Copilot, Gemini, Claude Code) and
-new contributors. This file does **not** restate the rules — it points to the
+new contributors. This file does **not** restate the rules - it points to the
 single sources of truth and lists the boundaries you need.
 
-## Sources of truth — read these first
+## Sources of truth - read these first
 
-- [`STYLEGUIDE.md`](./STYLEGUIDE.md) — **how** we write Move: naming, section
+- [`STYLEGUIDE.md`](./STYLEGUIDE.md) - **how** we write Move: naming, section
   ordering, imports, idiomatic Move 2024, testing, documentation. Follow it
   exactly; do not invent conventions from generic internet patterns.
-- [`ARCHITECTURE.md`](./ARCHITECTURE.md) — **why** the library is shaped this
+- [`ARCHITECTURE.md`](./ARCHITECTURE.md) - **why** the library is shaped this
   way: package split, capability-based access control, owned vs. shared objects,
   PTB composability, bounded state, upgrade safety.
-- [`CONTRIBUTING.md`](./CONTRIBUTING.md) — PR workflow, build/test/lint commands,
+- [`CONTRIBUTING.md`](./CONTRIBUTING.md) - PR workflow, build/test/lint commands,
   commit & PR conventions, coverage gate, and the dependency/package-split policy.
 
 ## Build & test
 
 Commands operate **one package at a time** (`--path <package>`, e.g.
-`contracts/access`, `math/core`) — there is no workspace-wide build. The full
+`contracts/access`, `math/core`) - there is no workspace-wide build. The full
 command list (build, test, coverage, lint, doc) is in
 [`CONTRIBUTING.md`](./CONTRIBUTING.md#a-typical-workflow); the required Sui CLI
 version is pinned in [`README.md`](./README.md).
@@ -27,7 +27,7 @@ Review changes against the style guide before committing:
 
 - **Claude Code**: run the `/code-quality` command.
 - **Other agents** (Codex / Cursor / Copilot / Gemini): the slash command is
-  Claude-specific, but the procedure is plain markdown — read and follow
+  Claude-specific, but the procedure is plain markdown - read and follow
   [`.claude/commands/code-quality.md`](./.claude/commands/code-quality.md).
 
 Either way the rules come from `STYLEGUIDE.md`; the procedure restates none of them.
@@ -35,17 +35,17 @@ Either way the rules come from `STYLEGUIDE.md`; the procedure restates none of t
 ## Packages
 
 Each `Move.toml` directory under `contracts/` and `math/` is a separate package.
-For the catalog — what each package/module does, install snippets, docs links —
+For the catalog - what each package/module does, install snippets, docs links -
 read the group and package READMEs (the single source of truth):
 
 - [`contracts/README.md`](./contracts/README.md) + each package's `README.md`
 - [`math/README.md`](./math/README.md) + each package's `README.md`
 
-## Boundaries — do not touch
+## Boundaries - do not touch
 
-- `**/build/` — compiler output (generated)
-- `**/artifacts/` — generated reference data; never hand-edit
-- `audits/` — published audit reports; adding a new report is fine, but don't
+- `**/build/` - compiler output (generated)
+- `**/artifacts/` - generated reference data; never hand-edit
+- `audits/` - published audit reports; adding a new report is fine, but don't
   modify or delete existing ones
 
 For commit & PR conventions and the dependency/package-split policy, see

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,11 +42,11 @@ read the group and package READMEs (the single source of truth):
 - [`math/README.md`](./math/README.md) + each package's `README.md`
 
 For agents **integrating this library into a downstream project** (rather than
-contributing to this repo), [`llms.txt`](./llms.txt) is the discovery entry point —
+contributing to this repo), [`llms.txt`](./llms.txt) is the discovery entry point -
 it points to these catalogs, each package's `examples/`, the generated API reference,
 and `audits/`.
 
-## Boundaries — do not touch
+## Boundaries - do not touch
 
 - `**/build/` - compiler output (generated)
 - `**/artifacts/` - generated reference data; never hand-edit

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 The design decisions behind OpenZeppelin Contracts for Sui and the reasoning
 that holds them together. This document answers **why** the library is shaped
-the way it is. For **how** to write code that fits — naming, ordering, idioms —
+the way it is. For **how** to write code that fits - naming, ordering, idioms -
 see [`STYLEGUIDE.md`](./STYLEGUIDE.md).
 
 This file is read by humans and by AI agents (every Dev3 stage, Codex, Cursor,
@@ -12,7 +12,7 @@ than generic internet patterns.
 ## Overview
 
 OpenZeppelin Contracts for Sui is a collection of secure, reusable Move
-**libraries** — not a dApp. Components are designed to be composed into
+**libraries** - not a dApp. Components are designed to be composed into
 downstream applications via Programmable Transaction Blocks (PTBs), audited
 independently, and adopted piecemeal. Every design choice favours integrator
 safety and composability over end-to-end convenience.
@@ -27,7 +27,7 @@ a `Move.toml` is an independently buildable, independently publishable package.
 
 **The package catalog is owned by the READMEs, not this file.** What each
 package and module does, install snippets, and docs links live in the group
-READMEs and each package's own README — the single source of truth for that
+READMEs and each package's own README - the single source of truth for that
 information:
 
 - [`contracts/README.md`](./contracts/README.md) → per-package READMEs (e.g.
@@ -39,12 +39,12 @@ This document covers only the *principles* behind the layout, never the catalog.
 **Why split into many small packages?** Each package has its own dependency set,
 its own audit surface, and its own published address. Integrators depend only on
 the components they use, and a vulnerability in one package never forces a
-republish of the others — the package boundary is an audit boundary.
+republish of the others - the package boundary is an audit boundary.
 
 **Conventional package layout.** Every package follows the same internal shape:
 
-- `sources/` — public modules; `sources/internal/` for package-private helpers
-- `tests/` — unit tests (mirrors the `sources/` grouping)
+- `sources/` - public modules; `sources/internal/` for package-private helpers
+- `tests/` - unit tests (mirrors the `sources/` grouping)
 
 ## Core design principles
 
@@ -57,15 +57,15 @@ that grow unboundedly. See `openzeppelin_access` for the canonical pattern.
 
 ### Owned vs. shared objects
 
-- **Owned objects** for 1-to-1 relationships — cheaper, no consensus ordering.
+- **Owned objects** for 1-to-1 relationships - cheaper, no consensus ordering.
 - **Shared objects** for multi-user / concurrent access.
 - **Shared-object creation is two functions**: one creates and returns the
-  object, one shares it — so callers can run setup logic before the object
+  object, one shares it - so callers can run setup logic before the object
   becomes shared.
 
 ### Composability first (PTB-friendly)
 
-These are defaults that keep components reusable in PTBs — not absolutes. Some
+These are defaults that keep components reusable in PTBs - not absolutes. Some
 functions legitimately transfer (when transferring *is* the operation's
 semantic); treat those as documented exceptions, not reasons to drop the
 guideline.
@@ -76,7 +76,7 @@ guideline.
 - Mint/create functions should return the created object rather than transferring
   it internally.
 - Return excess coins (even zero-value) rather than transferring them internally.
-- Keep core logic mostly free of `transfer::*` — push transfers to the edges
+- Keep core logic mostly free of `transfer::*` - push transfers to the edges
   (entry functions / the integrator) where practical.
 
 ### Bounded state
@@ -92,7 +92,7 @@ library therefore:
 ## Storage & object model
 
 Prefer explicit, typed storage keys (positional `*Key` structs) for dynamic
-fields over ad-hoc primitive keys — they document intent and prevent key
+fields over ad-hoc primitive keys - they document intent and prevent key
 collisions across features in the same object.
 
 ## Upgrade safety
@@ -104,11 +104,11 @@ be retracted. Design for forward compatibility from day one.
   signature can never change. Expose only the stable external API as `public`;
   keep anything you may want to evolve `public(package)` or private (the rule
   lives in [`STYLEGUIDE.md`](./STYLEGUIDE.md#functions)).
-- **Struct types are immutable across upgrades** — they cannot be deleted,
+- **Struct types are immutable across upgrades** - they cannot be deleted,
   redefined, or have their abilities changed once published. Introduce a struct
   only when its shape is settled.
 - **Error codes are append-only.** Never renumber an existing
-  `#[error(code = N)]` — integrators match on the numeric abort code (the rule
+  `#[error(code = N)]` - integrators match on the numeric abort code (the rule
   lives in [`STYLEGUIDE.md`](./STYLEGUIDE.md#naming)).
 - **Version long-lived shared state** so a module published in a later upgrade
   can reject calls made against a stale version of the object.
@@ -133,7 +133,7 @@ When extending this library with AI assistance:
   consistency across the library outranks local cleverness.
 - **Treat this file and [`STYLEGUIDE.md`](./STYLEGUIDE.md) as authoritative** over
   generic Move/Sui patterns learned from the wider internet.
-- The package split is an audit boundary, not just an organisational one — which
+- The package split is an audit boundary, not just an organisational one - which
   is why changing it (or adding dependencies) requires sign-off; see the policy
   in [`CONTRIBUTING.md`](./CONTRIBUTING.md#commit-and-pr-conventions).
 - Prefer the boring, explicit solution; this is security-critical library code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ As a contributor, you are expected to fork this repository, work on your own for
 ## Code Quality Standards
 
 Coding style and conventions for this repository live in
-[`STYLEGUIDE.md`](./STYLEGUIDE.md) (the single source of truth — naming, section
+[`STYLEGUIDE.md`](./STYLEGUIDE.md) (the single source of truth - naming, section
 ordering, idioms, testing, documentation), with the design rationale in
 [`ARCHITECTURE.md`](./ARCHITECTURE.md). Read those before opening a PR; the items
 below are the hard gates your contribution must clear:
@@ -33,7 +33,7 @@ below are the hard gates your contribution must clear:
 
 ## Commit and PR conventions
 
-The single source of truth for how changes land — humans and agents follow the
+The single source of truth for how changes land - humans and agents follow the
 same rules:
 
 - Use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for
@@ -41,7 +41,7 @@ same rules:
 - Never add a `Co-Authored-By` trailer to commits.
 - Do not include a "Test plan" section in PR descriptions.
 - Do not add dependencies or change the package split without explicit sign-off
-  — the package boundary is an audit boundary (see
+  - the package boundary is an audit boundary (see
   [`ARCHITECTURE.md`](./ARCHITECTURE.md)).
 
 ## A typical workflow

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ sui move build --doc --path <module>
 ```
 
 **AI agents:** [`llms.txt`](./llms.txt) is the discovery entry point for integrating
-this library into a downstream project — it points to the package catalogs, examples,
+this library into a downstream project - it points to the package catalogs, examples,
 generated API reference, and audits.
 
 ## Notes

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -235,7 +235,7 @@ Examples of required rewrites:
 
 - `///` for doc comments (renders in IDEs), `//` for inline technical notes
 - No JavaDoc-style `/** */`
-- Use regular dashes (`-`) instead of em dashes (`—`) in all prose, comments,
+- Use regular dashes (`-`) instead of em dashes (`-`) in all prose, comments,
   and documentation
 - Document struct fields, complex params, and return values
 - Use section headings `#### Parameters`, `#### Returns`, and `#### Aborts` when

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -235,7 +235,7 @@ Examples of required rewrites:
 
 - `///` for doc comments (renders in IDEs), `//` for inline technical notes
 - No JavaDoc-style `/** */`
-- Use regular dashes (`-`) instead of em dashes (`-`) in all prose, comments,
+- Use regular dashes (`-`) instead of em dashes (`—`) in all prose, comments,
   and documentation
 - Document struct fields, complex params, and return values
 - Use section headings `#### Parameters`, `#### Returns`, and `#### Aborts` when

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -4,7 +4,7 @@ The single source of truth for coding style and conventions in this repository.
 It serves humans and AI agents alike: contributors follow it by hand, and every
 Dev3 stage and code-review tool reads it instead of restating the rules.
 
-> Scope: **how** we write Move in this repo — naming, ordering, idioms, testing,
+> Scope: **how** we write Move in this repo - naming, ordering, idioms, testing,
 > documentation. For **why** the library is shaped the way it is (design
 > decisions, package layout, object model), see [`ARCHITECTURE.md`](./ARCHITECTURE.md).
 
@@ -16,7 +16,7 @@ These conventions target **Move 2024** (module label syntax, receiver syntax,
 
 - **Error constants**: `EPascalCase`, declared with `#[error(code = N)]`, type
   `vector<u8>`, plain `"..."` string literal (NOT `b"..."`). Codes are sequential
-  from 0 and **append-only** — never renumber existing errors when adding new
+  from 0 and **append-only** - never renumber existing errors when adding new
   ones. Callers (frontends, integrators, tests in other packages) may match on
   the numeric abort code; renumbering silently breaks them. New errors go at the
   bottom with `code = N+1`.
@@ -27,17 +27,17 @@ These conventions target **Move 2024** (module label syntax, receiver syntax,
 - **CRUD**: `new`/`create`, `empty`, `borrow`/`borrow_mut`, `add`/`remove`,
   `exists`/`contains`, `drop`/`destroy`/`destroy_empty`, `to_name`/`from_name`
 - **Dynamic field keys**: positional struct with `Key` suffix
-- **Generic type parameters**: `T`, `U` — use descriptive names only when they
+- **Generic type parameters**: `T`, `U` - use descriptive names only when they
   materially aid readability
 - No "Potato" in hot-potato struct names
 
 ## Module & Package
 
-- `module my_package::my_module;` — no braces, 2024 edition label syntax
+- `module my_package::my_module;` - no braces, 2024 edition label syntax
 - One module per object/data structure
 - PascalCase package names, snake_case named addresses; prefix named addresses
   with the project name (`openzeppelin_*`)
-- Since Sui 1.45, Sui / MoveStdlib / Bridge / SuiSystem are implicitly imported —
+- Since Sui 1.45, Sui / MoveStdlib / Bridge / SuiSystem are implicitly imported -
   no manual dep declaration needed
 
 ## Section ordering
@@ -48,12 +48,12 @@ Every file must use `// === <Name> ===` delimiters in this order:
 2. `// === Errors ===`
 3. `// === Constants ===`
 4. `// === Structs ===`
-5. `// === Events ===` — placed **after** Structs when both are present in the
+5. `// === Events ===` - placed **after** Structs when both are present in the
    same module; in a dedicated events module, this is the only struct-family
    section and Structs is omitted
-6. `// === Method Exports ===` (if any) — `public use fun ...` receiver-syntax
+6. `// === Method Exports ===` (if any) - `public use fun ...` receiver-syntax
    aliases exposed by this module
-7. `// === Init ===` (if an `init` function is present — place it first)
+7. `// === Init ===` (if an `init` function is present - place it first)
 8. `// === Public Functions ===`
 9. `// === View helpers ===`
 10. `// === Admin Functions ===` (if any)
@@ -70,20 +70,20 @@ be preserved:
 // === Scheduling / delay management ===
 ```
 
-These are intentional organisation aids — do **not** remove them.
+These are intentional organisation aids - do **not** remove them.
 
 Common ordering violations to watch for:
 
 - Constants section appearing before Errors
 - View helpers appearing after Private Functions
 - Witness structs placed in `// === Init ===` instead of `// === Structs ===`
-- `// === Test only helpers ===` (wrong capitalisation — must be
+- `// === Test only helpers ===` (wrong capitalisation - must be
   `// === Test-Only Helpers ===`)
 
 ## Imports
 
 - Don't write `use pkg::mod::{Self};` on its own line when other members of
-  `pkg::mod` are imported elsewhere — merge into a single grouped import:
+  `pkg::mod` are imported elsewhere - merge into a single grouped import:
   `use pkg::mod::{Self, OtherMember};`. A lone `use pkg::mod;` (without `{}`) is
   fine when only the module itself is needed.
 
@@ -93,7 +93,7 @@ Common ordering violations to watch for:
 
 ## Functions
 
-- Use `public` OR `entry` — never combine as `public entry`
+- Use `public` OR `entry` - never combine as `public entry`
 - Write composable functions that return values (for PTB usage); mint/create
   functions should return the object, not transfer it internally
 - Parameter order: **self (receiver object) first → capability second → other
@@ -102,11 +102,11 @@ Common ordering violations to watch for:
   syntax `self.fn(&cap, other_obj, ...)` keeps the cap visible at the call site.
 
   ```move
-  // good — self, cap, rest
+  // good - self, cap, rest
   public fun set_name(account: &mut Account, _: &AdminCap, new_name: String) { ... }
   // call: account.set_name(&cap, new_name)
 
-  // good — self, cap, other object, primitives, Clock, ctx
+  // good - self, cap, other object, primitives, Clock, ctx
   public fun authorize_transfer(
       pool: &mut Pool,
       cap: &AdminCap,
@@ -117,19 +117,19 @@ Common ordering violations to watch for:
   ) { ... }
   // call: pool.authorize_transfer(&cap, &account, amount, &clock, ctx)
 
-  // bad — reversed associativity, reads backwards at the call site
+  // bad - reversed associativity, reads backwards at the call site
   public fun update(_: &AdminCap, account: &mut Account, new_name: String) { ... }
   // call: cap.update(&mut account, new_name)
   ```
 
-- Prefer keeping core logic free of `transfer::*` — return objects instead and
+- Prefer keeping core logic free of `transfer::*` - return objects instead and
   push transfers to the edges. Exceptions exist where transferring *is* the
   operation's semantic; document them rather than working around the guideline
   (see [`ARCHITECTURE.md`](./ARCHITECTURE.md#core-design-principles)).
-- Accept payment by value — `fun pay(payment: Coin<SUI>)`, not
-  `&mut Coin<SUI>` plus an `amount` — so the caller hands over exactly what they
+- Accept payment by value - `fun pay(payment: Coin<SUI>)`, not
+  `&mut Coin<SUI>` plus an `amount` - so the caller hands over exactly what they
   intend; a `&mut Coin` lets the callee draw an unbounded amount.
-- Use `public(package)` or private visibility liberally — only expose the stable
+- Use `public(package)` or private visibility liberally - only expose the stable
   external API as `public`. A `public` signature is permanent across package
   upgrades (see [`ARCHITECTURE.md`](./ARCHITECTURE.md#upgrade-safety)).
 
@@ -152,22 +152,22 @@ Examples of required rewrites:
 - `string::length(&s)` → `s.length()`
 - `vector::length(&v)` → `v.length()`
 
-**Cases that CANNOT use receiver syntax — keep the module-qualified form:**
+**Cases that CANNOT use receiver syntax - keep the module-qualified form:**
 
-- `event::emit(e)` — generic function with no native method binding; always
+- `event::emit(e)` - generic function with no native method binding; always
   write `event::emit(e)`
 - `transfer::transfer(obj, recipient)` / `transfer::public_transfer(...)` /
-  `transfer::share_object(obj)` / `transfer::freeze_object(obj)` — Sui transfer
+  `transfer::share_object(obj)` / `transfer::freeze_object(obj)` - Sui transfer
   builtins have no method aliases by default; keep module-qualified
-- `object::id(&obj)` / `object::id_address(&obj)` — no method alias is
+- `object::id(&obj)` / `object::id_address(&obj)` - no method alias is
   registered for these generic `key` functions; keep as `object::id(&obj)`
 - `dynamic_field::add/borrow/borrow_mut/remove` and
-  `dynamic_object_field::*` — no method alias is registered on `UID`; keep
+  `dynamic_object_field::*` - no method alias is registered on `UID`; keep
   module-qualified (e.g. `dof::add(&mut uid, key, val)`)
 - Constructor / factory free functions where no instance exists yet (e.g.
   `MyStruct::new(...)`)
 - Any free function whose first parameter is a primitive (`u8`..`u256`, `bool`,
-  `address`) — `public use fun fn as u64.method` is rejected by the compiler when
+  `address`) - `public use fun fn as u64.method` is rejected by the compiler when
   the type is from a different package (stdlib). There is no correct workaround
   short of the function being defined in stdlib itself. Do NOT add non-public
   `use fun` workarounds in test modules as a substitute.
@@ -188,7 +188,7 @@ Examples of required rewrites:
 
 ## Collections & object size
 
-- Objects max 250 KB — transactions abort if exceeded
+- Objects max 250 KB - transactions abort if exceeded
 - Use `vector` / `VecSet` / `VecMap` only for bounded collections ≤ 1000 items
 - Use `Table` / `Bag` / `ObjectBag` / `ObjectTable` / `LinkedTable` for large or
   unbounded collections
@@ -203,33 +203,33 @@ Examples of required rewrites:
   `#[test_only]` helpers (compiled only in test mode) and `#[test]` functions
   that exercise private items unreachable from `tests/`. Place all `#[test_only]`
   and `#[test]` items under the `// === Test-Only Helpers ===` section (item 13).
-- Combine attributes: `#[test, expected_failure(abort_code = EMyError)]` —
+- Combine attributes: `#[test, expected_failure(abort_code = EMyError)]` -
   **always reference the error constant by name**, never by numeric literal.
   `abort_code = 5` is brittle: renumbering the error const breaks the test
   silently.
 - Prefer pinning exact values: `assert_eq!(result, exact)` over bound-only
   assertions (`assert!(r >= lo && r <= hi)`). For genuine property tests, use
   Sui's `#[random_test]` attribute.
-- Prefer `assert!(cond)` over `assert!(cond, 0)` — Move 2024 auto-assigns abort
+- Prefer `assert!(cond)` over `assert!(cond, 0)` - Move 2024 auto-assigns abort
   codes when omitted; a literal `0` is meaningless boilerplate.
-- No cleanup in expected-failure tests — just `abort` at the failure boundary.
+- No cleanup in expected-failure tests - just `abort` at the failure boundary.
 - In `_tests` modules: no `test_` prefix on function names; use descriptive names.
 - Use `tx_context::dummy()` for simple tests instead of TestScenario overhead.
 - Use `assert_eq!` (from `std::unit_test`) not `assert!` with abort codes (abort
   codes collide with app errors). Import with `use std::unit_test::assert_eq;`.
 - Use `use std::unit_test::destroy` as the black hole instead of
-  `destroy_for_testing()` (note: `sui::test_utils::destroy` is deprecated — the
+  `destroy_for_testing()` (note: `sui::test_utils::destroy` is deprecated - the
   current Sui compiler emits `E04037` and points to `std::unit_test::destroy`).
 
 ## Lint suppression
 
 - **Do not add `#[allow(lint(...))]` attributes.** Every lint warning must be
   resolved by fixing the underlying code, not by silencing it.
-- If a lint warning cannot be addressed, stop and escalate — do not suppress.
+- If a lint warning cannot be addressed, stop and escalate - do not suppress.
 - An existing `#[allow(lint(...))]` is itself a violation: remove the attribute
   and fix the code it was hiding. If the fix is non-trivial, surface it.
 - `#[allow(...)]` for non-lint diagnostics (e.g. `unused_const`, `unused_use`) is
-  similarly disallowed — fix or remove the offending item.
+  similarly disallowed - fix or remove the offending item.
 
 ## Documentation
 

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -235,6 +235,8 @@ Examples of required rewrites:
 
 - `///` for doc comments (renders in IDEs), `//` for inline technical notes
 - No JavaDoc-style `/** */`
+- Use regular dashes (`-`) instead of em dashes (`—`) in all prose, comments,
+  and documentation
 - Document struct fields, complex params, and return values
 - Use section headings `#### Parameters`, `#### Returns`, and `#### Aborts` when
   relevant; use `-` for list items (not `*`)

--- a/contracts/access/sources/access_control.move
+++ b/contracts/access/sources/access_control.move
@@ -19,7 +19,7 @@
 ///    Foreign role types are rejected at the boundary; they cannot be
 ///    introduced into the non-root role map. The check uses
 ///    `type_name::with_original_ids`, which compares the package's *original*
-///    publish address — so role types introduced in later upgrades to the same
+///    publish address - so role types introduced in later upgrades to the same
 ///    module in the same package pass the check too. The home-module rule
 ///    restricts roles to the same original package and module, not to the same
 ///    package version.
@@ -120,7 +120,7 @@ const EDefaultAdminTransferToSelf: vector<u8> = "Cannot transfer default admin t
 
 // === Constants ===
 
-/// Upper bound on `default_admin_delay_ms` — the configured timelock for
+/// Upper bound on `default_admin_delay_ms` - the configured timelock for
 /// root role transfer / renounce.
 ///
 /// Value: 60 days (≈ 2 calendar months) in milliseconds.
@@ -135,7 +135,7 @@ const MAX_DEFAULT_ADMIN_DELAY_MS: u64 = 60 * 24 * 60 * 60 * 1_000;
 /// increase: for example, raising the delay from 1 day to 60 days would
 /// otherwise mean waiting the full 60 days before the new delay is in force.
 ///
-/// Decreases follow a different rule — see `begin_default_admin_delay_change`.
+/// Decreases follow a different rule - see `begin_default_admin_delay_change`.
 ///
 /// Value: 48 hours in milliseconds.
 const MAX_DELAY_INCREASE_WAIT_MS: u64 = 48 * 60 * 60 * 1_000;
@@ -178,7 +178,7 @@ public struct AccessControl<phantom RootRole> has key, store {
     /// Stored as a dedicated field (not inside `roles`) to express the
     /// singleton constraint directly and simplify transfer and renounce paths.
     default_admin: Option<address>,
-    /// Pending change to the default admin — either a transfer to a specific
+    /// Pending change to the default admin - either a transfer to a specific
     /// new admin or a renounce. See `PendingAdminTransfer`.
     pending_default_admin: Option<PendingAdminTransfer>,
     /// Pending change to `default_admin_delay_ms`. The change becomes effective
@@ -201,10 +201,10 @@ public struct RoleData has store {
 
 /// Snapshot of a pending change to the default admin.
 ///
-/// `new_admin = some(addr)` represents a pending transfer — `addr` accepts
+/// `new_admin = some(addr)` represents a pending transfer - `addr` accepts
 /// after the delay via `accept_default_admin_transfer`.
 ///
-/// `new_admin = none` represents a pending renounce — the current default admin
+/// `new_admin = none` represents a pending renounce - the current default admin
 /// finalizes after the delay via `accept_default_admin_renounce`. The same
 /// pending slot is reused so a transfer and a renounce are mutually
 /// exclusive: scheduling either cancels and overwrites the other.
@@ -231,7 +231,7 @@ public struct PendingDelayChange has drop, store {
 
 /// Emitted when a role is granted to an account.
 ///
-/// Role identifiers are `TypeName`s — they embed the defining package address
+/// Role identifiers are `TypeName`s - they embed the defining package address
 /// and module name of the role struct, so events from independently-published
 /// consumer protocols are distinguishable off-chain.
 public struct RoleGranted<phantom RootRole> has copy, drop {
@@ -241,7 +241,7 @@ public struct RoleGranted<phantom RootRole> has copy, drop {
 
 /// Emitted when a role is removed from an account.
 ///
-/// Role identifiers are `TypeName`s — they embed the defining package address
+/// Role identifiers are `TypeName`s - they embed the defining package address
 /// and module name of the role struct, so events from independently-published
 /// consumer protocols are distinguishable off-chain.
 public struct RoleRevoked<phantom RootRole> has copy, drop {
@@ -251,7 +251,7 @@ public struct RoleRevoked<phantom RootRole> has copy, drop {
 
 /// Emitted when a role's admin role is reconfigured.
 ///
-/// Role identifiers are `TypeName`s — they embed the defining package address
+/// Role identifiers are `TypeName`s - they embed the defining package address
 /// and module name of each role struct, so events from independently-published
 /// consumer protocols are distinguishable off-chain.
 public struct RoleAdminChanged<phantom RootRole> has copy, drop {
@@ -300,7 +300,7 @@ public struct DefaultAdminDelayChangeCancelled<phantom RootRole> has copy, drop 
 /// sender as the initial default admin.
 ///
 /// The caller passes their module's One-Time Witness as `otw`. The runtime
-/// `is_one_time_witness` check confirms the value is genuine — this is what
+/// `is_one_time_witness` check confirms the value is genuine - this is what
 /// enforces Invariant 1 (one registry per module, initialized at first
 /// publish). The transaction sender automatically becomes the default admin.
 /// Prefer this constructor when the publishing transaction sender should be the
@@ -508,7 +508,7 @@ public fun revoke_role<RootRole, Role>(
 }
 
 /// Voluntarily relinquish role `Role`.
-/// No-op if the caller does not hold `Role`. **Blocked on the root role** —
+/// No-op if the caller does not hold `Role`. **Blocked on the root role** -
 /// use `begin_default_admin_renounce` + `accept_default_admin_renounce`
 /// instead, so the protocol gets the configured timelock and a cancel window
 /// before the registry becomes unmanaged.
@@ -589,7 +589,7 @@ public fun set_role_admin<RootRole, Role, AdminRole>(
 ///
 /// Caller must hold the root role. The transfer cannot be accepted until
 /// `default_admin_delay_ms` has elapsed. An existing pending transfer or
-/// renounce is cancelled and overwritten — the caller can correct a wrong
+/// renounce is cancelled and overwritten - the caller can correct a wrong
 /// target (or switch between transfer and renounce) without cancelling first.
 /// If a pending delay change has elapsed, it is applied before scheduling.
 ///
@@ -774,13 +774,13 @@ public fun cancel_default_admin_transfer<RootRole>(
 /// - **Increase** (`new_delay_ms > current`):
 ///   wait = `min(new_delay_ms, MAX_DELAY_INCREASE_WAIT_MS)`.
 ///   The cap exists so a large increase doesn't force you to wait the
-///   entire new value before it takes effect — see `MAX_DELAY_INCREASE_WAIT_MS`.
+///   entire new value before it takes effect - see `MAX_DELAY_INCREASE_WAIT_MS`.
 /// - **Decrease** (`new_delay_ms < current`):
 ///   wait = `current - new_delay_ms`.
 ///   The freed time forces the admin to commit to the change for that
 ///   period before they can schedule new transfers under the shorter delay,
 ///   preserving the protection level of the current delay. (In-flight
-///   transfers / renounces aren't affected by the change anyway — they use
+///   transfers / renounces aren't affected by the change anyway - they use
 ///   the delay they were scheduled under.)
 /// - **No change** (`new_delay_ms == current`): wait = 0.
 ///
@@ -925,7 +925,7 @@ public fun default_admin_delay_ms<RootRole>(ac: &AccessControl<RootRole>, clock:
     effective_default_admin_delay_ms(ac, clock)
 }
 
-/// Whether there is any pending action on the root role — either a
+/// Whether there is any pending action on the root role - either a
 /// transfer or a renounce.
 ///
 /// #### Parameters
@@ -1096,7 +1096,7 @@ fun cancel_pending_default_admin<RootRole>(ac: &mut AccessControl<RootRole>) {
     };
 }
 
-/// Membership check by `TypeName` — used internally when the admin role is
+/// Membership check by `TypeName` - used internally when the admin role is
 /// known only as a `TypeName` value, not as a type parameter. Root role
 /// membership is stored separately as the current default admin.
 fun has_role_by_name<RootRole>(
@@ -1121,7 +1121,7 @@ fun get_role_admin_name<RootRole>(ac: &AccessControl<RootRole>, role: TypeName):
 /// Asserts `Role` and `RootRole` come from the same package + module.
 ///
 /// Uses `with_original_ids` so role types introduced in later upgrades to the
-/// same module still match — the address compared is the package's original
+/// same module still match - the address compared is the package's original
 /// publish ID, which is stable across upgrades. This is the runtime arm of
 /// Invariant 2.
 fun assert_home_module<RootRole, Role>() {

--- a/contracts/access/sources/ownership_transfer/delayed.move
+++ b/contracts/access/sources/ownership_transfer/delayed.move
@@ -137,7 +137,7 @@ public fun wrap<T: key + store>(
     transfer::transfer(wrapper, recipient);
 }
 
-/// Borrow the wrapped object immutably—useful for inspection without touching the schedule.
+/// Borrow the wrapped object immutably-useful for inspection without touching the schedule.
 ///
 /// #### Parameters
 /// - `self`: Wrapper holding the object.
@@ -295,7 +295,7 @@ public fun execute_transfer<T: key + store>(
     transfer::transfer(self, recipient);
 }
 
-/// Complete a previously scheduled unwrap after the delay—return the object and delete the wrapper
+/// Complete a previously scheduled unwrap after the delay-return the object and delete the wrapper
 /// so the owner regains full control.
 ///
 /// #### Parameters

--- a/contracts/access/sources/ownership_transfer/two_step.move
+++ b/contracts/access/sources/ownership_transfer/two_step.move
@@ -152,7 +152,7 @@ public fun wrap<T: key + store>(obj: T, ctx: &mut TxContext): TwoStepTransferWra
     wrapper
 }
 
-/// Borrow the wrapped object immutably—useful for read-only inspection without touching the
+/// Borrow the wrapped object immutably-useful for read-only inspection without touching the
 /// transfer flow.
 ///
 /// #### Parameters

--- a/contracts/access/tests/access_control_tests.move
+++ b/contracts/access/tests/access_control_tests.move
@@ -1,5 +1,5 @@
 // `abort 999` sentinels appear after each known-aborting call in the
-// `expected_failure` tests — they're deliberate, unreachable, and exist only
+// `expected_failure` tests - they're deliberate, unreachable, and exist only
 // to satisfy the type checker on the `ac` / `clk` bindings without rewriting
 // every test as a by-value helper. Suppressed module-wide so individual
 // tests stay clean.
@@ -16,7 +16,7 @@ use sui::test_scenario::{Self, Scenario};
 
 // === Test fixtures ===
 //
-// `ACCESS_CONTROL_TESTS` is the OTW for this module — its name matches the
+// `ACCESS_CONTROL_TESTS` is the OTW for this module - its name matches the
 // module name, so `is_one_time_witness` accepts it as the root role even when
 // constructed manually inside a test. `NotAnOtw` deliberately violates the
 // OTW name convention to exercise the rejection path. The phantom role
@@ -236,7 +236,7 @@ fun test_grant_role_idempotent() {
     let count_after_first = event::events_by_type<
         access_control::RoleGranted<ACCESS_CONTROL_TESTS>,
     >().length();
-    // Second grant to the same account is a no-op — no new event, no abort.
+    // Second grant to the same account is a no-op - no new event, no abort.
     ac.grant_role<_, AdminA>(alice, scenario.ctx());
     let count_after_second = event::events_by_type<
         access_control::RoleGranted<ACCESS_CONTROL_TESTS>,
@@ -346,7 +346,7 @@ fun test_revoke_role_idempotent_non_member() {
         access_control::RoleRevoked<ACCESS_CONTROL_TESTS>,
     >().length();
 
-    // Carol never had the role — revoking is a no-op.
+    // Carol never had the role - revoking is a no-op.
     ac.revoke_role<_, AdminA>(@0xC, scenario.ctx());
     assert_eq!(
         event::events_by_type<access_control::RoleRevoked<ACCESS_CONTROL_TESTS>>().length(),
@@ -437,7 +437,7 @@ fun test_renounce_role_happy_path() {
     scenario.end();
 }
 
-// Direct `renounce_role` on the root role is blocked — the only way to
+// Direct `renounce_role` on the root role is blocked - the only way to
 // relinquish the root role is the timelocked `begin_default_admin_renounce`
 // + `accept_default_admin_renounce` flow. Without this block, a stray
 // renounce call could leave the registry permanently unmanaged with no
@@ -459,7 +459,7 @@ fun test_renounce_role_idempotent_non_member() {
     scenario.next_tx(alice);
     let mut ac = take_ac(&scenario);
 
-    // alice never held AdminA — renounce is a no-op, no event.
+    // alice never held AdminA - renounce is a no-op, no event.
     ac.renounce_role<_, AdminA>(scenario.ctx());
     assert_eq!(
         event::events_by_type<access_control::RoleRevoked<ACCESS_CONTROL_TESTS>>().length(),
@@ -470,7 +470,7 @@ fun test_renounce_role_idempotent_non_member() {
     scenario.end();
 }
 
-// Renounce idempotency: role entry exists, but the caller is not a member —
+// Renounce idempotency: role entry exists, but the caller is not a member -
 // the second early-return path. Distinct from the "no role entry" path covered
 // by the test above.
 #[test]
@@ -481,11 +481,11 @@ fun test_renounce_role_idempotent_existing_role_non_member() {
     let mut scenario = setup(deployer, 0);
     let mut ac = take_ac(&scenario);
 
-    // Grant AdminA to alice — the role entry now exists.
+    // Grant AdminA to alice - the role entry now exists.
     ac.grant_role<_, AdminA>(alice, scenario.ctx());
     test_scenario::return_shared(ac);
 
-    // Carol is not a member of AdminA — exercises the "role entry exists, not
+    // Carol is not a member of AdminA - exercises the "role entry exists, not
     // member" early-return branch.
     scenario.next_tx(carol);
     let mut ac = take_ac(&scenario);
@@ -534,7 +534,7 @@ fun test_set_role_admin_happy_path() {
     assert_eq!(changed[0], expected);
 
     // Grant AdminA to alice. alice can now grant RoleX (chain in effect),
-    // but the deployer (root) no longer can — RoleX's admin is now AdminA.
+    // but the deployer (root) no longer can - RoleX's admin is now AdminA.
     ac.grant_role<_, AdminA>(alice, scenario.ctx());
     test_scenario::return_shared(ac);
 
@@ -561,7 +561,7 @@ fun test_set_role_admin_lazy_create() {
     scenario.end();
 }
 
-// set_role_admin against a role that already has an entry — exercises
+// set_role_admin against a role that already has an entry - exercises
 // the "update existing admin_role" branch (the lazy-create branch is covered
 // by the test above) and asserts the event reports previous = old admin
 // rather than empty / fresh-default.
@@ -576,7 +576,7 @@ fun test_set_role_admin_updates_existing_role() {
     ac.grant_role<_, RoleX>(alice, scenario.ctx());
     assert_eq!(ac.get_role_admin<_, RoleX>(), with_original_ids<ACCESS_CONTROL_TESTS>());
 
-    // Re-target RoleX's admin to AdminA — exercises the "update existing
+    // Re-target RoleX's admin to AdminA - exercises the "update existing
     // entry" branch (the lazy-create branch is covered by the test above).
     ac.set_role_admin<_, RoleX, AdminA>(scenario.ctx());
 
@@ -634,7 +634,7 @@ fun test_set_role_admin_rejects_non_admin_existing_entry() {
     ac.set_role_admin<_, RoleX, AdminA>(scenario.ctx());
 
     // Second call hits the update-existing branch. `previous_admin_role` is
-    // now AdminA — deployer holds root but NOT AdminA, so this must abort.
+    // now AdminA - deployer holds root but NOT AdminA, so this must abort.
     ac.set_role_admin<_, RoleX, AdminB>(scenario.ctx());
     abort 999
 }
@@ -699,7 +699,7 @@ fun test_assert_has_role_passes_for_member() {
     let deployer = @0xA;
     let scenario = setup(deployer, 0);
     let ac = take_ac(&scenario);
-    // Deployer holds root — assert_has_role on root must not abort.
+    // Deployer holds root - assert_has_role on root must not abort.
     ac.assert_has_role<_, ACCESS_CONTROL_TESTS>(deployer);
     test_scenario::return_shared(ac);
     scenario.end();
@@ -719,7 +719,7 @@ fun test_get_role_admin_defaults_to_root() {
     let deployer = @0xA;
     let scenario = setup(deployer, 0);
     let ac = take_ac(&scenario);
-    // RoleX has no entry — get_role_admin returns the protected root.
+    // RoleX has no entry - get_role_admin returns the protected root.
     assert_eq!(ac.get_role_admin<_, RoleX>(), with_original_ids<ACCESS_CONTROL_TESTS>());
     test_scenario::return_shared(ac);
     scenario.end();
@@ -1283,7 +1283,7 @@ fun test_role_hierarchy_chain() {
 
 // Companion to `test_role_hierarchy_chain`: pins that `set_role_admin`
 // *transfers* grant authority rather than duplicating it. After RoleX's admin
-// is shifted to AdminA, the deployer — who still holds root but not AdminA —
+// is shifted to AdminA, the deployer - who still holds root but not AdminA -
 // must no longer be able to grant RoleX. Without this negative assertion, a
 // regression where the previous admin retained grant power would slip past the
 // happy-path test.
@@ -1320,7 +1320,7 @@ fun test_begin_admin_renounce_happy_path() {
     assert!(ac.has_pending_default_admin_transfer());
     assert!(ac.is_pending_default_admin_renounce());
     assert_eq!(ac.default_admin(), option::some(deployer));
-    // Renounce has no incoming admin — `pending_default_admin_new_admin`
+    // Renounce has no incoming admin - `pending_default_admin_new_admin`
     // returns `none` for both "no pending" and "pending renounce". Use
     // `is_pending_default_admin_renounce` to disambiguate (above).
     assert!(ac.pending_default_admin_new_admin().is_none());
@@ -1366,7 +1366,7 @@ fun test_begin_admin_renounce_rejects_non_root() {
 }
 
 // Scheduling a renounce cancels and overwrites an existing pending transfer
-// (and vice versa). The two are mutually exclusive — they share
+// (and vice versa). The two are mutually exclusive - they share
 // `pending_default_admin`.
 #[test]
 fun test_begin_admin_renounce_overwrites_pending_transfer() {
@@ -1532,7 +1532,7 @@ fun test_accept_admin_renounce_rejects_no_pending() {
 }
 
 // `accept_default_admin_renounce` rejects when the pending action is a
-// transfer (not a renounce) — the caller must use the matching accept path.
+// transfer (not a renounce) - the caller must use the matching accept path.
 #[test, expected_failure(abort_code = access_control::ENotPendingRenounce)]
 fun test_accept_admin_renounce_rejects_pending_transfer() {
     let deployer = @0xA;
@@ -1545,7 +1545,7 @@ fun test_accept_admin_renounce_rejects_pending_transfer() {
 }
 
 // `accept_default_admin_transfer` rejects when the pending action is a
-// renounce (not a transfer) — symmetric with the above.
+// renounce (not a transfer) - symmetric with the above.
 #[test, expected_failure(abort_code = access_control::ENotPendingTransfer)]
 fun test_accept_admin_transfer_rejects_pending_renounce() {
     let deployer = @0xA;
@@ -1990,7 +1990,7 @@ fun test_delay_change_getters_when_no_pending() {
 
 // A pending admin transfer was scheduled under the old delay. A delay change
 // then becomes effective. The pending transfer's `execute_after_ms` must not
-// change — in-flight transfers honor the delay they were scheduled under,
+// change - in-flight transfers honor the delay they were scheduled under,
 // regardless of subsequent delay changes.
 #[test]
 fun test_delay_change_does_not_affect_pending_transfer() {

--- a/contracts/access/tests/two_step_tests.move
+++ b/contracts/access/tests/two_step_tests.move
@@ -107,7 +107,7 @@ fun borrow_and_return_roundtrip() {
 
 #[test, expected_failure(abort_code = two_step_transfer::EWrongTwoStepTransferWrapper)]
 fun return_val_rejects_wrong_wrapper() {
-    // Borrow from one wrapper but attempt to return into another—should abort.
+    // Borrow from one wrapper but attempt to return into another-should abort.
     let owner = @0xB;
     let mut ctx = dummy_ctx_with_sender(owner);
     let first = two_step_transfer::wrap(new_cap(&mut ctx), &mut ctx);

--- a/contracts/utils/README.md
+++ b/contracts/utils/README.md
@@ -16,9 +16,9 @@ Embeddable primitives for Sui smart contract development.
 
 Three strategies share the same API:
 
-- **Bucket** ([Wikipedia](https://en.wikipedia.org/wiki/Token_bucket)) — a bucket holds up to `capacity` tokens and refills at a steady rate. Each consume drains tokens; an empty bucket denies the call. Permits short bursts up to `capacity` on top of a sustained average rate, which is what most APIs and on-chain throughput controls actually want.
-- **Fixed window** — time is partitioned into back-to-back windows of `window_ms`, anchored at limiter creation. Each window allows up to `capacity` units and resets to full `capacity` at the boundary. Cheap and easy to reason about; the known trade-off is that a caller can spend the full quota at the end of one window and the full quota at the start of the next, yielding a `2 * capacity` burst across the boundary. Pick it when the quota is the contract (e.g. "100 mints per hour") and the boundary burst is acceptable.
-- **Cooldown** — after `capacity` units are drawn down, the limiter is gated for `cooldown_ms` before any further consumption is allowed; once the gate elapses, the full `capacity` is available again. Equivalent to a "recharge after use" pattern (think action cooldowns in games, or "wait 60s before retrying").
+- **Bucket** ([Wikipedia](https://en.wikipedia.org/wiki/Token_bucket)) - a bucket holds up to `capacity` tokens and refills at a steady rate. Each consume drains tokens; an empty bucket denies the call. Permits short bursts up to `capacity` on top of a sustained average rate, which is what most APIs and on-chain throughput controls actually want.
+- **Fixed window** - time is partitioned into back-to-back windows of `window_ms`, anchored at limiter creation. Each window allows up to `capacity` units and resets to full `capacity` at the boundary. Cheap and easy to reason about; the known trade-off is that a caller can spend the full quota at the end of one window and the full quota at the start of the next, yielding a `2 * capacity` burst across the boundary. Pick it when the quota is the contract (e.g. "100 mints per hour") and the boundary burst is acceptable.
+- **Cooldown** - after `capacity` units are drawn down, the limiter is gated for `cooldown_ms` before any further consumption is allowed; once the gate elapses, the full `capacity` is available again. Equivalent to a "recharge after use" pattern (think action cooldowns in games, or "wait 60s before retrying").
 
 | Variant | When to pick it |
 |---------|-----------------|
@@ -41,13 +41,13 @@ Pick the constructor that matches your policy; the consume and inspect calls are
 use openzeppelin_utils::rate_limiter::{Self, RateLimiter};
 use sui::clock::Clock;
 
-// Bucket — smooth throughput with bursts; cap 1 000, refills 100 units every 6 s, starting full.
+// Bucket - smooth throughput with bursts; cap 1 000, refills 100 units every 6 s, starting full.
 let limiter: RateLimiter = rate_limiter::new_bucket(1_000, 100, 6_000, clock.timestamp_ms(), 1_000, clock);
 
-// Fixed window — hard per-hour quota of 100 units, starting full at the current time.
+// Fixed window - hard per-hour quota of 100 units, starting full at the current time.
 let limiter: RateLimiter = rate_limiter::new_fixed_window(100, 3_600_000, clock.timestamp_ms(), 100, clock);
 
-// Cooldown — up to 1 000 units per batch, then a 60 s gate before the next batch.
+// Cooldown - up to 1 000 units per batch, then a 60 s gate before the next batch.
 let limiter: RateLimiter = rate_limiter::new_cooldown(1_000, 60_000, 0, 1_000, clock);
 
 // Identical hot-path API regardless of variant:

--- a/contracts/utils/examples/rate_limiter/faucet.move
+++ b/contracts/utils/examples/rate_limiter/faucet.move
@@ -3,7 +3,7 @@
 /// The shared `Faucet` carries one global fixed-window limiter that throttles *every*
 /// claimer collectively. On top of that global window, each holder is handed a `ClaimCap`
 /// carrying its own `RateLimiter` (a token bucket) that caps how much that specific holder
-/// can claim. A claim must satisfy both limiters — the holder's personal bucket and the
+/// can claim. A claim must satisfy both limiters - the holder's personal bucket and the
 /// global window.
 ///
 /// # Disclaimer

--- a/contracts/utils/examples/rate_limiter/rare_coin.move
+++ b/contracts/utils/examples/rate_limiter/rare_coin.move
@@ -1,5 +1,5 @@
 /// A throwaway fixed-supply coin used solely to give the `faucet` example something
-/// concrete to hand out. Not part of the rate limiter itself — it just supplies the
+/// concrete to hand out. Not part of the rate limiter itself - it just supplies the
 /// `Balance` the faucet is funded with.
 ///
 /// # Disclaimer

--- a/contracts/utils/examples/rate_limiter/tests/faucet_tests.move
+++ b/contracts/utils/examples/rate_limiter/tests/faucet_tests.move
@@ -122,7 +122,7 @@ fun global_limit_binds_even_if_personal_allows() {
 
     scenario.next_tx(admin);
 
-    // Personal cap of 200 — deliberately above the 100 global window, so the global cap binds first.
+    // Personal cap of 200 - deliberately above the 100 global window, so the global cap binds first.
     issue_claim_cap(&admin_cap, user, 200, 10, 1_000, &clock, scenario.ctx());
 
     scenario.next_tx(user);

--- a/contracts/utils/examples/rate_limiter/tests/mage_duel_tests.move
+++ b/contracts/utils/examples/rate_limiter/tests/mage_duel_tests.move
@@ -80,7 +80,7 @@ fun second_fireball_aborts_before_cooldown_elapses() {
 }
 
 // A defeated mage ends the duel: the killing blow drives health to 0, `is_over` flips true, and
-// `DuelEnded` is emitted. Also exercises the overkill clamp — the final meteor's 30 damage is
+// `DuelEnded` is emitted. Also exercises the overkill clamp - the final meteor's 30 damage is
 // clamped to the defender's remaining 15 health by the `min` in `cast`.
 #[test]
 fun duel_ends_when_a_mage_is_defeated() {
@@ -104,7 +104,7 @@ fun duel_ends_when_a_mage_is_defeated() {
     assert!(!duel.is_over());
 
     // Advance CD_MS so the meteor cooldown releases and mana regenerates. Opponent regenerates
-    // 5 health (1 per 2s) to 15; the next meteor's 30 damage is clamped to that 15 — the killing blow.
+    // 5 health (1 per 2s) to 15; the next meteor's 30 damage is clamped to that 15 - the killing blow.
     clock.increment_for_testing(CD_MS);
     assert_eq!(duel.opponent_health(&clock), 15);
     duel.challenger_cast_meteor(&challenger_cap, &clock);
@@ -255,7 +255,7 @@ fun start_duel(scenario: &mut Scenario, clock: &Clock): (ID, ChallengerCap, Oppo
 }
 
 // Build two independent duels and return duel 2 (taken from the inventory) together with duel 1's
-// caps — so a cast against duel 2 with a duel-1 cap exercises the `EWrongDuel` guard. Duel 2's own
+// caps - so a cast against duel 2 with a duel-1 cap exercises the `EWrongDuel` guard. Duel 2's own
 // caps are discarded; the caller cleans up whichever duel-1 cap it does not use.
 fun two_duels_cross_caps(
     scenario: &mut Scenario,

--- a/contracts/utils/examples/rate_limiter/tests/rare_coin_tests.move
+++ b/contracts/utils/examples/rate_limiter/tests/rare_coin_tests.move
@@ -19,7 +19,7 @@ fun init_mints_fixed_supply_to_publisher() {
 
     let coins = scenario.take_from_sender<Coin<RARE_COIN>>();
     assert_eq!(coins.value(), 10_000);
-    // The whole supply lands in a single coin object — nothing else was minted to the publisher.
+    // The whole supply lands in a single coin object - nothing else was minted to the publisher.
     assert!(!scenario.has_most_recent_for_sender<Coin<RARE_COIN>>());
 
     destroy(coins);

--- a/contracts/utils/tests/rate_limiter_tests.move
+++ b/contracts/utils/tests/rate_limiter_tests.move
@@ -954,7 +954,7 @@ fun reconfigure_fixed_window_via_construct_fresh_preserve_anchor() {
     let initial = if (projected < new_cap) projected else new_cap;
     rl = rate_limiter::new_fixed_window(new_cap, 100, anchor, initial, &clk);
 
-    // Same window as before — rollover still lands at t=100.
+    // Same window as before - rollover still lands at t=100.
     assert_eq!(rl.available(&clk), 3);
     clk.set_for_testing(99);
     assert_eq!(rl.available(&clk), 3);
@@ -1040,7 +1040,7 @@ fun consumes_at_one_timestamp_have_no_txn_scoped_accumulator() {
     assert!(split.try_consume(3, &clk));
     assert!(whole.try_consume(6, &clk));
 
-    // Identical committed state — the per-call decomposition leaves no residue.
+    // Identical committed state - the per-call decomposition leaves no residue.
     assert_eq!(split.available(&clk), whole.available(&clk));
     assert_eq!(split.available(&clk), 4);
 

--- a/llms.txt
+++ b/llms.txt
@@ -3,24 +3,24 @@
 > Audited Move building blocks for the Sui blockchain. Use these reviewed
 > primitives instead of writing access control, math, or rate limiting from scratch.
 
-A pointer file ([llmstxt.org](https://llmstxt.org/)) — nothing is restated here;
+A pointer file ([llmstxt.org](https://llmstxt.org/)) - nothing is restated here;
 follow the links to the sources of truth.
 
 ## Start here
 
 - [ARCHITECTURE.md](ARCHITECTURE.md): why the library is shaped this way and how to compose it
-- [contracts/](contracts/README.md) and [math/](math/README.md): the package catalogs —
+- [contracts/](contracts/README.md) and [math/](math/README.md): the package catalogs -
   browse for the available packages, their MVR slugs, paths, and docs
 
 ## For each package
 
-- **README** — what it does, when to use it, install snippet
-- **`examples/`** — compilable, audited-adjacent integration examples (the composition recipes)
-- **API reference** — generated from doc-comments (`sui move build --doc`), published at
+- **README** - what it does, when to use it, install snippet
+- **`examples/`** - compilable, audited-adjacent integration examples (the composition recipes)
+- **API reference** - generated from doc-comments (`sui move build --doc`), published at
   `https://docs.openzeppelin.com/contracts-sui/1.x/api/<package>`
-- [audits/](audits/README.md) — audit reports and their scope
+- [audits/](audits/README.md) - audit reports and their scope
 
 ## Dependencies
 
 Pin stable releases from the Move Registry (MVR):
-`dep = { r.mvr = "@openzeppelin-move/<package>" }` — see each package's README install snippet for the exact name.
+`dep = { r.mvr = "@openzeppelin-move/<package>" }` - see each package's README install snippet for the exact name.

--- a/math/core/sources/vector.move
+++ b/math/core/sources/vector.move
@@ -26,7 +26,7 @@ const EMedianOfEmptyVector: vector<u8> = "Median of empty vector is undefined";
 ///
 /// #### Bytecode vs. gas trade-off
 ///
-/// As a macro, every call site inlines the full sorting algorithm — roughly 750 bytes of
+/// As a macro, every call site inlines the full sorting algorithm - roughly 750 bytes of
 /// compiled bytecode per call. This module ships no precompiled sorting wrappers, so if you
 /// sort the same element type from more than one place, wrap the macro in a small function in
 /// your own module (e.g. `fun sort(v: &mut vector<u64>) { vector::quick_sort!(v) }`) and call
@@ -70,7 +70,7 @@ public macro fun quick_sort<$Int>($vec: &mut vector<$Int>) {
 ///
 /// #### Bytecode vs. gas trade-off
 ///
-/// As a macro, every call site inlines the full sorting algorithm together with the comparator —
+/// As a macro, every call site inlines the full sorting algorithm together with the comparator -
 /// roughly 750 bytes of compiled bytecode per call. A precompiled wrapper cannot live in this
 /// library because the comparator is a compile-time lambda, which ordinary functions cannot
 /// accept as an argument. If you sort with the same element type and comparator from more than

--- a/math/core/tests/macros/math_ops.move
+++ b/math/core/tests/macros/math_ops.move
@@ -54,7 +54,7 @@ fun checked_shl_returns_some() {
 
 #[test]
 fun checked_shl_detects_high_bits() {
-    // Highest bit of u256 set — shifting would overflow the 256-bit range.
+    // Highest bit of u256 set - shifting would overflow the 256-bit range.
     let result = macros::checked_shl!(std::u256::max_value!(), 1);
     assert_eq!(result, option::none());
 }

--- a/math/core/tests/macros/median.move
+++ b/math/core/tests/macros/median.move
@@ -286,7 +286,7 @@ fun median_even_length_rounds_up() {
 
 #[test]
 fun median_even_length_rounds_nearest_half_rounds_up() {
-    // (1 + 2) / 2 = 1.5 — rounding::nearest() rounds half-up
+    // (1 + 2) / 2 = 1.5 - rounding::nearest() rounds half-up
     assert_eq!(vector::median_u64(&vector[1u64, 2], rounding::nearest()), 2u64);
 }
 

--- a/math/core/tests/u128_tests.move
+++ b/math/core/tests/u128_tests.move
@@ -51,7 +51,7 @@ fun checked_shl_returns_same_for_zero_shift() {
 
 #[test]
 fun checked_shl_detects_high_bits() {
-    // Highest bit already set — shifting would overflow.
+    // Highest bit already set - shifting would overflow.
     let result = u128::checked_shl(1u128 << 127, 1);
     assert_eq!(result, option::none());
 }

--- a/math/core/tests/u256_tests.move
+++ b/math/core/tests/u256_tests.move
@@ -53,7 +53,7 @@ fun checked_shl_returns_same_for_zero_shift() {
 
 #[test]
 fun checked_shl_detects_high_bits() {
-    // Highest bit already set — shifting again should fail.
+    // Highest bit already set - shifting again should fail.
     let result = u256::checked_shl(1u256 << 255, 1);
     assert_eq!(result, option::none());
 }
@@ -90,7 +90,7 @@ fun checked_shr_handles_top_bit() {
 
 #[test]
 fun checked_shr_detects_set_bits() {
-    // LSB set — shifting by one would drop it.
+    // LSB set - shifting by one would drop it.
     let result = u256::checked_shr(5, 1);
     assert_eq!(result, option::none());
 }

--- a/math/core/tests/u64_tests.move
+++ b/math/core/tests/u64_tests.move
@@ -51,7 +51,7 @@ fun checked_shl_returns_same_for_zero_shift() {
 
 #[test]
 fun checked_shl_detects_high_bits() {
-    // Top bit already set — shifting would overflow.
+    // Top bit already set - shifting would overflow.
     let result = u64::checked_shl(1 << 63, 1);
     assert_eq!(result, option::none());
 }

--- a/math/fixed_point/sources/internal/common.move
+++ b/math/fixed_point/sources/internal/common.move
@@ -22,7 +22,7 @@ const ELogOfZero: vector<u8> = "Logarithm of zero is undefined";
 ///
 /// Error analysis: in the squaring loop, error in `y` grows ~2× per iteration
 /// (since `y_new = y_old^2 / internal`), but a wrong bit at iteration `i`
-/// only perturbs `frac` by `internal / 2^(i+1)` — exponentially decaying, so
+/// only perturbs `frac` by `internal / 2^(i+1)` - exponentially decaying, so
 /// late-iteration errors contribute little. Empirically the total `frac`
 /// error stays under `~10^3` at scale `10^18`, well below one user-facing
 /// ulp (unit in the last place, `10^9`). A 9-decimal variant would lack the
@@ -151,7 +151,7 @@ public(package) macro fun log10_2_e18(): u128 {
 ///   raw form.
 public(package) fun apply_log2_factor(log2_mag_e18: u128, factor_e18: u128): u128 {
     // `log2_mag_e18 < 2^67` and `factor_e18 < 2^60`, so the product reaches up
-    // to ~2^127 — right at the `u128` boundary. `u128::mul_div` widens the
+    // to ~2^127 - right at the `u128` boundary. `u128::mul_div` widens the
     // product to `u256` internally before dividing, so the intermediate value
     // never overflows; the final quotient (after `/ 10^27`) safely fits back
     // in `u128`.
@@ -186,12 +186,12 @@ public(package) fun apply_log2_factor(log2_mag_e18: u128, factor_e18: u128): u12
 /// - `x_raw >= scale` (`n_abs = floor(log2(x_raw / 10^9))`): the magnitude
 ///   is at most 2 user-facing ulps below the true magnitude, monotone-down.
 ///   The dominant loss is the `x_raw >> n_abs` truncation, which discards up
-///   to `n_abs` low-order bits — so the deficit grows with `n_abs` and
+///   to `n_abs` low-order bits - so the deficit grows with `n_abs` and
 ///   reaches the 2-ulp ceiling at `x_raw = u128::MAX`.
 /// - `x_raw < scale`: normalization is a lossless left shift, so the only
 ///   loss is the loop's round-down of `frac`. Since `frac` is subtracted
 ///   here, that round-down leaves the magnitude at or slightly above the
-///   true magnitude — a sub-ulp upward bias.
+///   true magnitude - a sub-ulp upward bias.
 ///
 /// The user-facing rounding this induces on negative results (toward zero,
 /// with rare 1-ulp edge cases) is documented on `SD29x9::log2`.

--- a/math/fixed_point/sources/ud30x9/ud30x9_base.move
+++ b/math/fixed_point/sources/ud30x9/ud30x9_base.move
@@ -269,7 +269,7 @@ public fun unchecked_lshift(x: UD30x9, bits: u8): UD30x9 {
 /// #### Aborts
 /// - `ELogUndefined` if `x` is zero.
 /// - `ELogResultUnrepresentable` if `x` is in `(0, 1)` (the result would be negative
-///   and cannot be represented in `UD30x9` — use `SD29x9` instead).
+///   and cannot be represented in `UD30x9` - use `SD29x9` instead).
 public fun ln(x: UD30x9): UD30x9 {
     let raw = x.unwrap();
     assert!(raw > 0, ELogUndefined);
@@ -297,7 +297,7 @@ public fun ln(x: UD30x9): UD30x9 {
 /// #### Aborts
 /// - `ELogUndefined` if `x` is zero.
 /// - `ELogResultUnrepresentable` if `x` is in `(0, 1)` (the result would be negative
-///   and cannot be represented in `UD30x9` — use `SD29x9` instead).
+///   and cannot be represented in `UD30x9` - use `SD29x9` instead).
 public fun log10(x: UD30x9): UD30x9 {
     let raw = x.unwrap();
     assert!(raw > 0, ELogUndefined);
@@ -328,7 +328,7 @@ public fun log10(x: UD30x9): UD30x9 {
 /// #### Aborts
 /// - `ELogUndefined` if `x` is zero.
 /// - `ELogResultUnrepresentable` if `x` is in `(0, 1)` (the result would be negative
-///   and cannot be represented in `UD30x9` — use `SD29x9` instead).
+///   and cannot be represented in `UD30x9` - use `SD29x9` instead).
 public fun log2(x: UD30x9): UD30x9 {
     let raw = x.unwrap();
     assert!(raw > 0, ELogUndefined);


### PR DESCRIPTION
PR #388's repo-wide em-dash → `-` replace also hit the **literal em-dash this rule uses as its example**, leaving the nonsensical "use `-` instead of em dashes (`-`)". Restore the example character.

This one line is the single intentional `—` in the repo (it has to show the character it tells you to avoid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized punctuation and typography across all documentation files, code comments, and guides by replacing em-dashes with standard hyphens and normalizing formatting throughout.

* **Style**
  * Improved overall readability and consistency by adjusting line wrapping, dash formatting, and text layout in markdown, configuration, and source files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->