### PR TITLE
build: bump Sui CLI to 1.73.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ permissions:
   pull-requests: write
 
 env:
-  SUI_VERSION: "1.72.5"
+  SUI_VERSION: "1.73.2"
 
 jobs:
   setup:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Sui smart contracts are written in Move leveraging the Sui Move framework.
 
 Follow the installation guide in the [Sui documentation](https://docs.sui.io/guides/developer/getting-started/sui-install).
 
-**Required version**: Sui CLI [1.72.5](https://github.com/MystenLabs/sui/releases/tag/mainnet-v1.72.5).
+**Required version**: Sui CLI [1.73.2](https://github.com/MystenLabs/sui/releases/tag/mainnet-v1.73.2).
 
 ## Docs
 


### PR DESCRIPTION
## Summary

Bumps the required Sui CLI version from `1.72.5` to [`1.73.2`](https://github.com/MystenLabs/sui/releases/tag/mainnet-v1.73.2).

- `.github/workflows/test.yml` — `SUI_VERSION` env updated to `1.73.2`
- `README.md` — documented required version + release link updated

Mirrors the established bump pattern (cf. #368, #324): only the two version-pin sites are touched. `Published.toml` `toolchain-version` fields are publish-time artifacts and are intentionally left untouched.

## Verification

CI runs the full build/test suite against the new CLI version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Sui CLI version requirement from mainnet-v1.72.5 to mainnet-v1.73.2

* **Documentation**
  * Updated installation documentation to reflect the new Sui CLI version requirement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->