### PR TITLE
docs: drop audit-status claim from llms.txt examples line

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -16,7 +16,7 @@ follow the links to the sources of truth.
 ## For each package
 
 - **README** - what it does, when to use it, install snippet
-- **`examples/`** - compilable, audited-adjacent integration examples (the composition recipes)
+- **`examples/`** - compilable integration examples (composition recipes)
 - **API reference** - generated from doc-comments (`sui move build --doc`), published at
   `https://docs.openzeppelin.com/contracts-sui/1.x/api/<package>`
 - [audits/](audits/README.md) - audit reports and their scope


### PR DESCRIPTION
Examples aren't audited (high-level review only); `audited-adjacent` overstated it. Now just "integration examples (composition recipes)".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation to better characterize examples as compilable integration examples serving as composition recipes, helping users understand how to utilize these resources as reference implementations and practical templates for building their own integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->