### PR TITLE
fix: restore the em-dash example in the no-em-dash STYLEGUIDE rule

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -235,7 +235,7 @@ Examples of required rewrites:
 
 - `///` for doc comments (renders in IDEs), `//` for inline technical notes
 - No JavaDoc-style `/** */`
-- Use regular dashes (`-`) instead of em dashes (`-`) in all prose, comments,
+- Use regular dashes (`-`) instead of em dashes (`—`) in all prose, comments,
   and documentation
 - Document struct fields, complex params, and return values
 - Use section headings `#### Parameters`, `#### Returns`, and `#### Aborts` when


### PR DESCRIPTION
PR #388's repo-wide em-dash → `-` replace also hit the **literal em-dash this rule uses as its example**, leaving the nonsensical "use `-` instead of em dashes (`-`)". Restore the example character.

This one line is the single intentional `—` in the repo (the rule has to show the character it tells you to avoid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated style guidelines to standardize punctuation conventions for contributed content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->