### PR TITLE
ci: split fast tests from coverage tracing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,7 +103,7 @@ jobs:
     name: Test ${{ matrix.package }}
     needs: [setup, lint]
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,14 +99,13 @@ jobs:
         run: sui move build --doc
         working-directory: ./${{ matrix.package }}
 
+  # Fast, untraced run: the primary regression gate. Finishes in seconds even
+  # for the heaviest suites, so a failing test is reported quickly.
   test:
     name: Test ${{ matrix.package }}
     needs: [setup, lint]
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: read
-      pull-requests: write
+    timeout-minutes: 15
     strategy:
       fail-fast: true
       matrix:
@@ -121,7 +120,42 @@ jobs:
           version: ${{ env.SUI_VERSION }}
 
       - name: Run tests
-        run: sui move test --trace
+        run: sui move test
+        working-directory: ./${{ matrix.package }}
+
+  # Coverage runs separately because `sui move test --trace` (required by
+  # `sui move coverage lcov`) traces every VM instruction and is orders of
+  # magnitude slower than a plain test run - the randomized sort/median tests in
+  # `math/core` alone emit multi-gigabyte traces. Keeping it out of the gate
+  # means regressions surface fast in `test`, and a slow trace never blocks a
+  # merge (`continue-on-error`). It only runs once `test` is green.
+  coverage:
+    name: Coverage ${{ matrix.package }}
+    needs: [test]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    continue-on-error: true
+    permissions:
+      contents: read
+      pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ fromJson(needs.setup.outputs.packages) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Restore Sui CLI
+        uses: ./.github/actions/restore-sui
+        with:
+          version: ${{ env.SUI_VERSION }}
+
+      - name: Run tests with tracing
+        # `--rand-num-iters 1`: coverage only needs each line executed once. The
+        # full randomized property iterations run in the `test` job above, so a
+        # single iteration here keeps trace volume down without losing coverage.
+        run: sui move test --trace --rand-num-iters 1
         working-directory: ./${{ matrix.package }}
 
       - name: Generate Codecov report

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,7 +131,9 @@ jobs:
   # merge (`continue-on-error`). It only runs once `test` is green.
   coverage:
     name: Coverage ${{ matrix.package }}
-    needs: [test]
+    # `setup` is needed for the package matrix below; `test` gates this on a
+    # green fast run so we never trace a broken build.
+    needs: [setup, test]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     continue-on-error: true


### PR DESCRIPTION
## What

Splits the single `test` job into two, per @0xNeshi's review:

- **`test`** — `sui move test` (no tracing): the fast regression gate (~5s even for `math/core`). Gates merges.
- **`coverage`** — `sui move test --trace` + `sui move coverage lcov` + Codecov: isolated, `continue-on-error: true` (informational, never blocks a merge), runs only after `test` is green.

## Why the 30-minute bump wasn't enough

Profiled `math/core` locally (Sui 1.71.1):

- `sui move test` (no trace): **~5.5s**.
- `sui move test --trace` (what CI runs): the single random test `median_matches_sorted_reference_u256` alone takes **7m21s and writes 4.1 GB** of traces. It `quick_sort!`s a Sui-generated random `vector<u256>` that can be very large, and `--trace` (full mode) records every VM instruction. The whole suite is many GB and never finishes inside 30 min.

`--trace` (full) is mandatory for `sui move coverage lcov` — the lighter `--trace function-only` / `instruction-only` modes produce no line records — so the cost can't simply be switched off.

## The fix

@0xNeshi's split keeps the gate fast and moves the slow trace off the critical path. The coverage job also passes `--rand-num-iters 1`: coverage only needs each line executed once, and the full randomized property iterations still run in the fast `test` job, so this cuts trace volume without losing coverage.

## Deferred follow-ups (`math/core`'s domain)

- The durable cure for the trace time is bounding the random vector length in `math/core`'s ~9 heavy `median`/`quick_sort` random tests (one of them produces the 4.1 GB above). Left out here since it changes those property tests.
- `traces/` is not gitignored — worth adding so a local `--trace` run can't accidentally commit gigabytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Split automated checks into two stages for a faster primary test run and a separate coverage run.
  * Kept the main test job on a shorter timeout while allowing coverage collection to run independently.
  * Adjusted coverage execution to reduce trace output and improve reliability of test reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->