### PR TITLE
docs: improve llms.txt agent discoverability (absolute links + README pointers)

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -2,6 +2,8 @@
 
 OpenZeppelin building blocks for Sui smart contracts development.
 
+**AI agents:** [`llms.txt`](../llms.txt) is the discovery entry point for integrating this library into a downstream project.
+
 ---
 
 ## Packages

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -2,7 +2,7 @@
 
 OpenZeppelin building blocks for Sui smart contracts development.
 
-**AI agents:** [`llms.txt`](../llms.txt) is the discovery entry point for integrating this library into a downstream project.
+**AI agents:** [`llms.txt`](https://raw.githubusercontent.com/OpenZeppelin/contracts-sui/main/llms.txt) is the discovery entry point for integrating this library into a downstream project.
 
 ---
 

--- a/contracts/access/README.md
+++ b/contracts/access/README.md
@@ -89,5 +89,5 @@ Docs:
 
 - [Access package overview](https://docs.openzeppelin.com/contracts-sui/1.x/access)
 - [Access API reference](https://docs.openzeppelin.com/contracts-sui/1.x/api/access)
-- [`llms.txt`](../../llms.txt): discovery entry point for AI integrators
+- [`llms.txt`](https://raw.githubusercontent.com/OpenZeppelin/contracts-sui/main/llms.txt): discovery entry point for AI integrators
 - [OpenZeppelin Contracts for Sui](https://docs.openzeppelin.com/contracts-sui)

--- a/contracts/access/README.md
+++ b/contracts/access/README.md
@@ -89,4 +89,5 @@ Docs:
 
 - [Access package overview](https://docs.openzeppelin.com/contracts-sui/1.x/access)
 - [Access API reference](https://docs.openzeppelin.com/contracts-sui/1.x/api/access)
+- [`llms.txt`](../../llms.txt): discovery entry point for AI integrators
 - [OpenZeppelin Contracts for Sui](https://docs.openzeppelin.com/contracts-sui)

--- a/contracts/allowance/README.md
+++ b/contracts/allowance/README.md
@@ -126,5 +126,5 @@ Complete integration examples live in [`examples/spend_vault/`](examples/spend_v
 
 - [Allowance package overview](https://docs.openzeppelin.com/contracts-sui/1.x/allowance)
 - [Allowance API reference](https://docs.openzeppelin.com/contracts-sui/1.x/api/allowance)
-- [`llms.txt`](../../llms.txt): discovery entry point for AI integrators
+- [`llms.txt`](https://raw.githubusercontent.com/OpenZeppelin/contracts-sui/main/llms.txt): discovery entry point for AI integrators
 - [OpenZeppelin Contracts for Sui](https://docs.openzeppelin.com/contracts-sui)

--- a/contracts/allowance/README.md
+++ b/contracts/allowance/README.md
@@ -126,4 +126,5 @@ Complete integration examples live in [`examples/spend_vault/`](examples/spend_v
 
 - [Allowance package overview](https://docs.openzeppelin.com/contracts-sui/1.x/allowance)
 - [Allowance API reference](https://docs.openzeppelin.com/contracts-sui/1.x/api/allowance)
+- [`llms.txt`](../../llms.txt): discovery entry point for AI integrators
 - [OpenZeppelin Contracts for Sui](https://docs.openzeppelin.com/contracts-sui)

--- a/contracts/finance/README.md
+++ b/contracts/finance/README.md
@@ -297,4 +297,5 @@ one per integration boundary described above:
 
 - [Finance package overview](https://docs.openzeppelin.com/contracts-sui/1.x/finance)
 - [Finance API reference](https://docs.openzeppelin.com/contracts-sui/1.x/api/finance)
+- [`llms.txt`](../../llms.txt): discovery entry point for AI integrators
 - [OpenZeppelin Contracts for Sui](https://docs.openzeppelin.com/contracts-sui)

--- a/contracts/finance/README.md
+++ b/contracts/finance/README.md
@@ -297,5 +297,5 @@ one per integration boundary described above:
 
 - [Finance package overview](https://docs.openzeppelin.com/contracts-sui/1.x/finance)
 - [Finance API reference](https://docs.openzeppelin.com/contracts-sui/1.x/api/finance)
-- [`llms.txt`](../../llms.txt): discovery entry point for AI integrators
+- [`llms.txt`](https://raw.githubusercontent.com/OpenZeppelin/contracts-sui/main/llms.txt): discovery entry point for AI integrators
 - [OpenZeppelin Contracts for Sui](https://docs.openzeppelin.com/contracts-sui)

--- a/contracts/utils/README.md
+++ b/contracts/utils/README.md
@@ -102,4 +102,5 @@ Complete integration examples live in [`examples/rate_limiter/`](examples/rate_l
 
 - [Utils package overview](https://docs.openzeppelin.com/contracts-sui/1.x/utils)
 - [Utils API reference](https://docs.openzeppelin.com/contracts-sui/1.x/api/utils)
+- [`llms.txt`](../../llms.txt): discovery entry point for AI integrators
 - [OpenZeppelin Contracts for Sui](https://docs.openzeppelin.com/contracts-sui)

--- a/contracts/utils/README.md
+++ b/contracts/utils/README.md
@@ -102,5 +102,5 @@ Complete integration examples live in [`examples/rate_limiter/`](examples/rate_l
 
 - [Utils package overview](https://docs.openzeppelin.com/contracts-sui/1.x/utils)
 - [Utils API reference](https://docs.openzeppelin.com/contracts-sui/1.x/api/utils)
-- [`llms.txt`](../../llms.txt): discovery entry point for AI integrators
+- [`llms.txt`](https://raw.githubusercontent.com/OpenZeppelin/contracts-sui/main/llms.txt): discovery entry point for AI integrators
 - [OpenZeppelin Contracts for Sui](https://docs.openzeppelin.com/contracts-sui)

--- a/llms.txt
+++ b/llms.txt
@@ -9,8 +9,8 @@ follow the links to the sources of truth.
 
 ## Start here
 
-- [ARCHITECTURE.md](ARCHITECTURE.md): why the library is shaped this way and how to compose it
-- [contracts/](contracts/README.md) and [math/](math/README.md): the package catalogs -
+- [ARCHITECTURE.md](https://raw.githubusercontent.com/OpenZeppelin/contracts-sui/main/ARCHITECTURE.md): why the library is shaped this way and how to compose it
+- [contracts/](https://raw.githubusercontent.com/OpenZeppelin/contracts-sui/main/contracts/README.md) and [math/](https://raw.githubusercontent.com/OpenZeppelin/contracts-sui/main/math/README.md): the package catalogs -
   browse for the available packages, their MVR slugs, paths, and docs
 
 ## For each package
@@ -19,7 +19,7 @@ follow the links to the sources of truth.
 - **`examples/`** - compilable integration examples (composition recipes)
 - **API reference** - generated from doc-comments (`sui move build --doc`), published at
   `https://docs.openzeppelin.com/contracts-sui/1.x/api/<package>`
-- [audits/](audits/README.md) - audit reports and their scope
+- [audits/](https://raw.githubusercontent.com/OpenZeppelin/contracts-sui/main/audits/README.md) - audit reports and their scope
 
 ## Dependencies
 

--- a/math/README.md
+++ b/math/README.md
@@ -2,7 +2,7 @@
 
 Math primitives for Sui DeFi, implemented as pure functions (no on-chain storage).
 
-**AI agents:** [`llms.txt`](../llms.txt) is the discovery entry point for integrating this library into a downstream project.
+**AI agents:** [`llms.txt`](https://raw.githubusercontent.com/OpenZeppelin/contracts-sui/main/llms.txt) is the discovery entry point for integrating this library into a downstream project.
 
 ## Packages
 

--- a/math/README.md
+++ b/math/README.md
@@ -2,6 +2,8 @@
 
 Math primitives for Sui DeFi, implemented as pure functions (no on-chain storage).
 
+**AI agents:** [`llms.txt`](../llms.txt) is the discovery entry point for integrating this library into a downstream project.
+
 ## Packages
 
 | Package | MVR | Move package | Docs | Highlights |

--- a/math/core/README.md
+++ b/math/core/README.md
@@ -70,5 +70,5 @@ let med = vector::median!(&vector[5u64, 1, 9, 3, 7], rounding::down());
 
 - [Integer math package overview](https://docs.openzeppelin.com/contracts-sui/1.x/math)
 - [Integer math API reference](https://docs.openzeppelin.com/contracts-sui/1.x/api/math)
-- [`llms.txt`](../../llms.txt): discovery entry point for AI integrators
+- [`llms.txt`](https://raw.githubusercontent.com/OpenZeppelin/contracts-sui/main/llms.txt): discovery entry point for AI integrators
 - [OpenZeppelin Contracts for Sui](https://docs.openzeppelin.com/contracts-sui)

--- a/math/core/README.md
+++ b/math/core/README.md
@@ -70,4 +70,5 @@ let med = vector::median!(&vector[5u64, 1, 9, 3, 7], rounding::down());
 
 - [Integer math package overview](https://docs.openzeppelin.com/contracts-sui/1.x/math)
 - [Integer math API reference](https://docs.openzeppelin.com/contracts-sui/1.x/api/math)
+- [`llms.txt`](../../llms.txt): discovery entry point for AI integrators
 - [OpenZeppelin Contracts for Sui](https://docs.openzeppelin.com/contracts-sui)

--- a/math/fixed_point/README.md
+++ b/math/fixed_point/README.md
@@ -142,4 +142,5 @@ let third_up = one.div_away(ud30x9::wrap(3000000000)); // 0.333333334
 
 - [Fixed-point math package overview](https://docs.openzeppelin.com/contracts-sui/1.x/fixed-point)
 - [Fixed-point math API reference](https://docs.openzeppelin.com/contracts-sui/1.x/api/fixed-point)
+- [`llms.txt`](../../llms.txt): discovery entry point for AI integrators
 - [OpenZeppelin Contracts for Sui](https://docs.openzeppelin.com/contracts-sui)

--- a/math/fixed_point/README.md
+++ b/math/fixed_point/README.md
@@ -142,5 +142,5 @@ let third_up = one.div_away(ud30x9::wrap(3000000000)); // 0.333333334
 
 - [Fixed-point math package overview](https://docs.openzeppelin.com/contracts-sui/1.x/fixed-point)
 - [Fixed-point math API reference](https://docs.openzeppelin.com/contracts-sui/1.x/api/fixed-point)
-- [`llms.txt`](../../llms.txt): discovery entry point for AI integrators
+- [`llms.txt`](https://raw.githubusercontent.com/OpenZeppelin/contracts-sui/main/llms.txt): discovery entry point for AI integrators
 - [OpenZeppelin Contracts for Sui](https://docs.openzeppelin.com/contracts-sui)


### PR DESCRIPTION
Two small changes so AI agents reliably find and use the repo's `llms.txt`:

- **`llms.txt` links → absolute (raw).** Fetched raw (how an agent consumes it), the relative links (`ARCHITECTURE.md`, `contracts/README.md`, …) resolved to nothing. Now point at `raw.githubusercontent.com` so the pointer file works standalone, off-domain.
- **README pointers.** The catalog READMEs (`contracts/`, `math/`) and each per-package README now point at `llms.txt` as the AI-integrator discovery entry point — so an agent landing mid-repo (on the package it depends on, not the root) still finds the entry point.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated `llms.txt` to use direct, stable raw links for the architecture and package catalog.
  * Added an `audits/` catalog entry in `llms.txt` for discovering audit reports and scope.
  * Added “AI agents”/“Learn More” discovery bullets linking to `llms.txt` across multiple README files (including raw GitHub links).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->