### PR TITLE
build: remove redundant [addresses] section from Move.toml

### DIFF
--- a/contracts/access/Move.toml
+++ b/contracts/access/Move.toml
@@ -1,6 +1,3 @@
 [package]
 name = "openzeppelin_access"
 edition = "2024"
-
-[addresses]
-openzeppelin_access = "0x0"

--- a/contracts/allowance/Move.toml
+++ b/contracts/allowance/Move.toml
@@ -1,6 +1,3 @@
 [package]
 name = "openzeppelin_allowance"
 edition = "2024"
-
-[addresses]
-openzeppelin_allowance = "0x0"

--- a/contracts/finance/Move.toml
+++ b/contracts/finance/Move.toml
@@ -4,6 +4,3 @@ edition = "2024"
 
 [dependencies]
 openzeppelin_math = { local = "../../math/core" }
-
-[addresses]
-openzeppelin_finance = "0x0"

--- a/contracts/utils/Move.toml
+++ b/contracts/utils/Move.toml
@@ -1,6 +1,3 @@
 [package]
 name = "openzeppelin_utils"
 edition = "2024"
-
-[addresses]
-openzeppelin_utils = "0x0"

--- a/math/core/Move.toml
+++ b/math/core/Move.toml
@@ -1,6 +1,3 @@
 [package]
 name = "openzeppelin_math"
 edition = "2024"
-
-[addresses]
-openzeppelin_math = "0x0"

--- a/math/fixed_point/Move.toml
+++ b/math/fixed_point/Move.toml
@@ -4,6 +4,3 @@ edition = "2024"
 
 [dependencies]
 openzeppelin_math = { local = "../core" }
-
-[addresses]
-openzeppelin_fp_math = "0x0"


### PR DESCRIPTION
This section is not necessary since Sui 1.63 (see [Migration guide](https://docs.sui.io/references/package-managers/package-manager-migration#migrating-movetoml)).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed several explicit package address settings from Move package manifests.
  * Simplified project configuration while keeping package metadata and dependencies unchanged.
  * No user-facing functionality or public interfaces were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->