### PR TITLE
feat: Make VestingWallet work with address balances

### DIFF
--- a/contracts/finance/Move.lock
+++ b/contracts/finance/Move.lock
@@ -4,6 +4,30 @@
 [move]
 version = 4
 
+[pinned.mainnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "718ae563a42fb4ba0d055588f81c704dcef58c25" }
+use_environment = "mainnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.mainnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "718ae563a42fb4ba0d055588f81c704dcef58c25" }
+use_environment = "mainnet"
+manifest_digest = "CD547CB1ACCE0880C835DAED2D8FFCB91D56C833AE5240D3AA5B918398263195"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.mainnet.openzeppelin_finance]
+source = { root = true }
+use_environment = "mainnet"
+manifest_digest = "7C0AA1FA8A2A8D05C350DF6C1B74B7E5015BC8CD5A2FE59EAD29F5FE7D910B36"
+deps = { openzeppelin_math = "openzeppelin_math", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.mainnet.openzeppelin_math]
+source = { local = "../../math/core" }
+use_environment = "mainnet"
+manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
 [pinned.testnet.MoveStdlib]
 source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "718ae563a42fb4ba0d055588f81c704dcef58c25" }
 use_environment = "testnet"

--- a/contracts/finance/README.md
+++ b/contracts/finance/README.md
@@ -228,7 +228,7 @@ To author a new curve, follow the `vesting_wallet_linear` pattern:
    build the wallet itself without routing through `new`.
 3. A `vested_amount(&VestingWallet<MyCurve, MyParams, C>, &Clock): VestedAmount<MyCurve>`
    that evaluates the curve and ends in `wallet.mint_vested_amount(MyCurve {}, amount)`.
-4. A teardown that calls `wallet.destroy_empty()` for a `DestroyReceipt<MyCurve,
+4. A teardown that calls `wallet.destroy_empty(root)` for a `DestroyReceipt<MyCurve,
    MyParams>`, then `vesting_wallet::consume_receipt(receipt, MyCurve {})` to recover
    the beneficiary and parameters and destructure them. `destroy_empty` is permissionless;
    the witness-gated `consume_receipt` is what lets the curve run teardown logic or veto.

--- a/contracts/finance/README.md
+++ b/contracts/finance/README.md
@@ -184,10 +184,9 @@ public fun inner<S: drop, P: copy + drop + store, C>(
 public fun release<S: drop, P: copy + drop + store, C>(
     self: &mut GatedVault<S, P, C>,
     vested: &VestedAmount<S>,
-    ctx: &mut TxContext,
 ) {
     // ... enforce protocol invariants (not paused, caller approved, ...) ...
-    self.inner.release(vested, ctx);
+    self.inner.release(vested);
 }
 ```
 

--- a/contracts/finance/README.md
+++ b/contracts/finance/README.md
@@ -271,8 +271,9 @@ one per integration boundary described above:
   teardown. Works with any present or future curve.
 - [`splitter`](examples/vesting_wallet/splitter.move) - the **beneficiary-as-object**
   pattern: point a wallet's `beneficiary` at a shared `Beneficiary` object so each
-  release lands as a `Receiving<Coin<C>>` that anyone can `disperse` to many receivers
-  by fixed weights. Composes with any curve and topology.
+  release settles into the object's accumulator, which anyone can `disperse` to many
+  receivers by fixed weights (crediting each via `balance::send_funds`). Composes with
+  any curve and topology.
 
 ## Security Notes
 

--- a/contracts/finance/README.md
+++ b/contracts/finance/README.md
@@ -50,15 +50,15 @@ is not required up front.
 1. **Create** - call `new` (stepped) or `new_continuous`, both returning the wallet
    by value so you can fund and choose a topology in the same PTB. `create_and_share`/
    `create_and_share_continuous` are sugar that builds the wallet and shares it in one call.
-2. **Fund** - `deposit` a `Coin<C>`. Permissionless: anyone may fund, and funds added
+2. **Fund** - `deposit` a `Balance<C>`. Permissionless: anyone may fund, and funds added
    after the schedule starts participate retroactively.
 3. **Release** - `release` evaluates the curve at the current `Clock` and pays the
    not-yet-released portion to the beneficiary. Permissionless and idempotent: if
    nothing new has vested it is a no-op.
 4. **Inspect** - `releasable` returns what `release` would pay right now; `start_ms`,
    `period_ms`, `steps`, `duration_ms`, `end_ms`, and `cliff_ms` read the schedule.
-5. **Tear down** - once drained, `vesting_wallet::destroy_empty` reclaims the storage
-   rebate and returns a `DestroyReceipt`; hand that to `vesting_wallet_linear::destroy`,
+5. **Tear down** - once drained (and any settled funds swept), `vesting_wallet::destroy_empty`
+   reclaims the storage rebate and returns a `DestroyReceipt`; hand that to `vesting_wallet_linear::destroy`,
    which requires the schedule to have ended and the caller to be the beneficiary
    before accepting the teardown.
 
@@ -85,7 +85,7 @@ public fun grant<C>(beneficiary: address, start_ms: u64, funds: Coin<C>, ctx: &m
         4,            // steps
         ctx,
     );
-    wallet.deposit(funds);
+    wallet.deposit(funds.into_balance());
     transfer::public_share_object(wallet);
 }
 
@@ -101,8 +101,8 @@ public fun stream<C>(beneficiary: address, start_ms: u64, ctx: &mut TxContext) {
 }
 
 // Anyone can release; the beneficiary is read fresh from the wallet at call time.
-public fun claim<C>(wallet: &mut VestingWallet<Linear, Params, C>, clock: &Clock, ctx: &mut TxContext) {
-    vesting_wallet_linear::release(wallet, clock, ctx);
+public fun claim<C>(wallet: &mut VestingWallet<Linear, Params, C>, clock: &Clock) {
+    vesting_wallet_linear::release(wallet, clock);
 }
 
 // A read-only "what can I claim?" query for clients.
@@ -122,8 +122,9 @@ and you pick the topology:
 - **Owned** (fast path) - `transfer::public_transfer(wallet, holder)`. Only the
   holder can pass the wallet by `&mut`, so release is reachable from the holder's
   transactions only. Outside parties fund an owned wallet by `public_transfer`-ing a
-  `Coin<C>` to the wallet's object address; the holder then claims each with
-  `receive_and_deposit`.
+  `Coin<C>` to the wallet's object address (the holder claims each with
+  `receive_and_deposit`) or by settling a `Balance<C>` into the address (the holder
+  pulls it in with `sweep_settled`).
 
 The `beneficiary` is fixed at construction. To rotate the recipient, point
 `beneficiary` at a consumer-owned object and rotate ownership of that object instead.
@@ -194,7 +195,7 @@ The caller picks the curve module at the call site; the vault never knows which 
 
 ```move
 let v = vesting_wallet_linear::vested_amount(vault.inner(), clock);
-vault.release(&v, ctx);
+vault.release(&v);
 ```
 
 If `release` instead required the witness `S`, this would be impossible: a wrapper

--- a/contracts/finance/README.md
+++ b/contracts/finance/README.md
@@ -53,8 +53,8 @@ is not required up front.
 2. **Fund** - `deposit` a `Balance<C>`. Permissionless: anyone may fund, and funds added
    after the schedule starts participate retroactively.
 3. **Release** - `release` evaluates the curve at the current `Clock` and pays the
-   not-yet-released portion to the beneficiary. Permissionless and idempotent: if
-   nothing new has vested it is a no-op.
+   not-yet-released portion into the beneficiary's address balance. Permissionless
+   and idempotent: if nothing new has vested it is a no-op.
 4. **Inspect** - `releasable` returns what `release` would pay right now; `start_ms`,
    `period_ms`, `steps`, `duration_ms`, `end_ms`, and `cliff_ms` read the schedule.
 5. **Tear down** - once drained (and any settled funds swept), `vesting_wallet::destroy_empty`

--- a/contracts/finance/examples/vesting_wallet/pausable_grant.move
+++ b/contracts/finance/examples/vesting_wallet/pausable_grant.move
@@ -14,7 +14,7 @@
 ///
 /// ```move
 /// let v = vesting_wallet_linear::vested_amount(grant.inner(), clock);
-/// grant.release(&v, ctx);
+/// grant.release(&v);
 /// ```
 ///
 /// # What the curve-agnostic core can and cannot do
@@ -26,7 +26,9 @@
 /// does not refund.
 ///
 /// Teardown follows the same split. `vesting_wallet::destroy_empty` is permissionless,
-/// but it requires a drained wallet and only hands back a `DestroyReceipt` that the
+/// but it requires a fully emptied wallet - no held balance *and* no unswept settled
+/// funds at its address (`sweep_settled` first) - and only hands back a `DestroyReceipt`
+/// that the
 /// curve module must consume with its witness `S`. A curve-agnostic wrapper has no `S`,
 /// so it cannot finalize teardown itself. What it *can* do is dissolve the wrapper:
 /// `unwrap` consumes the grant and its admin cap and returns the bare nested wallet, so

--- a/contracts/finance/examples/vesting_wallet/pausable_grant.move
+++ b/contracts/finance/examples/vesting_wallet/pausable_grant.move
@@ -113,10 +113,9 @@ public fun inner<S: drop, P: copy + drop + store, C>(
 public fun release<S: drop, P: copy + drop + store, C>(
     self: &mut PausableGrant<S, P, C>,
     vested: &VestedAmount<S>,
-    ctx: &mut TxContext,
 ) {
     assert!(!self.paused, EPaused);
-    self.inner.release(vested, ctx);
+    self.inner.release(vested);
 }
 
 /// Freeze releases. Idempotent.

--- a/contracts/finance/examples/vesting_wallet/pausable_grant.move
+++ b/contracts/finance/examples/vesting_wallet/pausable_grant.move
@@ -146,7 +146,7 @@ public fun resume<S: drop, P: copy + drop + store, C>(
 /// wallet to the caller. This is the curve-agnostic half of teardown - the wrapper
 /// holds no witness `S`, so it cannot consume a `DestroyReceipt` itself; it stops at
 /// handing back the bare wallet. The caller finishes teardown through the curve
-/// module: `vesting_wallet::destroy_empty(wallet)` for the receipt, then the curve's
+/// module: `vesting_wallet::destroy_empty(wallet, root)` for the receipt, then the curve's
 /// witness-gated `destroy` to consume it (which can impose its own gates, e.g. that
 /// the schedule has ended).
 ///

--- a/contracts/finance/examples/vesting_wallet/splitter.move
+++ b/contracts/finance/examples/vesting_wallet/splitter.move
@@ -5,8 +5,8 @@
 /// A `VestingWallet`'s `beneficiary` is just an address: `release` credits the payout
 /// to it via `balance::send_funds`, the funds-accumulator transfer. Point it at a
 /// shared `Beneficiary` and each release settles into the object's address balance;
-/// anyone can then poke `disperse` with the released amount to withdraw it from the
-/// object's accumulator and split it among the receivers - crediting each via
+/// anyone can then poke `disperse` to withdraw all of it from the object's accumulator
+/// and split it among the receivers - crediting each via
 /// `balance::send_funds` too - by their allocations, fixed at creation and free to
 /// differ between receivers. Each split emits a `Dispersed` event recording the
 /// per-receiver amounts.
@@ -27,6 +27,7 @@ module openzeppelin_finance::example_splitter;
 
 use openzeppelin_math::rounding;
 use openzeppelin_math::u64::mul_div;
+use sui::accumulator::AccumulatorRoot;
 use sui::balance::{Self, Balance};
 use sui::coin::Coin;
 use sui::event;
@@ -75,6 +76,15 @@ public struct Dispersed<phantom C> has copy, drop {
 /// Create and share a splitter, returning the object's address to use as a vesting
 /// wallet's `beneficiary`. Allocations are fixed here and may differ per receiver.
 ///
+/// #### Parameters
+/// - `receivers`: Payout recipients; must be non-empty.
+/// - `weights`: Allocation weight per receiver, parallel to `receivers`; each must be
+///   positive.
+/// - `ctx`: Transaction context, used to allocate the splitter's `UID`.
+///
+/// #### Returns
+/// - The shared splitter object's address, to set as a vesting wallet's `beneficiary`.
+///
 /// #### Aborts
 /// - `EBadConfig` if the vectors are empty or of unequal length.
 /// - `EZeroWeight` if any weight is zero.
@@ -95,19 +105,19 @@ public fun new(receivers: vector<address>, weights: vector<u64>, ctx: &mut TxCon
     addr
 }
 
-/// Withdraw `amount` of `C` from this object's funds accumulator - where a vesting
-/// wallet `release` credits its object beneficiary via `balance::send_funds` - and fan
-/// it out to the receivers by weight. Permissionless. `amount` is the released amount
-/// (e.g. read from the wallet's `Released` event).
+/// Withdraw *all* of this object's settled `C` - where a vesting wallet `release`
+/// credits its object beneficiary via `balance::send_funds` - and fan it out to the
+/// receivers by weight. Permissionless. Always processes the entire settled balance in
+/// one shot, so the rounding boundary is fixed by the configured split rather than by a
+/// caller-chosen amount; a splitter with no settled funds is a no-op.
 ///
 /// #### Parameters
 /// - `self`: The splitter holding the settled payout.
-/// - `amount`: The amount of `C` to withdraw from the object's accumulator and split.
-///
-/// #### Aborts
-/// - The funds-accumulator `InsufficientFundsForWithdraw` execution status, raised at
-///   `redeem_funds`, if the object's settled balance is below `amount`.
-public fun disperse<C>(self: &mut Beneficiary, amount: u64) {
+/// - `root`: The shared `AccumulatorRoot`, read to find the splitter's settled funds.
+public fun disperse<C>(self: &mut Beneficiary, root: &AccumulatorRoot) {
+    let addr = object::uid_to_address(&self.id);
+    let amount = balance::settled_funds_value<C>(root, addr);
+    if (amount == 0) return;
     let withdrawal = balance::withdraw_funds_from_object<C>(&mut self.id, amount);
     self.fan_out(balance::redeem_funds(withdrawal));
 }
@@ -168,21 +178,53 @@ fun fan_out<C>(self: &Beneficiary, mut payout: Balance<C>) {
 // === View helpers ===
 
 /// The configured payout recipients.
+///
+/// #### Parameters
+/// - `self`: The splitter to query.
+///
+/// #### Returns
+/// - The configured payout recipients.
 public fun receivers(self: &Beneficiary): vector<address> {
     self.receivers
 }
 
 /// The configured allocation weights, parallel to `receivers`.
+///
+/// #### Parameters
+/// - `self`: The splitter to query.
+///
+/// #### Returns
+/// - The configured allocation weights, parallel to `receivers`.
 public fun weights(self: &Beneficiary): vector<u64> {
     self.weights
 }
 
 /// The sum of all weights.
+///
+/// #### Parameters
+/// - `self`: The splitter to query.
+///
+/// #### Returns
+/// - The sum of all weights, the denominator of each receiver's share.
 public fun total_weight(self: &Beneficiary): u64 {
     self.total_weight
 }
 
 // === Test Helpers ===
+
+/// Disperse an explicit `amount` from this object's accumulator without the
+/// `AccumulatorRoot` settled-funds lookup, so unit tests can exercise the settled-funds
+/// fan-out path without constructing an `AccumulatorRoot` - which has no test constructor
+/// in the pinned Sui release.
+///
+/// TODO: remove this and route the test through `disperse` with a real `AccumulatorRoot`
+/// (via `accumulator::create_for_testing`) once that test helper ships in the published
+/// Sui mainnet framework.
+#[test_only]
+public fun disperse_for_testing<C>(self: &mut Beneficiary, amount: u64) {
+    let withdrawal = balance::withdraw_funds_from_object<C>(&mut self.id, amount);
+    self.fan_out(balance::redeem_funds(withdrawal));
+}
 
 /// Build a `Dispersed` event value for asserting against `event::events_by_type`.
 #[test_only]

--- a/contracts/finance/examples/vesting_wallet/splitter.move
+++ b/contracts/finance/examples/vesting_wallet/splitter.move
@@ -100,6 +100,10 @@ public fun new(receivers: vector<address>, weights: vector<u64>, ctx: &mut TxCon
 /// it out to the receivers by weight. Permissionless. `amount` is the released amount
 /// (e.g. read from the wallet's `Released` event).
 ///
+/// #### Parameters
+/// - `self`: The splitter holding the settled payout.
+/// - `amount`: The amount of `C` to withdraw from the object's accumulator and split.
+///
 /// #### Aborts
 /// - The funds-accumulator `InsufficientFundsForWithdraw` execution status, raised at
 ///   `redeem_funds`, if the object's settled balance is below `amount`.
@@ -112,6 +116,15 @@ public fun disperse<C>(self: &mut Beneficiary, amount: u64) {
 /// an upstream emitter (or a stray coin) - turn it into a `Balance`, and fan it out to
 /// the receivers by weight. The coin-object counterpart to `disperse`'s accumulator
 /// withdrawal. Permissionless.
+///
+/// #### Parameters
+/// - `self`: The splitter the coin was parked at.
+/// - `payout`: The `Coin<C>` `public_transfer`'d to this object's address, to be
+///   claimed and split.
+///
+/// #### Aborts
+/// - The native receive abort, raised at `transfer::public_receive`, if `payout` does
+///   not match a coin currently sent to this object's address (wrong id or version).
 public fun receive_and_disperse<C>(self: &mut Beneficiary, payout: Receiving<Coin<C>>) {
     let coin = transfer::public_receive(&mut self.id, payout);
     self.fan_out(coin.into_balance());

--- a/contracts/finance/examples/vesting_wallet/splitter.move
+++ b/contracts/finance/examples/vesting_wallet/splitter.move
@@ -116,7 +116,7 @@ public fun new(receivers: vector<address>, weights: vector<u64>, ctx: &mut TxCon
 /// - `self`: The splitter holding the settled payout.
 /// - `root`: The shared `AccumulatorRoot`, read to find the splitter's settled funds.
 public fun disperse<C>(self: &mut Beneficiary, root: &AccumulatorRoot) {
-    let addr = object::uid_to_address(&self.id);
+    let addr = self.id.to_address();
     let amount = balance::settled_funds_value<C>(root, addr);
     if (amount == 0) return;
     let withdrawal = balance::withdraw_funds_from_object<C>(&mut self.id, amount);
@@ -139,6 +139,23 @@ public fun disperse<C>(self: &mut Beneficiary, root: &AccumulatorRoot) {
 public fun receive_and_disperse<C>(self: &mut Beneficiary, payout: Receiving<Coin<C>>) {
     let coin = transfer::public_receive(&mut self.id, payout);
     self.fan_out(coin.into_balance());
+}
+
+// === View helpers ===
+
+/// The configured payout recipients.
+public fun receivers(self: &Beneficiary): vector<address> {
+    self.receivers
+}
+
+/// The configured allocation weights, parallel to `receivers`.
+public fun weights(self: &Beneficiary): vector<u64> {
+    self.weights
+}
+
+/// The sum of all weights, the denominator of each receiver's share.
+public fun total_weight(self: &Beneficiary): u64 {
+    self.total_weight
 }
 
 // === Private Functions ===
@@ -176,42 +193,7 @@ fun fan_out<C>(self: &Beneficiary, mut payout: Balance<C>) {
     });
 }
 
-// === View helpers ===
-
-/// The configured payout recipients.
-///
-/// #### Parameters
-/// - `self`: The splitter to query.
-///
-/// #### Returns
-/// - The configured payout recipients.
-public fun receivers(self: &Beneficiary): vector<address> {
-    self.receivers
-}
-
-/// The configured allocation weights, parallel to `receivers`.
-///
-/// #### Parameters
-/// - `self`: The splitter to query.
-///
-/// #### Returns
-/// - The configured allocation weights, parallel to `receivers`.
-public fun weights(self: &Beneficiary): vector<u64> {
-    self.weights
-}
-
-/// The sum of all weights.
-///
-/// #### Parameters
-/// - `self`: The splitter to query.
-///
-/// #### Returns
-/// - The sum of all weights, the denominator of each receiver's share.
-public fun total_weight(self: &Beneficiary): u64 {
-    self.total_weight
-}
-
-// === Test Helpers ===
+// === Test-Only Helpers ===
 
 /// Disperse an explicit `amount` from this object's accumulator without the
 /// `AccumulatorRoot` settled-funds lookup, so unit tests can exercise the settled-funds

--- a/contracts/finance/examples/vesting_wallet/splitter.move
+++ b/contracts/finance/examples/vesting_wallet/splitter.move
@@ -105,6 +105,7 @@ public fun new(receivers: vector<address>, weights: vector<u64>, ctx: &mut TxCon
     addr
 }
 
+// TODO: add tests for this function once Sui supports creating AccumulatorRoot in tests.
 /// Withdraw *all* of this object's settled `C` - where a vesting wallet `release`
 /// credits its object beneficiary via `balance::send_funds` - and fan it out to the
 /// receivers by weight. Permissionless. Always processes the entire settled balance in

--- a/contracts/finance/examples/vesting_wallet/splitter.move
+++ b/contracts/finance/examples/vesting_wallet/splitter.move
@@ -2,15 +2,21 @@
 /// by fixed weights - a worked example of pointing a wallet's `beneficiary` at an
 /// object instead of a person.
 ///
-/// A `VestingWallet`'s `beneficiary` is just an address: `release` `public_transfer`s
-/// the payout coin to it. Point it at a shared `Beneficiary` and each release lands at
-/// the object's address as a `Receiving<Coin<C>>`; anyone can then poke `disperse` to
-/// split that coin among the receivers by their allocations, fixed at creation and
-/// free to differ between receivers.
+/// A `VestingWallet`'s `beneficiary` is just an address: `release` credits the payout
+/// to it via `balance::send_funds`, the funds-accumulator transfer. Point it at a
+/// shared `Beneficiary` and each release settles into the object's address balance;
+/// anyone can then poke `disperse` with the released amount to withdraw it from the
+/// object's accumulator and split it among the receivers - crediting each via
+/// `balance::send_funds` too - by their allocations, fixed at creation and free to
+/// differ between receivers. Each split emits a `Dispersed` event recording the
+/// per-receiver amounts.
+///
+/// For coins delivered the older way - `public_transfer`'d to the object's address by
+/// an upstream emitter, landing as a `Receiving<Coin<C>>` - `receive_and_disperse`
+/// claims that coin, turns it into a `Balance`, and fans it out the same way.
 ///
 /// This composes with *any* curve and topology: the wallet neither knows nor cares
-/// that its beneficiary is a contract. The split is per payout, so each `release`
-/// queues one more `Receiving` for `disperse` to fan out.
+/// that its beneficiary is a contract. The split is per payout.
 ///
 /// # Disclaimer
 ///
@@ -21,7 +27,9 @@ module openzeppelin_finance::example_splitter;
 
 use openzeppelin_math::rounding;
 use openzeppelin_math::u64::mul_div;
+use sui::balance::{Self, Balance};
 use sui::coin::Coin;
+use sui::event;
 use sui::transfer::Receiving;
 
 // === Errors ===
@@ -36,7 +44,8 @@ const EZeroWeight: vector<u8> = "Every weight must be greater than zero";
 // === Structs ===
 
 /// A shared payout splitter. Set a vesting wallet's `beneficiary` to this object's
-/// address; releases land here and `disperse` fans each one out by weight.
+/// address; releases settle into this object's accumulator and `disperse` fans each
+/// one out by weight.
 public struct Beneficiary has key {
     id: UID,
     /// Payout recipients.
@@ -45,6 +54,20 @@ public struct Beneficiary has key {
     weights: vector<u64>,
     /// Cached sum of `weights`, the denominator of each receiver's share.
     total_weight: u64,
+}
+
+// === Events ===
+
+/// Emitted once per `disperse` / `receive_and_disperse` call: the payout was split and
+/// credited to `receivers` via `balance::send_funds`, in the parallel `amounts`
+/// (receiver order). The amounts sum to the dispersed payout.
+public struct Dispersed<phantom C> has copy, drop {
+    /// The splitter object that fanned the payout out.
+    splitter: ID,
+    /// Recipients paid, in order.
+    receivers: vector<address>,
+    /// Amount credited to each receiver, parallel to `receivers`.
+    amounts: vector<u64>,
 }
 
 // === Public Functions ===
@@ -72,15 +95,40 @@ public fun new(receivers: vector<address>, weights: vector<u64>, ctx: &mut TxCon
     addr
 }
 
-/// Pull one payout coin parked at this object's address (from a wallet `release`) and
-/// fan it out to the receivers by weight. Permissionless. Conserves value exactly:
-/// integer division floors each share and the last receiver absorbs the remainder, so
-/// the transfers sum to the coin's value with nothing created or stranded as dust.
-public fun disperse<C>(self: &mut Beneficiary, payout: Receiving<Coin<C>>, ctx: &mut TxContext) {
-    let mut coin = transfer::public_receive(&mut self.id, payout);
-    let value = coin.value();
+/// Withdraw `amount` of `C` from this object's funds accumulator - where a vesting
+/// wallet `release` credits its object beneficiary via `balance::send_funds` - and fan
+/// it out to the receivers by weight. Permissionless. `amount` is the released amount
+/// (e.g. read from the wallet's `Released` event).
+///
+/// #### Aborts
+/// - The funds-accumulator `InsufficientFundsForWithdraw` execution status, raised at
+///   `redeem_funds`, if the object's settled balance is below `amount`.
+public fun disperse<C>(self: &mut Beneficiary, amount: u64) {
+    let withdrawal = balance::withdraw_funds_from_object<C>(&mut self.id, amount);
+    self.fan_out(balance::redeem_funds(withdrawal));
+}
+
+/// Claim one payout coin parked at this object's address - `public_transfer`'d there by
+/// an upstream emitter (or a stray coin) - turn it into a `Balance`, and fan it out to
+/// the receivers by weight. The coin-object counterpart to `disperse`'s accumulator
+/// withdrawal. Permissionless.
+public fun receive_and_disperse<C>(self: &mut Beneficiary, payout: Receiving<Coin<C>>) {
+    let coin = transfer::public_receive(&mut self.id, payout);
+    self.fan_out(coin.into_balance());
+}
+
+// === Private Functions ===
+
+/// Fan one payout balance out to the receivers by weight, crediting each via
+/// `balance::send_funds` (address-balance-first), and emit `Dispersed`. Conserves value
+/// exactly: integer division floors each share and the last receiver absorbs the
+/// remainder, so the credits sum to the balance's value with nothing created or
+/// stranded as dust.
+fun fan_out<C>(self: &Beneficiary, mut payout: Balance<C>) {
+    let value = payout.value();
     let n = self.receivers.length();
 
+    let mut amounts = vector[];
     let mut i = 0;
     while (i < n - 1) {
         let share = mul_div(
@@ -89,11 +137,19 @@ public fun disperse<C>(self: &mut Beneficiary, payout: Receiving<Coin<C>>, ctx: 
             self.total_weight,
             rounding::down(),
         ).destroy_some();
-        transfer::public_transfer(coin.split(share, ctx), self.receivers[i]);
+        amounts.push_back(share);
+        balance::send_funds(payout.split(share), self.receivers[i]);
         i = i + 1;
     };
     // The last receiver takes whatever remains, so floored shares never strand dust.
-    transfer::public_transfer(coin, self.receivers[n - 1]);
+    amounts.push_back(payout.value());
+    balance::send_funds(payout, self.receivers[n - 1]);
+
+    event::emit(Dispersed<C> {
+        splitter: object::id(self),
+        receivers: self.receivers,
+        amounts,
+    });
 }
 
 // === View helpers ===
@@ -111,4 +167,16 @@ public fun weights(self: &Beneficiary): vector<u64> {
 /// The sum of all weights.
 public fun total_weight(self: &Beneficiary): u64 {
     self.total_weight
+}
+
+// === Test Helpers ===
+
+/// Build a `Dispersed` event value for asserting against `event::events_by_type`.
+#[test_only]
+public fun test_new_dispersed<C>(
+    splitter: ID,
+    receivers: vector<address>,
+    amounts: vector<u64>,
+): Dispersed<C> {
+    Dispersed { splitter, receivers, amounts }
 }

--- a/contracts/finance/examples/vesting_wallet/tests/pausable_grant_tests.move
+++ b/contracts/finance/examples/vesting_wallet/tests/pausable_grant_tests.move
@@ -154,7 +154,9 @@ fun unwrap_then_curve_teardown() {
     // curve's witness-gated `destroy`.
     scenario.next_tx(BENEFICIARY);
     let wallet = scenario.take_from_sender<VestingWallet<Linear, Params, USDC>>();
-    let receipt = wallet.destroy_empty();
+    // TODO: use `destroy_empty` with a real `AccumulatorRoot` once
+    // `accumulator::create_for_testing` ships in the published Sui mainnet framework.
+    let receipt = wallet.destroy_empty_for_testing();
     linear::destroy(receipt, &clock, scenario.ctx());
 
     destroy(clock);

--- a/contracts/finance/examples/vesting_wallet/tests/pausable_grant_tests.move
+++ b/contracts/finance/examples/vesting_wallet/tests/pausable_grant_tests.move
@@ -176,7 +176,7 @@ fun foreign_cap_cannot_unwrap() {
     create_grant(&mut scenario);
     scenario.next_tx(EMPLOYER);
 
-    let grant_a = ts::take_shared_by_id<PausableGrant<Linear, Params, USDC>>(&scenario, id_a);
+    let grant_a = scenario.take_shared_by_id<PausableGrant<Linear, Params, USDC>>(id_a);
     // The sender holds two caps; the most recent one belongs to grant B.
     let cap_b = scenario.take_from_sender<GrantAdminCap>();
 
@@ -199,7 +199,7 @@ fun foreign_cap_cannot_pause() {
     create_grant(&mut scenario);
     scenario.next_tx(EMPLOYER);
 
-    let mut grant_a = ts::take_shared_by_id<PausableGrant<Linear, Params, USDC>>(&scenario, id_a);
+    let mut grant_a = scenario.take_shared_by_id<PausableGrant<Linear, Params, USDC>>(id_a);
     // The sender holds two caps; the most recent one belongs to grant B.
     let cap_b = scenario.take_from_sender<GrantAdminCap>();
 
@@ -221,7 +221,7 @@ fun foreign_cap_cannot_resume() {
     create_grant(&mut scenario);
     scenario.next_tx(EMPLOYER);
 
-    let mut grant_a = ts::take_shared_by_id<PausableGrant<Linear, Params, USDC>>(&scenario, id_a);
+    let mut grant_a = scenario.take_shared_by_id<PausableGrant<Linear, Params, USDC>>(id_a);
     // The sender holds two caps; the most recent one belongs to grant B.
     let cap_b = scenario.take_from_sender<GrantAdminCap>();
 

--- a/contracts/finance/examples/vesting_wallet/tests/pausable_grant_tests.move
+++ b/contracts/finance/examples/vesting_wallet/tests/pausable_grant_tests.move
@@ -4,6 +4,7 @@ use openzeppelin_finance::example_pausable_grant::{Self, PausableGrant, GrantAdm
 use openzeppelin_finance::vesting_wallet::{Self, VestingWallet};
 use openzeppelin_finance::vesting_wallet_linear::{Self as linear, Linear, Params};
 use std::unit_test::{assert_eq, destroy};
+use sui::balance;
 use sui::coin::{Self, Coin};
 use sui::test_scenario as ts;
 
@@ -26,20 +27,16 @@ fun create_grant(scenario: &mut ts::Scenario) {
         BENEFICIARY,
         scenario.ctx(),
     );
-    wallet.deposit(coin::mint_for_testing<USDC>(TOTAL, scenario.ctx()));
+    wallet.deposit(balance::create_for_testing<USDC>(TOTAL));
     let cap = example_pausable_grant::new(wallet, scenario.ctx());
     transfer::public_transfer(cap, EMPLOYER);
 }
 
 // Evaluate the curve through the grant's immutable `inner()` view, then release
 // through the grant's own `release`. The caller never touches `&mut inner`.
-fun release(
-    grant: &mut PausableGrant<Linear, Params, USDC>,
-    clock: &sui::clock::Clock,
-    ctx: &mut TxContext,
-) {
+fun release(grant: &mut PausableGrant<Linear, Params, USDC>, clock: &sui::clock::Clock) {
     let vested = linear::vested_amount(grant.inner(), clock);
-    grant.release(&vested, ctx);
+    grant.release(&vested);
 }
 
 // Happy path: a curve-agnostic release flows through the wrapper to the beneficiary.
@@ -56,7 +53,7 @@ fun release_flows_through_wrapper_to_beneficiary() {
 
     // Halfway through the linear schedule: half is releasable.
     clock.set_for_testing(START_MS + DURATION_MS / 2);
-    release(&mut grant, &clock, scenario.ctx());
+    release(&mut grant, &clock);
 
     scenario.next_tx(BENEFICIARY);
     let paid = scenario.take_from_address<Coin<USDC>>(BENEFICIARY);
@@ -84,7 +81,7 @@ fun release_aborts_while_paused() {
     assert!(grant.is_paused());
 
     clock.set_for_testing(START_MS + DURATION_MS / 2);
-    release(&mut grant, &clock, scenario.ctx());
+    release(&mut grant, &clock);
 
     abort
 }
@@ -108,7 +105,7 @@ fun resume_restores_releases() {
     grant.resume(&cap);
 
     // The full total is now releasable in one go.
-    release(&mut grant, &clock, scenario.ctx());
+    release(&mut grant, &clock);
 
     scenario.next_tx(BENEFICIARY);
     let paid = scenario.take_from_address<Coin<USDC>>(BENEFICIARY);
@@ -136,7 +133,7 @@ fun unwrap_then_curve_teardown() {
     // Drain the grant at the end of the schedule.
     let mut grant = scenario.take_shared<PausableGrant<Linear, Params, USDC>>();
     clock.set_for_testing(START_MS + DURATION_MS);
-    release(&mut grant, &clock, scenario.ctx());
+    release(&mut grant, &clock);
 
     // Admin dissolves the wrapper, recovering the bare wallet, and forwards it to the
     // beneficiary so the beneficiary-gated curve teardown can run.

--- a/contracts/finance/examples/vesting_wallet/tests/pausable_grant_tests.move
+++ b/contracts/finance/examples/vesting_wallet/tests/pausable_grant_tests.move
@@ -1,11 +1,11 @@
 module openzeppelin_finance::example_pausable_grant_tests;
 
 use openzeppelin_finance::example_pausable_grant::{Self, PausableGrant, GrantAdminCap};
-use openzeppelin_finance::vesting_wallet::{Self, VestingWallet};
+use openzeppelin_finance::vesting_wallet::{Self, VestingWallet, Released};
 use openzeppelin_finance::vesting_wallet_linear::{Self as linear, Linear, Params};
 use std::unit_test::{assert_eq, destroy};
 use sui::balance;
-use sui::coin::{Self, Coin};
+use sui::event;
 use sui::test_scenario as ts;
 
 /// Phantom coin marker for the vested asset.
@@ -55,11 +55,15 @@ fun release_flows_through_wrapper_to_beneficiary() {
     clock.set_for_testing(START_MS + DURATION_MS / 2);
     release(&mut grant, &clock);
 
-    scenario.next_tx(BENEFICIARY);
-    let paid = scenario.take_from_address<Coin<USDC>>(BENEFICIARY);
-    assert_eq!(paid.value(), TOTAL / 2);
+    // The half-vested payout was directed to the beneficiary.
+    let wallet_id = object::id(grant.inner());
+    let released = event::events_by_type<Released<Linear, USDC>>();
+    assert_eq!(released.length(), 1);
+    assert_eq!(
+        released[0],
+        vesting_wallet::test_new_released<Linear, USDC>(wallet_id, BENEFICIARY, TOTAL / 2),
+    );
 
-    destroy(paid);
     ts::return_shared(grant);
     destroy(clock);
     scenario.end();
@@ -107,11 +111,15 @@ fun resume_restores_releases() {
     // The full total is now releasable in one go.
     release(&mut grant, &clock);
 
-    scenario.next_tx(BENEFICIARY);
-    let paid = scenario.take_from_address<Coin<USDC>>(BENEFICIARY);
-    assert_eq!(paid.value(), TOTAL);
+    // What accrued during the pause is paid to the beneficiary in full.
+    let wallet_id = object::id(grant.inner());
+    let released = event::events_by_type<Released<Linear, USDC>>();
+    assert_eq!(released.length(), 1);
+    assert_eq!(
+        released[0],
+        vesting_wallet::test_new_released<Linear, USDC>(wallet_id, BENEFICIARY, TOTAL),
+    );
 
-    destroy(paid);
     destroy(cap);
     ts::return_shared(grant);
     destroy(clock);

--- a/contracts/finance/examples/vesting_wallet/tests/splitter_tests.move
+++ b/contracts/finance/examples/vesting_wallet/tests/splitter_tests.move
@@ -37,11 +37,11 @@ fun release_to_splitter_fans_out_by_weight() {
 
     scenario.next_tx(EMPLOYER);
     let mut wallet = scenario.take_shared<VestingWallet<Linear, Params, USDC>>();
-    wallet.deposit(coin::mint_for_testing<USDC>(TOTAL, scenario.ctx()));
+    wallet.deposit(coin::mint_for_testing<USDC>(TOTAL, scenario.ctx()).into_balance());
 
     // Release the full total at the end of the schedule; it lands at the splitter.
     clock.set_for_testing(START_MS + DURATION_MS);
-    linear::release(&mut wallet, &clock, scenario.ctx());
+    linear::release(&mut wallet, &clock);
     ts::return_shared(wallet);
 
     // Anyone fans the parked payout out to the three receivers.

--- a/contracts/finance/examples/vesting_wallet/tests/splitter_tests.move
+++ b/contracts/finance/examples/vesting_wallet/tests/splitter_tests.move
@@ -1,10 +1,11 @@
 module openzeppelin_finance::example_splitter_tests;
 
-use openzeppelin_finance::example_splitter::{Self, Beneficiary};
+use openzeppelin_finance::example_splitter::{Self, Beneficiary, Dispersed};
 use openzeppelin_finance::vesting_wallet::VestingWallet;
 use openzeppelin_finance::vesting_wallet_linear::{Self as linear, Linear, Params};
 use std::unit_test::{assert_eq, destroy};
 use sui::coin::{Self, Coin};
+use sui::event;
 use sui::test_scenario as ts;
 
 /// Phantom coin marker for the vested asset.
@@ -44,26 +45,28 @@ fun release_to_splitter_fans_out_by_weight() {
     linear::release(&mut wallet, &clock);
     ts::return_shared(wallet);
 
-    // Anyone fans the parked payout out to the three receivers.
+    // Anyone withdraws the released payout from the splitter's accumulator and fans it
+    // out to the three receivers.
     scenario.next_tx(EMPLOYER);
     let mut splitter = scenario.take_shared<Beneficiary>();
-    let payout = ts::most_recent_receiving_ticket<Coin<USDC>>(&object::id(&splitter));
-    splitter.disperse<USDC>(payout, scenario.ctx());
+    let splitter_id = object::id(&splitter);
+    splitter.disperse<USDC>(TOTAL);
+
+    // 50/30/20 of the total, conserving every unit. The per-receiver credits land in
+    // each address's accumulator (not takeable as coins in the unit-test VM), so the
+    // split is attested by the `Dispersed` event.
+    let dispersed = event::events_by_type<Dispersed<USDC>>();
+    assert_eq!(dispersed.length(), 1);
+    assert_eq!(
+        dispersed[0],
+        example_splitter::test_new_dispersed<USDC>(
+            splitter_id,
+            vector[ALICE, BOB, CAROL],
+            vector[TOTAL * 50 / 100, TOTAL * 30 / 100, TOTAL * 20 / 100],
+        ),
+    );
+
     ts::return_shared(splitter);
-
-    // 50/30/20 of the total, conserving every unit.
-    scenario.next_tx(EMPLOYER);
-    let to_alice = scenario.take_from_address<Coin<USDC>>(ALICE);
-    let to_bob = scenario.take_from_address<Coin<USDC>>(BOB);
-    let to_carol = scenario.take_from_address<Coin<USDC>>(CAROL);
-    assert_eq!(to_alice.value(), TOTAL * 50 / 100);
-    assert_eq!(to_bob.value(), TOTAL * 30 / 100);
-    assert_eq!(to_carol.value(), TOTAL * 20 / 100);
-    assert_eq!(to_alice.value() + to_bob.value() + to_carol.value(), TOTAL);
-
-    destroy(to_alice);
-    destroy(to_bob);
-    destroy(to_carol);
     destroy(clock);
     scenario.end();
 }
@@ -88,21 +91,22 @@ fun rounding_dust_goes_to_last_receiver() {
 
     scenario.next_tx(EMPLOYER);
     let payout = ts::most_recent_receiving_ticket<Coin<USDC>>(&object::id(&splitter));
-    splitter.disperse<USDC>(payout, scenario.ctx());
+    let splitter_id = object::id(&splitter);
+    splitter.receive_and_disperse<USDC>(payout);
+
+    // Floored 33/33 with the last receiver absorbing the +1 dust, summing to 100.
+    let dispersed = event::events_by_type<Dispersed<USDC>>();
+    assert_eq!(dispersed.length(), 1);
+    assert_eq!(
+        dispersed[0],
+        example_splitter::test_new_dispersed<USDC>(
+            splitter_id,
+            vector[ALICE, BOB, CAROL],
+            vector[33, 33, 34],
+        ),
+    );
+
     ts::return_shared(splitter);
-
-    scenario.next_tx(EMPLOYER);
-    let to_alice = scenario.take_from_address<Coin<USDC>>(ALICE);
-    let to_bob = scenario.take_from_address<Coin<USDC>>(BOB);
-    let to_carol = scenario.take_from_address<Coin<USDC>>(CAROL);
-    assert_eq!(to_alice.value(), 33);
-    assert_eq!(to_bob.value(), 33);
-    assert_eq!(to_carol.value(), 34); // absorbs the +1 dust
-    assert_eq!(to_alice.value() + to_bob.value() + to_carol.value(), 100);
-
-    destroy(to_alice);
-    destroy(to_bob);
-    destroy(to_carol);
     scenario.end();
 }
 
@@ -120,14 +124,18 @@ fun single_receiver_takes_everything() {
 
     scenario.next_tx(EMPLOYER);
     let payout = ts::most_recent_receiving_ticket<Coin<USDC>>(&object::id(&splitter));
-    splitter.disperse<USDC>(payout, scenario.ctx());
+    let splitter_id = object::id(&splitter);
+    splitter.receive_and_disperse<USDC>(payout);
+
+    // The lone receiver absorbs the full payout as the "last" one.
+    let dispersed = event::events_by_type<Dispersed<USDC>>();
+    assert_eq!(dispersed.length(), 1);
+    assert_eq!(
+        dispersed[0],
+        example_splitter::test_new_dispersed<USDC>(splitter_id, vector[ALICE], vector[100]),
+    );
+
     ts::return_shared(splitter);
-
-    scenario.next_tx(EMPLOYER);
-    let to_alice = scenario.take_from_address<Coin<USDC>>(ALICE);
-    assert_eq!(to_alice.value(), 100);
-
-    destroy(to_alice);
     scenario.end();
 }
 

--- a/contracts/finance/examples/vesting_wallet/tests/splitter_tests.move
+++ b/contracts/finance/examples/vesting_wallet/tests/splitter_tests.move
@@ -45,12 +45,14 @@ fun release_to_splitter_fans_out_by_weight() {
     linear::release(&mut wallet, &clock);
     ts::return_shared(wallet);
 
-    // Anyone withdraws the released payout from the splitter's accumulator and fans it
-    // out to the three receivers.
+    // Anyone withdraws the full settled payout from the splitter's accumulator and fans
+    // it out to the three receivers. Uses the test-only bypass because `disperse` reads
+    // the settled balance from an `AccumulatorRoot`, which has no test constructor in the
+    // pinned Sui release.
     scenario.next_tx(EMPLOYER);
     let mut splitter = scenario.take_shared<Beneficiary>();
     let splitter_id = object::id(&splitter);
-    splitter.disperse<USDC>(TOTAL);
+    splitter.disperse_for_testing<USDC>(TOTAL);
 
     // 50/30/20 of the total, conserving every unit. The per-receiver credits land in
     // each address's accumulator (not takeable as coins in the unit-test VM), so the

--- a/contracts/finance/examples/vesting_wallet/tests/vesting_quadratic_tests.move
+++ b/contracts/finance/examples/vesting_wallet/tests/vesting_quadratic_tests.move
@@ -1,10 +1,10 @@
 module openzeppelin_finance::example_vesting_quadratic_tests;
 
 use openzeppelin_finance::example_vesting_quadratic::{Self as quadratic, Quadratic, Params};
-use openzeppelin_finance::vesting_wallet::{Self, VestingWallet};
+use openzeppelin_finance::vesting_wallet::{Self, VestingWallet, Released};
 use std::unit_test::{assert_eq, destroy};
 use sui::balance::{Self, Balance};
-use sui::coin::{Self, Coin};
+use sui::event;
 use sui::test_scenario as ts;
 
 /// Phantom coin marker for the vested asset.
@@ -43,6 +43,7 @@ fun compose_create_fund_and_release_across_modules() {
     scenario.next_tx(BENEFICIARY);
 
     let mut wallet = scenario.take_shared<VestingWallet<Quadratic, Params, USDC>>();
+    let wallet_id = object::id(&wallet);
 
     // Before start: nothing vested.
     clock.set_for_testing(START_MS);
@@ -67,14 +68,23 @@ fun compose_create_fund_and_release_across_modules() {
     assert_eq!(wallet.released(), TOTAL);
     assert_eq!(wallet.balance(), 0);
 
-    // The beneficiary received exactly the total across the two releases.
-    scenario.next_tx(BENEFICIARY);
-    let paid = scenario.take_from_address<Coin<USDC>>(BENEFICIARY);
-    let paid_2 = scenario.take_from_address<Coin<USDC>>(BENEFICIARY);
-    assert_eq!(paid.value() + paid_2.value(), TOTAL);
+    // The beneficiary was paid exactly the total across the two releases, attested
+    // by the two `Released` events: TOTAL / 4 then the remainder.
+    let released = event::events_by_type<Released<Quadratic, USDC>>();
+    assert_eq!(released.length(), 2);
+    assert_eq!(
+        released[0],
+        vesting_wallet::test_new_released<Quadratic, USDC>(wallet_id, BENEFICIARY, TOTAL / 4),
+    );
+    assert_eq!(
+        released[1],
+        vesting_wallet::test_new_released<Quadratic, USDC>(
+            wallet_id,
+            BENEFICIARY,
+            TOTAL - TOTAL / 4,
+        ),
+    );
 
-    destroy(paid);
-    destroy(paid_2);
     ts::return_shared(wallet);
     destroy(clock);
     scenario.end();
@@ -159,11 +169,20 @@ fun compose_destroy_after_drain() {
     scenario.next_tx(BENEFICIARY);
 
     let mut wallet = scenario.take_shared<VestingWallet<Quadratic, Params, USDC>>();
+    let wallet_id = object::id(&wallet);
 
     // Run to the end and drain the wallet.
     clock.set_for_testing(START_MS + DURATION_MS);
     quadratic_release(&mut wallet, &clock);
     assert_eq!(wallet.balance(), 0);
+
+    // The single release paid the full total to the beneficiary.
+    let released = event::events_by_type<Released<Quadratic, USDC>>();
+    assert_eq!(released.length(), 1);
+    assert_eq!(
+        released[0],
+        vesting_wallet::test_new_released<Quadratic, USDC>(wallet_id, BENEFICIARY, TOTAL),
+    );
 
     // Permissionless half reclaims the storage rebate; the witness-gated half consumes
     // the receipt and enforces the ended and beneficiary gates (the sender is the
@@ -171,11 +190,6 @@ fun compose_destroy_after_drain() {
     let receipt = wallet.destroy_empty();
     quadratic::destroy(receipt, &clock, scenario.ctx());
 
-    scenario.next_tx(BENEFICIARY);
-    let paid = scenario.take_from_address<Coin<USDC>>(BENEFICIARY);
-    assert_eq!(paid.value(), TOTAL);
-
-    destroy(paid);
     destroy(clock);
     scenario.end();
 }

--- a/contracts/finance/examples/vesting_wallet/tests/vesting_quadratic_tests.move
+++ b/contracts/finance/examples/vesting_wallet/tests/vesting_quadratic_tests.move
@@ -3,6 +3,7 @@ module openzeppelin_finance::example_vesting_quadratic_tests;
 use openzeppelin_finance::example_vesting_quadratic::{Self as quadratic, Quadratic, Params};
 use openzeppelin_finance::vesting_wallet::{Self, VestingWallet};
 use std::unit_test::{assert_eq, destroy};
+use sui::balance::{Self, Balance};
 use sui::coin::{Self, Coin};
 use sui::test_scenario as ts;
 
@@ -26,7 +27,7 @@ fun create_and_share(scenario: &mut ts::Scenario) {
         BENEFICIARY,
         scenario.ctx(),
     );
-    wallet.deposit(coin::mint_for_testing<USDC>(TOTAL, scenario.ctx()));
+    wallet.deposit(balance::create_for_testing<USDC>(TOTAL));
     transfer::public_share_object(wallet);
 }
 
@@ -56,13 +57,13 @@ fun compose_create_fund_and_release_across_modules() {
     clock.set_for_testing(START_MS + DURATION_MS / 2);
     assert_eq!(quadratic::releasable(&wallet, &clock), TOTAL / 4);
     let vested = quadratic::vested_amount(&wallet, &clock);
-    wallet.release(&vested, scenario.ctx());
+    wallet.release(&vested);
     assert_eq!(wallet.released(), TOTAL / 4);
 
     // After end: everything remaining is releasable, draining the wallet.
     clock.set_for_testing(START_MS + DURATION_MS);
     assert_eq!(quadratic::releasable(&wallet, &clock), TOTAL - TOTAL / 4);
-    quadratic_release(&mut wallet, &clock, scenario.ctx());
+    quadratic_release(&mut wallet, &clock);
     assert_eq!(wallet.released(), TOTAL);
     assert_eq!(wallet.balance(), 0);
 
@@ -121,7 +122,7 @@ fun late_deposit_vests_at_current_proportion() {
     // Halfway through, top up by the original total. New total is 2*TOTAL, and the
     // halfway proportion (1/4) applies to all of it.
     clock.set_for_testing(START_MS + DURATION_MS / 2);
-    wallet.deposit(coin::mint_for_testing<USDC>(TOTAL, scenario.ctx()));
+    wallet.deposit(balance::create_for_testing<USDC>(TOTAL));
     assert_eq!(quadratic::releasable(&wallet, &clock), 2 * TOTAL / 4);
 
     ts::return_shared(wallet);
@@ -161,7 +162,7 @@ fun compose_destroy_after_drain() {
 
     // Run to the end and drain the wallet.
     clock.set_for_testing(START_MS + DURATION_MS);
-    quadratic_release(&mut wallet, &clock, scenario.ctx());
+    quadratic_release(&mut wallet, &clock);
     assert_eq!(wallet.balance(), 0);
 
     // Permissionless half reclaims the storage rebate; the witness-gated half consumes
@@ -242,8 +243,7 @@ fun params_rejects_overflowing_end() {
 fun quadratic_release(
     wallet: &mut VestingWallet<Quadratic, Params, USDC>,
     clock: &sui::clock::Clock,
-    ctx: &mut TxContext,
 ) {
     let vested = quadratic::vested_amount(wallet, clock);
-    wallet.release(&vested, ctx);
+    wallet.release(&vested);
 }

--- a/contracts/finance/examples/vesting_wallet/tests/vesting_quadratic_tests.move
+++ b/contracts/finance/examples/vesting_wallet/tests/vesting_quadratic_tests.move
@@ -187,7 +187,9 @@ fun compose_destroy_after_drain() {
     // Permissionless half reclaims the storage rebate; the witness-gated half consumes
     // the receipt and enforces the ended and beneficiary gates (the sender is the
     // beneficiary here).
-    let receipt = wallet.destroy_empty();
+    // TODO: use `destroy_empty` with a real `AccumulatorRoot` once
+    // `accumulator::create_for_testing` ships in the published Sui mainnet framework.
+    let receipt = wallet.destroy_empty_for_testing();
     quadratic::destroy(receipt, &clock, scenario.ctx());
 
     destroy(clock);
@@ -211,7 +213,7 @@ fun destroy_aborts_before_end() {
     );
     clock.set_for_testing(START_MS + DURATION_MS - 1);
 
-    let receipt = wallet.destroy_empty();
+    let receipt = wallet.destroy_empty_for_testing();
     quadratic::destroy(receipt, &clock, scenario.ctx());
 
     abort
@@ -234,7 +236,7 @@ fun destroy_rejects_non_beneficiary() {
     );
     clock.set_for_testing(START_MS + DURATION_MS);
 
-    let receipt = wallet.destroy_empty();
+    let receipt = wallet.destroy_empty_for_testing();
     quadratic::destroy(receipt, &clock, scenario.ctx());
 
     abort

--- a/contracts/finance/sources/vesting_wallet.move
+++ b/contracts/finance/sources/vesting_wallet.move
@@ -495,9 +495,10 @@ public fun release<S: drop, P: copy + drop + store, C>(
 /// split as `VestedAmount`: one half stays callable without the witness, the curve gates
 /// the other.
 ///
-/// Coins `public_transfer`'d to a destroyed wallet's address after this call have no
-/// path back - pair destruction with halting any upstream emissions that target this
-/// wallet.
+/// Funds sent to a destroyed wallet's address after this call have no path back: a coin
+/// `public_transfer`'d there is unaddressable, and a balance `send_funds`'d there settles
+/// against an object whose `UID` is gone, so no `withdraw_funds_from_object` path can ever
+/// reclaim it. Pair destruction with halting any upstream emissions that target this wallet.
 ///
 /// #### Parameters
 /// - `wallet`: The wallet to destroy. Must hold a zero balance and have no pending

--- a/contracts/finance/sources/vesting_wallet.move
+++ b/contracts/finance/sources/vesting_wallet.move
@@ -86,7 +86,9 @@
 /// instead.
 module openzeppelin_finance::vesting_wallet;
 
+use sui::accumulator::AccumulatorRoot;
 use sui::balance::{Self, Balance};
+use sui::coin::Coin;
 use sui::event;
 use sui::transfer::Receiving;
 
@@ -343,6 +345,19 @@ public fun deposit<S: drop, P: copy + drop + store, C>(
     event::emit(Deposited<S, C> { wallet_id: object::id(wallet), amount });
 }
 
+/// Sweep `amount` from the wallet's own object address balance into its on-book
+/// `balance`, via `deposit`. The address-balance analogue of `receive_and_deposit`.
+public fun sweep_settled<S: drop, P: copy + drop + store, C>(
+    wallet: &mut VestingWallet<S, P, C>,
+    root: &AccumulatorRoot,
+) {
+    let addr = object::uid_to_address(&wallet.id);
+    let amount = balance::settled_funds_value<C>(root, addr);
+    if (amount == 0) return;
+    let w = balance::withdraw_funds_from_object<C>(&mut wallet.id, amount);
+    wallet.deposit(balance::redeem_funds(w));
+}
+
 /// Claim a coin that an upstream emitter `public_transfer`'d to this wallet's
 /// object address, then funnel it through the standard deposit path. Used by
 /// emission schedules and payroll robots that don't hold a wallet reference.
@@ -375,7 +390,6 @@ public fun receive_and_deposit<S: drop, P: copy + drop + store, C>(
 /// #### Parameters
 /// - `wallet`: The wallet to release from.
 /// - `vested`: A `VestedAmount<S>` minted for this wallet by its curve module.
-/// - `ctx`: Transaction context, used to mint the payout coin.
 ///
 /// #### Aborts
 /// - `EWalletMismatch` if `vested` was not minted for this wallet.
@@ -385,7 +399,6 @@ public fun receive_and_deposit<S: drop, P: copy + drop + store, C>(
 public fun release<S: drop, P: copy + drop + store, C>(
     wallet: &mut VestingWallet<S, P, C>,
     vested: &VestedAmount<S>,
-    ctx: &mut TxContext,
 ) {
     let VestedAmount { wallet_id, amount: vested_amount } = vested;
     assert!(wallet_id == object::id(wallet), EWalletMismatch);

--- a/contracts/finance/sources/vesting_wallet.move
+++ b/contracts/finance/sources/vesting_wallet.move
@@ -78,8 +78,9 @@
 /// - **Owned** (fast path): `transfer::public_transfer(wallet, addr)` - only the
 ///   holder can pass the wallet by `&mut`, so funding and release are reachable
 ///   from the holder's transactions only. Outside parties fund it by
-///   `public_transfer`ing a `Coin<C>` to the wallet's object address; the holder
-///   then claims each with `receive_and_deposit`.
+///   `public_transfer`ing a `Coin<C>` to the wallet's object address (the holder
+///   claims each with `receive_and_deposit`) or by settling a `Balance<C>` into the
+///   address (the holder pulls it in with `sweep_settled`).
 ///
 /// The `beneficiary` is fixed at construction. To rotate the recipient, point
 /// `beneficiary` at a consumer-owned object and rotate ownership of that object
@@ -181,7 +182,7 @@ public struct VestingWallet<phantom S: drop, P: copy + drop + store, phantom C> 
 ///
 /// ```move
 /// let v = some_curve::vested_amount(wrapper.inner(), clock);
-/// wrapper.release(&v, ctx);
+/// wrapper.release(&v);
 /// ```
 ///
 /// Handing out `&inner` is safe: it only allows views and curve-gated minting of an
@@ -325,10 +326,10 @@ public fun mint_vested_amount<S: drop, P: copy + drop + store, C>(
     VestedAmount { wallet_id: object::id(wallet), amount }
 }
 
-/// Add a coin to the wallet's balance. Permissionless - the beneficiary's
+/// Add a `Balance<C>` to the wallet's balance. Permissionless - the beneficiary's
 /// identity is data, not a capability, and anyone may fund.
 ///
-/// A deposit of a zero-value coin is a no-op: the (empty) balance is consumed but
+/// A deposit of a zero-value balance is a no-op: the (empty) balance is consumed but
 /// nothing changes and no `Deposited` event is emitted.
 ///
 /// #### Parameters

--- a/contracts/finance/sources/vesting_wallet.move
+++ b/contracts/finance/sources/vesting_wallet.move
@@ -383,7 +383,7 @@ public fun sweep_settled<S: drop, P: copy + drop + store, C>(
     wallet: &mut VestingWallet<S, P, C>,
     root: &AccumulatorRoot,
 ) {
-    let addr = object::uid_to_address(&wallet.id);
+    let addr = wallet.id.to_address();
     let amount = balance::settled_funds_value<C>(root, addr);
     if (amount == 0) return;
     let w = balance::withdraw_funds_from_object<C>(&mut wallet.id, amount);
@@ -419,28 +419,6 @@ public fun receive_and_deposit<S: drop, P: copy + drop + store, C>(
     let amount = wallet.deposit_internal(coin.into_balance());
     if (amount == 0) return;
     event::emit(Received<S, C> { wallet_id: object::id(wallet), amount });
-}
-
-/// Join `balance` into the wallet's balance and return the amount added, leaving
-/// event emission to the caller. Shared by `deposit`, `sweep_settled`, and
-/// `receive_and_deposit`.
-///
-/// #### Aborts
-/// - `EBalanceOverflow` if the deposit would push the wallet's lifetime total
-///   `balance + released` (== `Σ(deposits)`) past `u64::MAX`.
-fun deposit_internal<S: drop, P: copy + drop + store, C>(
-    wallet: &mut VestingWallet<S, P, C>,
-    balance: Balance<C>,
-): u64 {
-    let amount = balance.value();
-
-    assert!(
-        std::u64::max_value!() - wallet.balance.value() - wallet.released >= amount,
-        EBalanceOverflow,
-    );
-
-    wallet.balance.join(balance);
-    amount
 }
 
 /// Pay the not-yet-released portion attested by `vested` into the beneficiary's
@@ -518,29 +496,10 @@ public fun destroy_empty<S: drop, P: copy + drop + store, C>(
     root: &AccumulatorRoot,
 ): DestroyReceipt<S, P> {
     assert!(wallet.balance.value() == 0, ENotEmpty);
-    let settled = balance::settled_funds_value<C>(root, object::uid_to_address(&wallet.id));
+    let settled = balance::settled_funds_value<C>(root, wallet.id.to_address());
     assert!(settled == 0, EUnsweptFunds);
 
     wallet.finish_destroy()
-}
-
-/// Shared teardown for `destroy_empty`: consume the drained wallet, emit `Destroyed`, and
-/// return the receipt. Assumes the empty-balance and settled-funds gates have already
-/// passed.
-fun finish_destroy<S: drop, P: copy + drop + store, C>(
-    wallet: VestingWallet<S, P, C>,
-): DestroyReceipt<S, P> {
-    let wallet_id = object::id(&wallet);
-    let beneficiary = wallet.beneficiary;
-    let total_released = wallet.released;
-
-    let VestingWallet { id, balance, schedule_params, .. } = wallet;
-    balance.destroy_zero();
-    id.delete();
-
-    event::emit(Destroyed<S, C> { wallet_id, beneficiary, total_released });
-
-    DestroyReceipt { beneficiary, params: schedule_params }
 }
 
 /// Unwrap a `DestroyReceipt<S, P>` to recover the destroyed wallet's beneficiary and
@@ -593,35 +552,17 @@ public fun releasable<S: drop, P: copy + drop + store, C>(
 
 /// Read the cumulative vested total recorded in a `VestedAmount<S>` without
 /// consuming it.
-///
-/// #### Parameters
-/// - `vested`: The `VestedAmount<S>` to read.
-///
-/// #### Returns
-/// - The cumulative vested total recorded in `vested`.
 public fun amount<S>(vested: &VestedAmount<S>): u64 {
     vested.amount
 }
 
 /// Read the wallet's schedule parameters. Ungated - curve parameters are public
 /// information.
-///
-/// #### Parameters
-/// - `wallet`: The wallet to query.
-///
-/// #### Returns
-/// - The wallet's stored schedule parameters.
 public fun schedule_params<S: drop, P: copy + drop + store, C>(wallet: &VestingWallet<S, P, C>): P {
     wallet.schedule_params
 }
 
 /// Address that receives every `release`.
-///
-/// #### Parameters
-/// - `wallet`: The wallet to query.
-///
-/// #### Returns
-/// - The address that receives every `release`.
 public fun beneficiary<S: drop, P: copy + drop + store, C>(
     wallet: &VestingWallet<S, P, C>,
 ): address {
@@ -629,25 +570,56 @@ public fun beneficiary<S: drop, P: copy + drop + store, C>(
 }
 
 /// Cumulative amount released so far.
-///
-/// #### Parameters
-/// - `wallet`: The wallet to query.
-///
-/// #### Returns
-/// - The cumulative amount released so far.
 public fun released<S: drop, P: copy + drop + store, C>(wallet: &VestingWallet<S, P, C>): u64 {
     wallet.released
 }
 
 /// Funds currently held by the wallet and not yet released.
-///
-/// #### Parameters
-/// - `wallet`: The wallet to query.
-///
-/// #### Returns
-/// - The funds currently held by the wallet and not yet released.
 public fun balance<S: drop, P: copy + drop + store, C>(wallet: &VestingWallet<S, P, C>): u64 {
     wallet.balance.value()
+}
+
+// === Private Functions ===
+
+/// Join `balance` into the wallet's balance and return the amount added, leaving
+/// event emission to the caller. Shared by `deposit`, `sweep_settled`, and
+/// `receive_and_deposit`.
+///
+/// #### Aborts
+/// - `EBalanceOverflow` if the deposit would push the wallet's lifetime total
+///   `balance + released` (== `Σ(deposits)`) past `u64::MAX`.
+fun deposit_internal<S: drop, P: copy + drop + store, C>(
+    wallet: &mut VestingWallet<S, P, C>,
+    balance: Balance<C>,
+): u64 {
+    let amount = balance.value();
+
+    assert!(
+        std::u64::max_value!() - wallet.balance.value() - wallet.released >= amount,
+        EBalanceOverflow,
+    );
+
+    wallet.balance.join(balance);
+    amount
+}
+
+/// Shared teardown for `destroy_empty`: consume the drained wallet, emit `Destroyed`, and
+/// return the receipt. Assumes the empty-balance and settled-funds gates have already
+/// passed.
+fun finish_destroy<S: drop, P: copy + drop + store, C>(
+    wallet: VestingWallet<S, P, C>,
+): DestroyReceipt<S, P> {
+    let wallet_id = object::id(&wallet);
+    let beneficiary = wallet.beneficiary;
+    let total_released = wallet.released;
+
+    let VestingWallet { id, balance, schedule_params, .. } = wallet;
+    balance.destroy_zero();
+    id.delete();
+
+    event::emit(Destroyed<S, C> { wallet_id, beneficiary, total_released });
+
+    DestroyReceipt { beneficiary, params: schedule_params }
 }
 
 // === Test-Only Helpers ===

--- a/contracts/finance/sources/vesting_wallet.move
+++ b/contracts/finance/sources/vesting_wallet.move
@@ -400,11 +400,7 @@ public fun release<S: drop, P: copy + drop + store, C>(
     wallet: &mut VestingWallet<S, P, C>,
     vested: &VestedAmount<S>,
 ) {
-    let VestedAmount { wallet_id, amount: vested_amount } = vested;
-    assert!(wallet_id == object::id(wallet), EWalletMismatch);
-    assert!(*vested_amount >= wallet.released, EVestedBelowReleased);
-
-    let releasable = *vested_amount - wallet.released;
+    let releasable = wallet.releasable(vested);
     if (releasable == 0) return;
     assert!(releasable <= wallet.balance.value(), EInsufficientBalance);
 

--- a/contracts/finance/sources/vesting_wallet.move
+++ b/contracts/finance/sources/vesting_wallet.move
@@ -197,12 +197,13 @@ public struct VestedAmount<phantom S> has drop {
 }
 
 /// Carries a destroyed wallet's beneficiary and schedule params back to its curve. A
-/// HOT POTATO - no abilities - so it cannot be dropped, stored, or copied: it MUST be
-/// consumed before the tx ends, and only `consume_receipt` (witness-gated) can consume
-/// it. This is what drags the curve into the PTB to finalize, and lets it veto by
-/// aborting.
+/// HOT POTATO that only `consume_receipt` (witness-gated) can consume.
+/// This is what drags the curve into the PTB to finalize, and lets it veto by aborting.
 public struct DestroyReceipt<phantom S, P> {
+    /// Beneficiary of the destroyed wallet, handed back for the curve to use.
     beneficiary: address,
+    /// Schedule parameters of the destroyed wallet, handed back for the curve to
+    /// destructure.
     params: P,
 }
 
@@ -330,6 +331,10 @@ public fun mint_vested_amount<S: drop, P: copy + drop + store, C>(
 /// A deposit of a zero-value coin is a no-op: the (empty) balance is consumed but
 /// nothing changes and no `Deposited` event is emitted.
 ///
+/// #### Parameters
+/// - `wallet`: The wallet to fund.
+/// - `balance`: The funds to add to the wallet's balance.
+///
 /// #### Aborts
 /// - `EBalanceOverflow` if the deposit would push the wallet's lifetime total
 ///   `balance + released` (== `Σ(deposits)`) past `u64::MAX`, which would
@@ -352,6 +357,18 @@ public fun deposit<S: drop, P: copy + drop + store, C>(
 
 /// Sweep `amount` from the wallet's own object address balance into its on-book
 /// `balance`, via `deposit`. The address-balance analogue of `receive_and_deposit`.
+///
+/// A wallet with no settled funds at its address is a no-op: nothing is swept and
+/// no `Deposited` event is emitted.
+///
+/// #### Parameters
+/// - `wallet`: The wallet to sweep into.
+/// - `root`: The shared `AccumulatorRoot`, read to find the wallet's settled funds.
+///
+/// #### Aborts
+/// - `EBalanceOverflow` if sweeping the settled funds would push the wallet's
+///   lifetime total `balance + released` past `u64::MAX` (propagated from
+///   `deposit`).
 public fun sweep_settled<S: drop, P: copy + drop + store, C>(
     wallet: &mut VestingWallet<S, P, C>,
     root: &AccumulatorRoot,
@@ -366,6 +383,11 @@ public fun sweep_settled<S: drop, P: copy + drop + store, C>(
 /// Claim a coin that an upstream emitter `public_transfer`'d to this wallet's
 /// object address, then funnel it through the standard deposit path. Used by
 /// emission schedules and payroll robots that don't hold a wallet reference.
+///
+/// #### Parameters
+/// - `wallet`: The wallet to fund.
+/// - `receiving`: The `Coin<C>` transferred to the wallet's object address, to be
+///   claimed and deposited.
 ///
 /// #### Aborts
 /// - `EBalanceOverflow` if claiming the coin would overflow the wallet's

--- a/contracts/finance/sources/vesting_wallet.move
+++ b/contracts/finance/sources/vesting_wallet.move
@@ -58,7 +58,7 @@
 ///    itself (calling `vesting_wallet::new` directly) without routing through `new`.
 /// 3. A `vested(&VestingWallet<MyCurve, MyParams, C>, &Clock): VestedAmount<MyCurve>`
 ///    that ends in `vesting_wallet::mint_vested_amount(wallet, MyCurve {}, amount)`.
-/// 4. A teardown that calls `vesting_wallet::destroy_empty(wallet)` to get a
+/// 4. A teardown that calls `vesting_wallet::destroy_empty(wallet, root)` to get a
 ///    `DestroyReceipt<MyCurve, MyParams>`, then
 ///    `vesting_wallet::consume_receipt(receipt, MyCurve {})` to recover the
 ///    beneficiary and parameters for the curve module to destructure.
@@ -117,6 +117,11 @@ const EBalanceOverflow: vector<u8> = "Deposit would overflow the wallet's lifeti
 /// so the current balance cannot cover the releasable amount.
 #[error(code = 4)]
 const EInsufficientBalance: vector<u8> = "Releasable amount exceeds the wallet's balance";
+
+/// `destroy_empty` was called on a wallet that still has unswept settled funds at
+/// its object address. Call `sweep_settled` first.
+#[error(code = 5)]
+const EUnsweptFunds: vector<u8> = "Wallet has unswept settled funds at its address";
 
 // === Structs ===
 
@@ -433,7 +438,10 @@ public fun release<S: drop, P: copy + drop + store, C>(
 /// wallet.
 ///
 /// #### Parameters
-/// - `wallet`: The wallet to destroy. Must hold a zero balance.
+/// - `wallet`: The wallet to destroy. Must hold a zero balance and have no pending
+///   settled funds at its object address (`sweep_settled` first if it does).
+/// - `root`: The shared `AccumulatorRoot`, read to confirm the wallet's object
+///   address holds no unswept settled funds.
 ///
 /// #### Returns
 /// - A `DestroyReceipt<S, P>` carrying the wallet's beneficiary and schedule
@@ -441,11 +449,24 @@ public fun release<S: drop, P: copy + drop + store, C>(
 ///
 /// #### Aborts
 /// - `ENotEmpty` if the wallet still holds a balance.
+/// - `EUnsweptFunds` if the wallet has any pending settled funds.
 public fun destroy_empty<S: drop, P: copy + drop + store, C>(
     wallet: VestingWallet<S, P, C>,
+    root: &AccumulatorRoot,
 ): DestroyReceipt<S, P> {
     assert!(wallet.balance.value() == 0, ENotEmpty);
+    let settled = balance::settled_funds_value<C>(root, object::uid_to_address(&wallet.id));
+    assert!(settled == 0, EUnsweptFunds);
 
+    wallet.finish_destroy()
+}
+
+/// Shared teardown for `destroy_empty`: consume the drained wallet, emit `Destroyed`, and
+/// return the receipt. Assumes the empty-balance and settled-funds gates have already
+/// passed.
+fun finish_destroy<S: drop, P: copy + drop + store, C>(
+    wallet: VestingWallet<S, P, C>,
+): DestroyReceipt<S, P> {
     let wallet_id = object::id(&wallet);
     let beneficiary = wallet.beneficiary;
     let total_released = wallet.released;
@@ -567,6 +588,22 @@ public fun balance<S: drop, P: copy + drop + store, C>(wallet: &VestingWallet<S,
 }
 
 // === Test-Only Helpers ===
+
+/// Tear down a drained wallet without the `AccumulatorRoot` settled-funds gate, so unit
+/// tests can exercise teardown without constructing an `AccumulatorRoot` - which has no
+/// test constructor in the pinned Sui release. The empty-balance gate is kept, so the
+/// `ENotEmpty` path stays covered through this entry too.
+///
+/// TODO: remove this and route the teardown tests through `destroy_empty` with a real
+/// `AccumulatorRoot` (via `accumulator::create_for_testing`) once that test helper ships
+/// in the published Sui mainnet framework.
+#[test_only]
+public fun destroy_empty_for_testing<S: drop, P: copy + drop + store, C>(
+    wallet: VestingWallet<S, P, C>,
+): DestroyReceipt<S, P> {
+    assert!(wallet.balance.value() == 0, ENotEmpty);
+    wallet.finish_destroy()
+}
 
 /// Build a `Created` event value for asserting against `event::events_by_type`.
 #[test_only]

--- a/contracts/finance/sources/vesting_wallet.move
+++ b/contracts/finance/sources/vesting_wallet.move
@@ -217,11 +217,27 @@ public struct Created<phantom S, P, phantom C> has copy, drop {
     schedule_params: P,
 }
 
-/// Emitted by `deposit` (and `receive_and_deposit`) when a non-zero amount is
-/// added. A deposit of a zero-value balance emits no event.
+/// Emitted by `deposit` when a non-zero amount is added. A deposit of a
+/// zero-value balance emits no event.
 public struct Deposited<phantom S, phantom C> has copy, drop {
     wallet_id: ID,
     /// Amount added to the balance by this deposit.
+    amount: u64,
+}
+
+/// Emitted by `sweep_settled` when a non-zero amount is added. A sweep of a
+/// zero-value balance emits no event.
+public struct Swept<phantom S, phantom C> has copy, drop {
+    wallet_id: ID,
+    /// Amount added to the balance by this sweep.
+    amount: u64,
+}
+
+/// Emitted by `receive_and_deposit` when a non-zero amount is added. A deposit
+/// of a zero-value coin emits no event.
+public struct Received<phantom S, phantom C> has copy, drop {
+    wallet_id: ID,
+    /// Amount added to the balance by this receival.
     amount: u64,
 }
 
@@ -344,23 +360,16 @@ public fun deposit<S: drop, P: copy + drop + store, C>(
     wallet: &mut VestingWallet<S, P, C>,
     balance: Balance<C>,
 ) {
-    let amount = balance.value();
-
-    assert!(
-        std::u64::max_value!() - wallet.balance.value() - wallet.released >= amount,
-        EBalanceOverflow,
-    );
-
-    wallet.balance.join(balance);
+    let amount = wallet.deposit_internal(balance);
     if (amount == 0) return;
     event::emit(Deposited<S, C> { wallet_id: object::id(wallet), amount });
 }
 
 /// Sweep `amount` from the wallet's own object address balance into its on-book
-/// `balance`, via `deposit`. The address-balance analogue of `receive_and_deposit`.
+/// `balance`.
 ///
 /// A wallet with no settled funds at its address is a no-op: nothing is swept and
-/// no `Deposited` event is emitted.
+/// no `Swept` event is emitted.
 ///
 /// #### Parameters
 /// - `wallet`: The wallet to sweep into.
@@ -378,12 +387,17 @@ public fun sweep_settled<S: drop, P: copy + drop + store, C>(
     let amount = balance::settled_funds_value<C>(root, addr);
     if (amount == 0) return;
     let w = balance::withdraw_funds_from_object<C>(&mut wallet.id, amount);
-    wallet.deposit(balance::redeem_funds(w));
+    // amount is already known and positive, so the returned value is redundant here.
+    _ = wallet.deposit_internal(balance::redeem_funds(w));
+    event::emit(Swept<S, C> { wallet_id: object::id(wallet), amount });
 }
 
 /// Claim a coin that an upstream emitter `public_transfer`'d to this wallet's
-/// object address, then funnel it through the standard deposit path. Used by
-/// emission schedules and payroll robots that don't hold a wallet reference.
+/// object address, then add it to the balance. Used by emission schedules and
+/// payroll robots that don't hold a wallet reference.
+///
+/// A claim of a zero-value coin is a no-op: the (empty) balance is consumed but
+/// nothing changes and no `Received` event is emitted.
 ///
 /// #### Parameters
 /// - `wallet`: The wallet to fund.
@@ -402,7 +416,31 @@ public fun receive_and_deposit<S: drop, P: copy + drop + store, C>(
     receiving: Receiving<Coin<C>>,
 ) {
     let coin = transfer::public_receive(&mut wallet.id, receiving);
-    wallet.deposit(coin.into_balance());
+    let amount = wallet.deposit_internal(coin.into_balance());
+    if (amount == 0) return;
+    event::emit(Received<S, C> { wallet_id: object::id(wallet), amount });
+}
+
+/// Join `balance` into the wallet's balance and return the amount added, leaving
+/// event emission to the caller. Shared by `deposit`, `sweep_settled`, and
+/// `receive_and_deposit`.
+///
+/// #### Aborts
+/// - `EBalanceOverflow` if the deposit would push the wallet's lifetime total
+///   `balance + released` (== `Σ(deposits)`) past `u64::MAX`.
+fun deposit_internal<S: drop, P: copy + drop + store, C>(
+    wallet: &mut VestingWallet<S, P, C>,
+    balance: Balance<C>,
+): u64 {
+    let amount = balance.value();
+
+    assert!(
+        std::u64::max_value!() - wallet.balance.value() - wallet.released >= amount,
+        EBalanceOverflow,
+    );
+
+    wallet.balance.join(balance);
+    amount
 }
 
 /// Pay the not-yet-released portion attested by `vested` into the beneficiary's
@@ -643,6 +681,18 @@ public fun test_new_created<S, P, C>(
 #[test_only]
 public fun test_new_deposited<S, C>(wallet_id: ID, amount: u64): Deposited<S, C> {
     Deposited { wallet_id, amount }
+}
+
+/// Build a `Swept` event value for asserting against `event::events_by_type`.
+#[test_only]
+public fun test_new_swept<S, C>(wallet_id: ID, amount: u64): Swept<S, C> {
+    Swept { wallet_id, amount }
+}
+
+/// Build a `Received` event value for asserting against `event::events_by_type`.
+#[test_only]
+public fun test_new_received<S, C>(wallet_id: ID, amount: u64): Received<S, C> {
+    Received { wallet_id, amount }
 }
 
 /// Build a `Released` event value for asserting against `event::events_by_type`.

--- a/contracts/finance/sources/vesting_wallet.move
+++ b/contracts/finance/sources/vesting_wallet.move
@@ -17,7 +17,7 @@
 /// The wallet itself never interprets the schedule - it only enforces release
 /// accounting and conservation of funds. A curve module evaluates its curve for
 /// the current clock, mints a `VestedAmount<S>`, and `release` pays out the
-/// not-yet-released portion.
+/// not-yet-released portion into the beneficiary's address balance.
 ///
 /// This module ships no curve of its own. The built-in linear-with-cliff schedule
 /// lives in the sibling `vesting_wallet_linear` module - the reference curve, and the
@@ -405,14 +405,15 @@ public fun receive_and_deposit<S: drop, P: copy + drop + store, C>(
     wallet.deposit(coin.into_balance());
 }
 
-/// Pay the not-yet-released portion attested by `vested` to the beneficiary.
-/// Permissionless: anyone holding references to the wallet and a `VestedAmount` can
-/// poke this. The recipient is always read fresh from `wallet.beneficiary` at call
-/// time. `vested` is borrowed, not consumed, so the same attestation can still be
-/// passed to a later call in the PTB.
+/// Pay the not-yet-released portion attested by `vested` into the beneficiary's
+/// address balance (via `balance::send_funds`) - no `Coin<C>` object is minted or
+/// transferred. Permissionless: anyone holding references to the wallet and a
+/// `VestedAmount` can poke this. The recipient is always read fresh from
+/// `wallet.beneficiary` at call time. `vested` is borrowed, not consumed, so the
+/// same attestation can still be passed to a later call in the PTB.
 ///
 /// If nothing new is vested since the last release (the wallet is already drained
-/// at this clock), the call is a no-op: no coin is transferred and no event is
+/// at this clock), the call is a no-op: nothing is paid out and no event is
 /// emitted.
 ///
 /// #### Parameters

--- a/contracts/finance/sources/vesting_wallet.move
+++ b/contracts/finance/sources/vesting_wallet.move
@@ -87,7 +87,6 @@
 module openzeppelin_finance::vesting_wallet;
 
 use sui::balance::{Self, Balance};
-use sui::coin::{Self, Coin};
 use sui::event;
 use sui::transfer::Receiving;
 
@@ -210,7 +209,7 @@ public struct Created<phantom S, P, phantom C> has copy, drop {
 }
 
 /// Emitted by `deposit` (and `receive_and_deposit`) when a non-zero amount is
-/// added. A deposit of a zero-value coin emits no event.
+/// added. A deposit of a zero-value balance emits no event.
 public struct Deposited<phantom S, phantom C> has copy, drop {
     wallet_id: ID,
     /// Amount added to the balance by this deposit.
@@ -330,16 +329,16 @@ public fun mint_vested_amount<S: drop, P: copy + drop + store, C>(
 ///   indefinitely brick the release path.
 public fun deposit<S: drop, P: copy + drop + store, C>(
     wallet: &mut VestingWallet<S, P, C>,
-    coin: Coin<C>,
+    balance: Balance<C>,
 ) {
-    let amount = coin.value();
+    let amount = balance.value();
 
     assert!(
         std::u64::max_value!() - wallet.balance.value() - wallet.released >= amount,
         EBalanceOverflow,
     );
 
-    wallet.balance.join(coin.into_balance());
+    wallet.balance.join(balance);
     if (amount == 0) return;
     event::emit(Deposited<S, C> { wallet_id: object::id(wallet), amount });
 }
@@ -360,7 +359,7 @@ public fun receive_and_deposit<S: drop, P: copy + drop + store, C>(
     receiving: Receiving<Coin<C>>,
 ) {
     let coin = transfer::public_receive(&mut wallet.id, receiving);
-    wallet.deposit(coin);
+    wallet.deposit(coin.into_balance());
 }
 
 /// Pay the not-yet-released portion attested by `vested` to the beneficiary.
@@ -396,10 +395,12 @@ public fun release<S: drop, P: copy + drop + store, C>(
     if (releasable == 0) return;
     assert!(releasable <= wallet.balance.value(), EInsufficientBalance);
 
-    wallet.released = wallet.released + releasable;
-    let coin = coin::from_balance(wallet.balance.split(releasable), ctx);
     let beneficiary = wallet.beneficiary;
-    transfer::public_transfer(coin, beneficiary);
+
+    wallet.released = wallet.released + releasable;
+
+    let payout = wallet.balance.split(releasable);
+    balance::send_funds(payout, beneficiary);
 
     event::emit(Released<S, C> {
         wallet_id: object::id(wallet),

--- a/contracts/finance/sources/vesting_wallet_linear.move
+++ b/contracts/finance/sources/vesting_wallet_linear.move
@@ -318,14 +318,9 @@ public fun vested_amount<C>(
 /// #### Parameters
 /// - `wallet`: The wallet to release from.
 /// - `clock`: Sui `Clock`, read for the current timestamp.
-/// - `ctx`: Transaction context, used to mint the payout coin.
-public fun release<C>(
-    wallet: &mut VestingWallet<Linear, Params, C>,
-    clock: &Clock,
-    ctx: &mut TxContext,
-) {
+public fun release<C>(wallet: &mut VestingWallet<Linear, Params, C>, clock: &Clock) {
     let v = vested_amount(wallet, clock);
-    wallet.release(&v, ctx);
+    wallet.release(&v);
 }
 
 /// How much `release` would pay out right now, without the caller minting a

--- a/contracts/finance/sources/vesting_wallet_linear.move
+++ b/contracts/finance/sources/vesting_wallet_linear.move
@@ -378,68 +378,32 @@ public fun destroy(receipt: DestroyReceipt<Linear, Params>, clock: &Clock, ctx: 
 // === View helpers ===
 
 /// Timestamp (ms) at which vesting begins.
-///
-/// #### Parameters
-/// - `wallet`: The wallet to query.
-///
-/// #### Returns
-/// - The timestamp (ms) at which vesting begins.
 public fun start_ms<C>(wallet: &VestingWallet<Linear, Params, C>): u64 {
     wallet.schedule_params().start_ms
 }
 
 /// Length of each tranche period (ms).
-///
-/// #### Parameters
-/// - `wallet`: The wallet to query.
-///
-/// #### Returns
-/// - The length of each tranche period (ms).
 public fun period_ms<C>(wallet: &VestingWallet<Linear, Params, C>): u64 {
     wallet.schedule_params().period_ms
 }
 
 /// Number of equal tranches.
-///
-/// #### Parameters
-/// - `wallet`: The wallet to query.
-///
-/// #### Returns
-/// - The number of equal tranches.
 public fun steps<C>(wallet: &VestingWallet<Linear, Params, C>): u64 {
     wallet.schedule_params().steps
 }
 
 /// Length of the vesting period (ms): `period_ms * steps`.
-///
-/// #### Parameters
-/// - `wallet`: The wallet to query.
-///
-/// #### Returns
-/// - The length of the vesting period (ms): `period_ms * steps`.
 public fun duration_ms<C>(wallet: &VestingWallet<Linear, Params, C>): u64 {
     let params = wallet.schedule_params();
     params.period_ms * params.steps
 }
 
 /// Timestamp (ms) at which the schedule ends (`start_ms + period_ms * steps`).
-///
-/// #### Parameters
-/// - `wallet`: The wallet to query.
-///
-/// #### Returns
-/// - The timestamp (ms) at which the schedule ends (`start_ms + period_ms * steps`).
 public fun end_ms<C>(wallet: &VestingWallet<Linear, Params, C>): u64 {
     wallet.schedule_params().calculate_end()
 }
 
 /// Read the configured cliff length (ms from `start_ms`). `0` means no cliff.
-///
-/// #### Parameters
-/// - `wallet`: The wallet to query.
-///
-/// #### Returns
-/// - The configured cliff length (ms from `start_ms`); `0` means no cliff.
 public fun cliff_ms<C>(wallet: &VestingWallet<Linear, Params, C>): u64 {
     wallet.schedule_params().cliff_ms
 }
@@ -464,7 +428,7 @@ fun vested_amount_raw<C>(wallet: &VestingWallet<Linear, Params, C>, clock: &Cloc
     } else {
         // SAFETY: depositing has a check ensuring no balance overflow can occur.
         let total = wallet.balance() + wallet.released();
-        // SAFETY: construction guarantees `period_ms * steps` and`start_ms + period_ms * steps`
+        // SAFETY: construction guarantees `period_ms * steps` and `start_ms + period_ms * steps`
         // fit in u64, so neither arithmetic here overflows.
         if (now >= start_ms + period_ms * steps) {
             total

--- a/contracts/finance/tests/vesting_wallet_linear_tests.move
+++ b/contracts/finance/tests/vesting_wallet_linear_tests.move
@@ -3,6 +3,7 @@ module openzeppelin_finance::vesting_wallet_linear_tests;
 use openzeppelin_finance::vesting_wallet::{Self, VestingWallet, Created, Released, Destroyed};
 use openzeppelin_finance::vesting_wallet_linear::{Self, Linear, Params};
 use std::unit_test::{assert_eq, destroy};
+use sui::balance;
 use sui::clock::{Self, Clock};
 use sui::coin;
 use sui::event;
@@ -44,8 +45,8 @@ fun new_continuous(
     vesting_wallet_linear::new_continuous<USDC>(BENEFICIARY, start, cliff, duration, ctx)
 }
 
-fun fund(wallet: &mut VestingWallet<Linear, Params, USDC>, amount: u64, ctx: &mut TxContext) {
-    wallet.deposit(coin::mint_for_testing<USDC>(amount, ctx));
+fun fund(wallet: &mut VestingWallet<Linear, Params, USDC>, amount: u64) {
+    wallet.deposit(balance::create_for_testing(amount));
 }
 
 /// The curve's cumulative vested total at the given clock.
@@ -117,7 +118,7 @@ fun new_accepts_cliff_equal_to_duration() {
 
     // duration = 1000 * 4 = 4000.
     let mut wallet = new_stepped(0, 4000, 1000, 4, test.ctx());
-    wallet.fund(1000, test.ctx());
+    wallet.fund(1000);
 
     clk.set_for_testing(3999);
     assert_eq!(wallet.vested(&clk), 0); // still gated by the cliff
@@ -171,7 +172,7 @@ fun params_drives_bare_primitive() {
 
     let p = vesting_wallet_linear::params(100, 250, 1000, 4);
     let mut wallet = vesting_wallet::new<Linear, Params, USDC>(p, BENEFICIARY, test.ctx());
-    wallet.fund(1000, test.ctx());
+    wallet.fund(1000);
 
     assert_eq!(vesting_wallet_linear::start_ms(&wallet), 100);
     assert_eq!(vesting_wallet_linear::cliff_ms(&wallet), 250);
@@ -240,7 +241,7 @@ fun vested_amount_pre_start_is_zero() {
     let (mut test, mut clk) = setup(0);
 
     let mut wallet = new_stepped(1000, 0, 1000, 4, test.ctx());
-    wallet.fund(1000, test.ctx());
+    wallet.fund(1000);
 
     clk.set_for_testing(999);
     assert_eq!(wallet.vested(&clk), 0);
@@ -257,7 +258,7 @@ fun vested_amount_is_a_staircase() {
     let (mut test, mut clk) = setup(0);
 
     let mut wallet = new_stepped(0, 0, 1000, 4, test.ctx());
-    wallet.fund(1000, test.ctx());
+    wallet.fund(1000);
 
     // First period [0, 1000): zero steps elapsed, nothing vested.
     clk.set_for_testing(0);
@@ -291,7 +292,7 @@ fun vested_amount_pre_cliff_is_zero() {
     let (mut test, mut clk) = setup(0);
 
     let mut wallet = new_stepped(0, 500, 1000, 4, test.ctx());
-    wallet.fund(1000, test.ctx());
+    wallet.fund(1000);
 
     clk.set_for_testing(0);
     assert_eq!(wallet.vested(&clk), 0);
@@ -317,7 +318,7 @@ fun vested_amount_at_cliff_jumps_to_catch_up() {
 
     // 8 steps of 1000ms (duration 8000); cliff at 3000 spans 3 full periods.
     let mut wallet = new_stepped(0, 3000, 1000, 8, test.ctx());
-    wallet.fund(8000, test.ctx());
+    wallet.fund(8000);
 
     clk.set_for_testing(2999);
     assert_eq!(wallet.vested(&clk), 0); // gated by the cliff
@@ -339,7 +340,7 @@ fun vested_amount_post_end_clamps_to_total() {
     let (mut test, mut clk) = setup(0);
 
     let mut wallet = new_stepped(0, 0, 1000, 4, test.ctx());
-    wallet.fund(1000, test.ctx());
+    wallet.fund(1000);
 
     // Last boundary is the end (start + period * steps = 4000): full total.
     clk.set_for_testing(4000);
@@ -360,7 +361,7 @@ fun vested_amount_is_nondecreasing_in_time() {
     let (mut test, mut clk) = setup(0);
 
     let mut wallet = new_stepped(0, 1000, 1000, 4, test.ctx());
-    wallet.fund(1000, test.ctx());
+    wallet.fund(1000);
 
     let mut prev = 0;
     vector[0u64, 500, 1000, 1500, 2000, 3000, 4000, 5000].do!(|sample| {
@@ -385,7 +386,7 @@ fun vested_amount_uses_u128_intermediate_at_max() {
     // 2 steps of (max / 2) each: duration = max - 1 (max is odd), end = max - 1.
     let half = max / 2;
     let mut wallet = new_stepped(0, 0, half, 2, test.ctx());
-    wallet.fund(max, test.ctx());
+    wallet.fund(max);
 
     // One step elapsed: max * 1 / 2 = floor(max / 2), with no overflow and no abort.
     clk.set_for_testing(half);
@@ -407,7 +408,7 @@ fun deposit_vests_as_if_from_start() {
     clk.set_for_testing(2000); // two steps elapsed
     assert_eq!(wallet.vested(&clk), 0); // nothing deposited yet
 
-    wallet.fund(1000, test.ctx());
+    wallet.fund(1000);
     // two of four steps elapsed, so half the fresh deposit is already vested.
     assert_eq!(wallet.vested(&clk), 500);
 
@@ -427,10 +428,10 @@ fun release_pays_step_portion_and_is_permissionless() {
 
     let mut wallet = new_stepped(0, 0, 1000, 4, test.ctx());
     let wallet_id = object::id(&wallet);
-    wallet.fund(1000, test.ctx());
+    wallet.fund(1000);
 
     clk.set_for_testing(2000); // two steps => 500
-    vesting_wallet_linear::release(&mut wallet, &clk, test.ctx());
+    vesting_wallet_linear::release(&mut wallet, &clk);
 
     assert_eq!(wallet.released(), 500);
     assert_eq!(wallet.balance(), 500);
@@ -461,17 +462,17 @@ fun release_then_release_within_same_period_is_noop() {
     let (mut test, mut clk) = setup(0);
 
     let mut wallet = new_stepped(0, 0, 1000, 4, test.ctx());
-    wallet.fund(1000, test.ctx());
+    wallet.fund(1000);
 
     clk.set_for_testing(1000); // one step => 250
-    vesting_wallet_linear::release(&mut wallet, &clk, test.ctx());
+    vesting_wallet_linear::release(&mut wallet, &clk);
     assert_eq!(wallet.released(), 250);
     assert_eq!(event::events_by_type<Released<Linear, USDC>>().length(), 1);
 
     // Still in the same period: nothing new, no event, no change.
     test.next_tx(@0x1);
     clk.set_for_testing(1999);
-    vesting_wallet_linear::release(&mut wallet, &clk, test.ctx());
+    vesting_wallet_linear::release(&mut wallet, &clk);
     assert_eq!(wallet.released(), 250);
     assert_eq!(wallet.balance(), 750);
     assert_eq!(event::events_by_type<Released<Linear, USDC>>().length(), 0);
@@ -488,12 +489,12 @@ fun releasable_view_matches_release() {
     let (mut test, mut clk) = setup(0);
 
     let mut wallet = new_stepped(0, 0, 1000, 4, test.ctx());
-    wallet.fund(1000, test.ctx());
+    wallet.fund(1000);
 
     clk.set_for_testing(2000); // two steps => 500
     assert_eq!(vesting_wallet_linear::releasable(&wallet, &clk), 500);
 
-    vesting_wallet_linear::release(&mut wallet, &clk, test.ctx());
+    vesting_wallet_linear::release(&mut wallet, &clk);
     assert_eq!(vesting_wallet_linear::releasable(&wallet, &clk), 0);
 
     destroy(wallet);
@@ -512,7 +513,7 @@ fun releasable_is_zero_pre_start_and_pre_cliff() {
 
     // Opens at 1000; cliff at start + 3000 spans 3 full periods.
     let mut wallet = new_stepped(1000, 3000, 1000, 8, test.ctx());
-    wallet.fund(8000, test.ctx());
+    wallet.fund(8000);
 
     clk.set_for_testing(999); // pre-start
     assert_eq!(vesting_wallet_linear::releasable(&wallet, &clk), 0);
@@ -531,10 +532,10 @@ fun full_release_after_end_then_releasable_zero() {
     let (mut test, mut clk) = setup(0);
 
     let mut wallet = new_stepped(0, 0, 1000, 4, test.ctx());
-    wallet.fund(1000, test.ctx());
+    wallet.fund(1000);
 
     clk.set_for_testing(4000);
-    vesting_wallet_linear::release(&mut wallet, &clk, test.ctx());
+    vesting_wallet_linear::release(&mut wallet, &clk);
     assert_eq!(wallet.released(), 1000);
     assert_eq!(wallet.balance(), 0);
     assert_eq!(vesting_wallet_linear::releasable(&wallet, &clk), 0);
@@ -553,10 +554,10 @@ fun destroy_after_end_on_empty_wallet() {
 
     let mut wallet = new_stepped(0, 0, 1000, 4, test.ctx());
     let wallet_id = object::id(&wallet);
-    wallet.fund(1000, test.ctx());
+    wallet.fund(1000);
 
     clk.set_for_testing(4000);
-    vesting_wallet_linear::release(&mut wallet, &clk, test.ctx());
+    vesting_wallet_linear::release(&mut wallet, &clk);
     assert_eq!(wallet.balance(), 0);
 
     test.next_tx(BENEFICIARY);
@@ -594,7 +595,7 @@ fun destroy_rejects_nonempty_balance() {
     let (mut test, mut clk) = setup(0);
 
     let mut wallet = new_stepped(0, 0, 1000, 4, test.ctx());
-    wallet.fund(1, test.ctx());
+    wallet.fund(1);
     clk.set_for_testing(5000); // after end, so the ended gate cannot fire
     test.next_tx(BENEFICIARY);
     let receipt = wallet.destroy_empty();
@@ -624,9 +625,9 @@ fun create_deposit_release_in_one_flow() {
     let (mut test, mut clk) = setup(0);
 
     let mut wallet = new_stepped(0, 0, 1000, 4, test.ctx());
-    wallet.fund(1000, test.ctx());
+    wallet.fund(1000);
     clk.set_for_testing(2000); // two steps => 500
-    vesting_wallet_linear::release(&mut wallet, &clk, test.ctx());
+    vesting_wallet_linear::release(&mut wallet, &clk);
 
     assert_eq!(wallet.released(), 500);
     assert_eq!(wallet.balance(), 500);
@@ -648,14 +649,14 @@ fun release_before_first_step_moves_no_funds() {
 
     // Opens at 1000, first tranche at 2000.
     let mut wallet = new_stepped(1000, 0, 1000, 4, test.ctx());
-    wallet.fund(1_000_000, test.ctx());
+    wallet.fund(1_000_000);
 
     clk.set_for_testing(999); // pre-start
-    vesting_wallet_linear::release(&mut wallet, &clk, test.ctx());
+    vesting_wallet_linear::release(&mut wallet, &clk);
     clk.set_for_testing(1000); // at start, first period, zero steps elapsed
-    vesting_wallet_linear::release(&mut wallet, &clk, test.ctx());
+    vesting_wallet_linear::release(&mut wallet, &clk);
     clk.set_for_testing(1999); // one ms before the first tranche
-    vesting_wallet_linear::release(&mut wallet, &clk, test.ctx());
+    vesting_wallet_linear::release(&mut wallet, &clk);
 
     assert_eq!(wallet.released(), 0);
     assert_eq!(wallet.balance(), 1_000_000);
@@ -715,7 +716,7 @@ fun new_continuous_accepts_cliff_equal_to_duration() {
     let (mut test, mut clk) = setup(0);
 
     let mut wallet = new_continuous(0, 1000, 1000, test.ctx());
-    wallet.fund(1000, test.ctx());
+    wallet.fund(1000);
 
     clk.set_for_testing(999);
     assert_eq!(wallet.vested(&clk), 0); // still gated by the cliff
@@ -782,7 +783,7 @@ fun vested_amount_continuous_at_exact_start_is_zero() {
     let (mut test, mut clk) = setup(0);
 
     let mut wallet = new_continuous(1000, 0, 1000, test.ctx());
-    wallet.fund(1000, test.ctx());
+    wallet.fund(1000);
 
     clk.set_for_testing(1000); // now == start_ms, elapsed == 0
     assert_eq!(wallet.vested(&clk), 0);
@@ -800,7 +801,7 @@ fun vested_amount_continuous_at_cliff_jumps_to_proportional() {
 
     // total = 1000, cliff = 1000, duration = 4000  =>  jump to 1000 * 1000 / 4000 = 250
     let mut wallet = new_continuous(0, 1000, 4000, test.ctx());
-    wallet.fund(1000, test.ctx());
+    wallet.fund(1000);
 
     clk.set_for_testing(999);
     assert_eq!(wallet.vested(&clk), 0);
@@ -818,7 +819,7 @@ fun vested_amount_continuous_is_linear_mid_schedule() {
     let (mut test, mut clk) = setup(0);
 
     let mut wallet = new_continuous(0, 1000, 4000, test.ctx());
-    wallet.fund(1000, test.ctx());
+    wallet.fund(1000);
 
     clk.set_for_testing(2000);
     assert_eq!(wallet.vested(&clk), 500); // 1000 * 2000 / 4000
@@ -838,7 +839,7 @@ fun vested_amount_continuous_uses_u128_intermediate_at_max() {
     let max = std::u64::max_value!();
 
     let mut wallet = new_continuous(0, 0, max, test.ctx());
-    wallet.fund(max, test.ctx());
+    wallet.fund(max);
 
     clk.set_for_testing(max - 1);
     // max * (max - 1) / max == max - 1, with no overflow and no abort.
@@ -875,7 +876,7 @@ fun receive_and_deposit_then_release_in_one_flow() {
     let receiving = test_scenario::receiving_ticket_by_id<coin::Coin<USDC>>(coin_id);
     wallet.receive_and_deposit(receiving);
     clk.set_for_testing(500);
-    vesting_wallet_linear::release(&mut wallet, &clk, test.ctx());
+    vesting_wallet_linear::release(&mut wallet, &clk);
 
     assert_eq!(wallet.released(), 500);
     assert_eq!(wallet.balance(), 500);
@@ -898,20 +899,20 @@ fun retroactive_deposit_never_over_releases() {
     let (mut test, mut clk) = setup(0);
 
     let mut wallet = new_continuous(0, 0, 100, test.ctx());
-    wallet.fund(100, test.ctx());
+    wallet.fund(100);
 
     clk.set_for_testing(50);
-    vesting_wallet_linear::release(&mut wallet, &clk, test.ctx()); // floor(100 * 50 / 100) = 50
+    vesting_wallet_linear::release(&mut wallet, &clk); // floor(100 * 50 / 100) = 50
     assert_eq!(wallet.released(), 50);
     assert_eq!(wallet.balance(), 50);
 
     // Late deposit; total is now 200, re-derived fresh at call time.
-    wallet.fund(100, test.ctx());
+    wallet.fund(100);
     let releasable = vesting_wallet_linear::releasable(&wallet, &clk);
     assert_eq!(releasable, 50); // floor(200 * 50 / 100) = 100 cumulative, minus 50 already released
     assert!(releasable <= wallet.balance()); // never exceeds the balance backing it
 
-    vesting_wallet_linear::release(&mut wallet, &clk, test.ctx()); // does not abort, does not over-pay
+    vesting_wallet_linear::release(&mut wallet, &clk); // does not abort, does not over-pay
     assert_eq!(wallet.released(), 100);
     assert_eq!(wallet.balance(), 100);
     assert_eq!(wallet.balance() + wallet.released(), 200); // conserved: nothing minted from nowhere
@@ -932,13 +933,13 @@ fun overflowing_refund_is_rejected_at_deposit() {
     let max = std::u64::max_value!();
 
     let mut wallet = new_continuous(0, 0, max, test.ctx());
-    wallet.fund(max, test.ctx());
+    wallet.fund(max);
 
     clk.set_for_testing(1);
-    vesting_wallet_linear::release(&mut wallet, &clk, test.ctx()); // releases 1; balance = max - 1, released = 1
+    vesting_wallet_linear::release(&mut wallet, &clk); // releases 1; balance = max - 1, released = 1
 
     // balance + released == max already; refunding the released 1 would overflow it,
     // so the deposit is rejected here rather than bricking a later release.
-    wallet.fund(1, test.ctx());
+    wallet.fund(1);
     abort
 }

--- a/contracts/finance/tests/vesting_wallet_linear_tests.move
+++ b/contracts/finance/tests/vesting_wallet_linear_tests.move
@@ -445,11 +445,6 @@ fun release_pays_step_portion_and_is_permissionless() {
 
     destroy(wallet);
 
-    test.next_tx(BENEFICIARY);
-    let coin = test.take_from_sender<coin::Coin<USDC>>();
-    assert_eq!(coin.value(), 500);
-    destroy(coin);
-
     destroy(clk);
     test.end();
 }

--- a/contracts/finance/tests/vesting_wallet_linear_tests.move
+++ b/contracts/finance/tests/vesting_wallet_linear_tests.move
@@ -556,7 +556,9 @@ fun destroy_after_end_on_empty_wallet() {
     assert_eq!(wallet.balance(), 0);
 
     test.next_tx(BENEFICIARY);
-    let receipt = wallet.destroy_empty();
+    // TODO: use `destroy_empty` with a real `AccumulatorRoot` once
+    // `accumulator::create_for_testing` ships in the published Sui mainnet framework.
+    let receipt = wallet.destroy_empty_for_testing();
     vesting_wallet_linear::destroy(receipt, &clk, test.ctx());
 
     let destroyed = event::events_by_type<Destroyed<Linear, USDC>>();
@@ -577,7 +579,7 @@ fun destroy_rejects_before_end() {
 
     let wallet = new_stepped(0, 0, 1000, 4, test.ctx());
     clk.set_for_testing(3999);
-    let receipt = wallet.destroy_empty();
+    let receipt = wallet.destroy_empty_for_testing();
     vesting_wallet_linear::destroy(receipt, &clk, test.ctx());
     abort
 }
@@ -593,7 +595,7 @@ fun destroy_rejects_nonempty_balance() {
     wallet.fund(1);
     clk.set_for_testing(5000); // after end, so the ended gate cannot fire
     test.next_tx(BENEFICIARY);
-    let receipt = wallet.destroy_empty();
+    let receipt = wallet.destroy_empty_for_testing();
     vesting_wallet_linear::destroy(receipt, &clk, test.ctx());
     abort
 }
@@ -607,7 +609,7 @@ fun destroy_rejects_non_beneficiary() {
     let wallet = new_stepped(0, 0, 1000, 4, test.ctx());
     clk.set_for_testing(5000); // after end, so the ended gate cannot fire
     test.next_tx(@0xCAFE); // not the beneficiary
-    let receipt = wallet.destroy_empty();
+    let receipt = wallet.destroy_empty_for_testing();
     vesting_wallet_linear::destroy(receipt, &clk, test.ctx());
     abort
 }

--- a/contracts/finance/tests/vesting_wallet_tests.move
+++ b/contracts/finance/tests/vesting_wallet_tests.move
@@ -10,6 +10,7 @@ use openzeppelin_finance::vesting_wallet::{
     Destroyed
 };
 use std::unit_test::{assert_eq, destroy};
+use sui::balance::{Self, Balance};
 use sui::coin::{Self, Coin};
 use sui::event;
 use sui::test_scenario;
@@ -51,8 +52,8 @@ fun new_wallet(
     )
 }
 
-fun mint(amount: u64, ctx: &mut TxContext): Coin<USDC> {
-    coin::mint_for_testing<USDC>(amount, ctx)
+fun mint(amount: u64): Balance<USDC> {
+    balance::create_for_testing<USDC>(amount)
 }
 
 fun wrap(inner: VestingWallet<TestCurve, TestParams, USDC>, ctx: &mut TxContext): Wrapper {
@@ -67,8 +68,8 @@ fun inner(wrapper: &Wrapper): &VestingWallet<TestCurve, TestParams, USDC> {
 
 /// The wrapper's own `release`: takes a `&VestedAmount` (no witness) and delegates to
 /// the private `&mut inner`.
-fun release(wrapper: &mut Wrapper, vested: &VestedAmount<TestCurve>, ctx: &mut TxContext) {
-    wrapper.inner.release(vested, ctx);
+fun release(wrapper: &mut Wrapper, vested: &VestedAmount<TestCurve>) {
+    wrapper.inner.release(vested);
 }
 
 // === Construction & topology ===
@@ -130,7 +131,7 @@ fun deposit_increases_balance_emits_and_is_permissionless() {
 
     let mut wallet = new_wallet(BENEFICIARY, scenario.ctx());
     let wallet_id = object::id(&wallet);
-    wallet.deposit(mint(1000, scenario.ctx()));
+    wallet.deposit(mint(1000));
 
     assert_eq!(wallet.balance(), 1000);
     assert_eq!(wallet.released(), 0);
@@ -159,7 +160,7 @@ fun receive_and_deposit_claims_addressed_coin() {
 
     // An upstream emitter sends a coin to the wallet's object address.
     scenario.next_tx(@0x1);
-    let coin = mint(1000, scenario.ctx());
+    let coin = coin::mint_for_testing<USDC>(1000, scenario.ctx());
     let coin_id = object::id(&coin);
     transfer::public_transfer(coin, wallet_addr);
 
@@ -185,7 +186,7 @@ fun deposit_zero_value_coin_is_noop() {
     let mut scenario = test_scenario::begin(@0xCAFE);
 
     let mut wallet = new_wallet(BENEFICIARY, scenario.ctx());
-    wallet.deposit(mint(0, scenario.ctx()));
+    wallet.deposit(mint(0));
 
     assert_eq!(wallet.balance(), 0);
     assert_eq!(wallet.released(), 0);
@@ -211,7 +212,7 @@ fun receive_and_deposit_claims_addressed_coin_owned() {
 
     // An upstream emitter sends a coin to the wallet's object address.
     scenario.next_tx(@0x1);
-    let coin = mint(1000, scenario.ctx());
+    let coin = coin::mint_for_testing<USDC>(1000, scenario.ctx());
     let coin_id = object::id(&coin);
     transfer::public_transfer(coin, wallet_addr);
 
@@ -240,14 +241,14 @@ fun deposit_rejects_overflowing_total() {
     let max = std::u64::max_value!();
 
     let mut wallet = new_wallet(BENEFICIARY, &mut ctx);
-    wallet.deposit(mint(max, &mut ctx)); // balance = max, released = 0
+    wallet.deposit(mint(max)); // balance = max, released = 0
 
     // Release 1 so released > 0 while balance + released stays == max.
     let vested = wallet.mint_vested_amount(TestCurve {}, 1);
-    wallet.release(&vested, &mut ctx); // released = 1, balance = max - 1
+    wallet.release(&vested); // released = 1, balance = max - 1
 
     // balance + released == max already, so any further deposit overflows.
-    wallet.deposit(mint(1, &mut ctx));
+    wallet.deposit(mint(1));
     abort
 }
 
@@ -263,15 +264,15 @@ fun receive_and_deposit_rejects_overflowing_total() {
 
     // Fund to max, release 1 so balance + released == max, then share the wallet.
     let mut wallet = new_wallet(BENEFICIARY, scenario.ctx());
-    wallet.deposit(mint(max, scenario.ctx()));
+    wallet.deposit(mint(max));
     let vested = wallet.mint_vested_amount(TestCurve {}, 1);
-    wallet.release(&vested, scenario.ctx()); // released = 1, balance = max - 1
+    wallet.release(&vested); // released = 1, balance = max - 1
     let wallet_addr = object::id_address(&wallet);
     transfer::public_share_object(wallet);
 
     // An upstream emitter sends a coin to the wallet's object address.
     scenario.next_tx(@0x1);
-    let coin = mint(1, scenario.ctx());
+    let coin = coin::mint_for_testing<USDC>(1, scenario.ctx());
     let coin_id = object::id(&coin);
     transfer::public_transfer(coin, wallet_addr);
 
@@ -314,7 +315,7 @@ fun release_rejects_vested_from_other_wallet() {
     let mut wallet_b = new_wallet(BENEFICIARY, &mut ctx);
     let vested_a = wallet_a.mint_vested_amount(TestCurve {}, 100);
 
-    wallet_b.release(&vested_a, &mut ctx);
+    wallet_b.release(&vested_a);
     abort
 }
 
@@ -341,10 +342,10 @@ fun release_pays_releasable_to_beneficiary() {
 
     let mut wallet = new_wallet(BENEFICIARY, scenario.ctx());
     let wallet_id = object::id(&wallet);
-    wallet.deposit(mint(1000, scenario.ctx()));
+    wallet.deposit(mint(1000));
 
     let vested = wallet.mint_vested_amount(TestCurve {}, 400);
-    wallet.release(&vested, scenario.ctx());
+    wallet.release(&vested);
 
     assert_eq!(wallet.released(), 400);
     assert_eq!(wallet.balance(), 600);
@@ -374,10 +375,10 @@ fun release_is_noop_when_nothing_releasable() {
     let mut scenario = test_scenario::begin(@0x1);
 
     let mut wallet = new_wallet(BENEFICIARY, scenario.ctx());
-    wallet.deposit(mint(1000, scenario.ctx()));
+    wallet.deposit(mint(1000));
 
     let vested = wallet.mint_vested_amount(TestCurve {}, 0);
-    wallet.release(&vested, scenario.ctx());
+    wallet.release(&vested);
 
     assert_eq!(wallet.released(), 0);
     assert_eq!(wallet.balance(), 1000);
@@ -394,16 +395,16 @@ fun release_again_at_same_total_is_noop() {
     let mut ctx = tx_context::dummy();
 
     let mut wallet = new_wallet(BENEFICIARY, &mut ctx);
-    wallet.deposit(mint(1000, &mut ctx));
+    wallet.deposit(mint(1000));
 
     let vested = wallet.mint_vested_amount(TestCurve {}, 500);
-    wallet.release(&vested, &mut ctx);
+    wallet.release(&vested);
     assert_eq!(wallet.released(), 500);
     assert_eq!(wallet.balance(), 500);
 
     let again = wallet.mint_vested_amount(TestCurve {}, 500);
     assert_eq!(wallet.releasable(&again), 0);
-    wallet.release(&again, &mut ctx);
+    wallet.release(&again);
     assert_eq!(wallet.released(), 500);
     assert_eq!(wallet.balance(), 500);
 
@@ -417,15 +418,15 @@ fun release_is_monotone_across_increasing_totals() {
     let mut ctx = tx_context::dummy();
 
     let mut wallet = new_wallet(BENEFICIARY, &mut ctx);
-    wallet.deposit(mint(1000, &mut ctx));
+    wallet.deposit(mint(1000));
 
     let first = wallet.mint_vested_amount(TestCurve {}, 100);
-    wallet.release(&first, &mut ctx);
+    wallet.release(&first);
     let after_first = wallet.released();
     assert_eq!(after_first, 100);
 
     let second = wallet.mint_vested_amount(TestCurve {}, 300);
-    wallet.release(&second, &mut ctx);
+    wallet.release(&second);
     assert_eq!(wallet.released(), 300);
 
     // monotone and conserved
@@ -442,13 +443,13 @@ fun release_rejects_vested_below_released() {
     let mut ctx = tx_context::dummy();
 
     let mut wallet = new_wallet(BENEFICIARY, &mut ctx);
-    wallet.deposit(mint(1000, &mut ctx));
+    wallet.deposit(mint(1000));
 
     let high = wallet.mint_vested_amount(TestCurve {}, 200);
-    wallet.release(&high, &mut ctx);
+    wallet.release(&high);
 
     let regressed = wallet.mint_vested_amount(TestCurve {}, 100);
-    wallet.release(&regressed, &mut ctx);
+    wallet.release(&regressed);
     abort
 }
 
@@ -458,10 +459,10 @@ fun releasable_rejects_vested_below_released() {
     let mut ctx = tx_context::dummy();
 
     let mut wallet = new_wallet(BENEFICIARY, &mut ctx);
-    wallet.deposit(mint(1000, &mut ctx));
+    wallet.deposit(mint(1000));
 
     let high = wallet.mint_vested_amount(TestCurve {}, 200);
-    wallet.release(&high, &mut ctx);
+    wallet.release(&high);
 
     let regressed = wallet.mint_vested_amount(TestCurve {}, 100);
     wallet.releasable(&regressed);
@@ -477,12 +478,12 @@ fun release_aborts_when_vested_exceeds_total() {
     let mut ctx = tx_context::dummy();
 
     let mut wallet = new_wallet(BENEFICIARY, &mut ctx);
-    wallet.deposit(mint(100, &mut ctx));
+    wallet.deposit(mint(100));
 
     // Attest more than balance + released (= 100). `release` clears the wallet_id and
     // `>= released` guards, then `EInsufficientBalance` aborts before any coin is minted.
     let vested = wallet.mint_vested_amount(TestCurve {}, 200);
-    wallet.release(&vested, &mut ctx);
+    wallet.release(&vested);
     abort
 }
 
@@ -494,15 +495,15 @@ fun release_aborts_when_releasable_exceeds_remaining_balance() {
     let mut ctx = tx_context::dummy();
 
     let mut wallet = new_wallet(BENEFICIARY, &mut ctx);
-    wallet.deposit(mint(100, &mut ctx));
+    wallet.deposit(mint(100));
 
     // Drain part of the balance: released = 60, balance = 40.
     let first = wallet.mint_vested_amount(TestCurve {}, 60);
-    wallet.release(&first, &mut ctx);
+    wallet.release(&first);
 
     // Attest 150 > balance + released (= 100); releasable = 90 > balance (= 40).
     let second = wallet.mint_vested_amount(TestCurve {}, 150);
-    wallet.release(&second, &mut ctx);
+    wallet.release(&second);
     abort
 }
 
@@ -513,10 +514,10 @@ fun release_allows_draining_exact_balance() {
     let mut ctx = tx_context::dummy();
 
     let mut wallet = new_wallet(BENEFICIARY, &mut ctx);
-    wallet.deposit(mint(100, &mut ctx));
+    wallet.deposit(mint(100));
 
     let vested = wallet.mint_vested_amount(TestCurve {}, 100);
-    wallet.release(&vested, &mut ctx);
+    wallet.release(&vested);
 
     assert_eq!(wallet.released(), 100);
     assert_eq!(wallet.balance(), 0);
@@ -556,7 +557,7 @@ fun destroy_empty_rejects_nonempty_balance() {
     let mut ctx = tx_context::dummy();
 
     let mut wallet = new_wallet(BENEFICIARY, &mut ctx);
-    wallet.deposit(mint(1, &mut ctx));
+    wallet.deposit(mint(1));
 
     let _receipt = wallet.destroy_empty();
     abort
@@ -573,9 +574,9 @@ fun beneficiary_params_and_id_are_immutable() {
     let mut wallet = new_wallet(BENEFICIARY, &mut ctx);
     let id_at_creation = object::id(&wallet);
 
-    wallet.deposit(mint(1000, &mut ctx));
+    wallet.deposit(mint(1000));
     let vested = wallet.mint_vested_amount(TestCurve {}, 300);
-    wallet.release(&vested, &mut ctx);
+    wallet.release(&vested);
 
     assert_eq!(wallet.beneficiary(), BENEFICIARY);
     assert_eq!(wallet.schedule_params(), TestParams { tag: PARAMS_TAG });
@@ -591,15 +592,15 @@ fun released_coins_stay_with_beneficiary() {
     let mut scenario = test_scenario::begin(@0x1);
 
     let mut wallet = new_wallet(BENEFICIARY, scenario.ctx());
-    wallet.deposit(mint(1000, scenario.ctx()));
+    wallet.deposit(mint(1000));
 
     let first = wallet.mint_vested_amount(TestCurve {}, 400);
-    wallet.release(&first, scenario.ctx());
+    wallet.release(&first);
 
     // Further wallet activity in a later transaction.
     scenario.next_tx(@0x1);
     let second = wallet.mint_vested_amount(TestCurve {}, 900);
-    wallet.release(&second, scenario.ctx());
+    wallet.release(&second);
     assert_eq!(wallet.released(), 900);
     destroy(wallet);
 
@@ -626,9 +627,9 @@ fun beneficiary_can_be_object_address() {
     let object_addr = object::id_address(&placeholder);
 
     let mut wallet = new_wallet(object_addr, scenario.ctx());
-    wallet.deposit(mint(1000, scenario.ctx()));
+    wallet.deposit(mint(1000));
     let vested = wallet.mint_vested_amount(TestCurve {}, 1000);
-    wallet.release(&vested, scenario.ctx());
+    wallet.release(&vested);
 
     destroy(wallet);
     destroy(placeholder);
@@ -654,12 +655,12 @@ fun release_through_third_party_wrapper() {
     let mut scenario = test_scenario::begin(@0xCAFE); // unrelated sender drives the wrapper
 
     let mut wallet = new_wallet(BENEFICIARY, scenario.ctx());
-    wallet.deposit(mint(1000, scenario.ctx()));
+    wallet.deposit(mint(1000));
     let mut wrapper = wrap(wallet, scenario.ctx());
 
     // Curve-agnostic flow: mint against `&inner`, release through the wrapper.
     let vested = wrapper.inner().mint_vested_amount(TestCurve {}, 400);
-    wrapper.release(&vested, scenario.ctx());
+    wrapper.release(&vested);
 
     assert_eq!(wrapper.inner().released(), 400);
     assert_eq!(wrapper.inner().balance(), 600);
@@ -685,14 +686,14 @@ fun owned_handoff_does_not_redirect_cashflow() {
 
     // Alice is the beneficiary; the wallet is funded then handed to Bob.
     let mut wallet = new_wallet(alice, scenario.ctx());
-    wallet.deposit(mint(1000, scenario.ctx()));
+    wallet.deposit(mint(1000));
     transfer::public_transfer(wallet, bob);
 
     // Bob holds the wallet and pokes release.
     scenario.next_tx(bob);
     let mut wallet = scenario.take_from_sender<VestingWallet<TestCurve, TestParams, USDC>>();
     let vested = wallet.mint_vested_amount(TestCurve {}, 400);
-    wallet.release(&vested, scenario.ctx());
+    wallet.release(&vested);
     destroy(wallet);
 
     // Alice - not Bob - received the funds.

--- a/contracts/finance/tests/vesting_wallet_tests.move
+++ b/contracts/finance/tests/vesting_wallet_tests.move
@@ -6,6 +6,7 @@ use openzeppelin_finance::vesting_wallet::{
     VestedAmount,
     Created,
     Deposited,
+    Received,
     Released,
     Destroyed
 };
@@ -147,7 +148,7 @@ fun deposit_increases_balance_emits_and_is_permissionless() {
 }
 
 // Only receipts addressed to this wallet are claimable; doing so emits a single
-// `Deposited` (no separate `Received` event) and conserves funds.
+// `Received` event (not `Deposited`) and conserves funds.
 #[test]
 fun receive_and_deposit_claims_addressed_coin() {
     let mut scenario = test_scenario::begin(@0x1);
@@ -164,16 +165,18 @@ fun receive_and_deposit_claims_addressed_coin() {
     let coin_id = object::id(&coin);
     transfer::public_transfer(coin, wallet_addr);
 
-    // The wallet claims it through the standard deposit path.
+    // The wallet claims it, adding the coin to its balance.
     scenario.next_tx(@0x1);
     let mut wallet = scenario.take_shared<VestingWallet<TestCurve, TestParams, USDC>>();
     let receiving = test_scenario::receiving_ticket_by_id<Coin<USDC>>(coin_id);
     wallet.receive_and_deposit(receiving);
 
     assert_eq!(wallet.balance(), 1000);
-    let deposited = event::events_by_type<Deposited<TestCurve, USDC>>();
-    assert_eq!(deposited.length(), 1);
-    assert_eq!(deposited[0], vesting_wallet::test_new_deposited<TestCurve, USDC>(wallet_id, 1000));
+    let received = event::events_by_type<Received<TestCurve, USDC>>();
+    assert_eq!(received.length(), 1);
+    assert_eq!(received[0], vesting_wallet::test_new_received<TestCurve, USDC>(wallet_id, 1000));
+    // A claim emits `Received`, never `Deposited`.
+    assert_eq!(event::events_by_type<Deposited<TestCurve, USDC>>().length(), 0);
 
     test_scenario::return_shared(wallet);
     scenario.end();
@@ -216,18 +219,47 @@ fun receive_and_deposit_claims_addressed_coin_owned() {
     let coin_id = object::id(&coin);
     transfer::public_transfer(coin, wallet_addr);
 
-    // The holder takes their owned wallet and claims the coin through the deposit path.
+    // The holder takes their owned wallet and claims the coin.
     scenario.next_tx(holder);
     let mut wallet = scenario.take_from_sender<VestingWallet<TestCurve, TestParams, USDC>>();
     let receiving = test_scenario::receiving_ticket_by_id<Coin<USDC>>(coin_id);
     wallet.receive_and_deposit(receiving);
 
     assert_eq!(wallet.balance(), 1000);
-    let deposited = event::events_by_type<Deposited<TestCurve, USDC>>();
-    assert_eq!(deposited.length(), 1);
-    assert_eq!(deposited[0], vesting_wallet::test_new_deposited<TestCurve, USDC>(wallet_id, 1000));
+    let received = event::events_by_type<Received<TestCurve, USDC>>();
+    assert_eq!(received.length(), 1);
+    assert_eq!(received[0], vesting_wallet::test_new_received<TestCurve, USDC>(wallet_id, 1000));
 
     destroy(wallet);
+    scenario.end();
+}
+
+// Claiming a zero-value coin is a no-op: balance and ledger are untouched and no
+// `Received` event is emitted (mirroring `deposit` of a zero-value coin).
+#[test]
+fun receive_and_deposit_zero_value_coin_is_noop() {
+    let mut scenario = test_scenario::begin(@0x1);
+
+    let wallet = new_wallet(BENEFICIARY, scenario.ctx());
+    let wallet_addr = object::id_address(&wallet);
+    transfer::public_share_object(wallet);
+
+    // An upstream emitter sends a zero-value coin to the wallet's object address.
+    scenario.next_tx(@0x1);
+    let coin = coin::mint_for_testing<USDC>(0, scenario.ctx());
+    let coin_id = object::id(&coin);
+    transfer::public_transfer(coin, wallet_addr);
+
+    scenario.next_tx(@0x1);
+    let mut wallet = scenario.take_shared<VestingWallet<TestCurve, TestParams, USDC>>();
+    let receiving = test_scenario::receiving_ticket_by_id<Coin<USDC>>(coin_id);
+    wallet.receive_and_deposit(receiving);
+
+    assert_eq!(wallet.balance(), 0);
+    assert_eq!(wallet.released(), 0);
+    assert_eq!(event::events_by_type<Received<TestCurve, USDC>>().length(), 0);
+
+    test_scenario::return_shared(wallet);
     scenario.end();
 }
 
@@ -252,9 +284,9 @@ fun deposit_rejects_overflowing_total() {
     abort
 }
 
-// `receive_and_deposit` funnels through `deposit`, so the same overflow guard fires:
-// claiming a coin addressed to the wallet that would push `balance + released` past
-// u64::MAX aborts with `EOverflow`. (In production the already-transferred coin is
+// `receive_and_deposit` shares `deposit`'s balance logic, so the same overflow guard
+// fires: claiming a coin addressed to the wallet that would push `balance + released`
+// past u64::MAX aborts with `EOverflow`. (In production the already-transferred coin is
 // then stranded at the wallet's address - see the function's docs; here the abort
 // just rolls the claim back.)
 #[test, expected_failure(abort_code = vesting_wallet::EBalanceOverflow)]
@@ -276,7 +308,7 @@ fun receive_and_deposit_rejects_overflowing_total() {
     let coin_id = object::id(&coin);
     transfer::public_transfer(coin, wallet_addr);
 
-    // Claiming it would push balance + released to max + 1 -> EOverflow via `deposit`.
+    // Claiming it would push balance + released to max + 1 -> EOverflow.
     scenario.next_tx(@0x1);
     let mut wallet = scenario.take_shared<VestingWallet<TestCurve, TestParams, USDC>>();
     let receiving = test_scenario::receiving_ticket_by_id<Coin<USDC>>(coin_id);

--- a/contracts/finance/tests/vesting_wallet_tests.move
+++ b/contracts/finance/tests/vesting_wallet_tests.move
@@ -529,7 +529,9 @@ fun destroy_empty_returns_params_and_emits() {
     let wallet = new_wallet(BENEFICIARY, scenario.ctx());
     let wallet_id = object::id(&wallet);
 
-    let receipt = wallet.destroy_empty();
+    // TODO: use `destroy_empty` with a real `AccumulatorRoot` once
+    // `accumulator::create_for_testing` ships in the published Sui mainnet framework.
+    let receipt = wallet.destroy_empty_for_testing();
     assert_eq!(vesting_wallet::test_receipt_beneficiary(&receipt), BENEFICIARY);
     assert_eq!(vesting_wallet::test_receipt_params(&receipt), TestParams { tag: PARAMS_TAG });
 
@@ -552,9 +554,39 @@ fun destroy_empty_rejects_nonempty_balance() {
     let mut wallet = new_wallet(BENEFICIARY, &mut ctx);
     wallet.deposit(mint(1));
 
-    let _receipt = wallet.destroy_empty();
+    let _receipt = wallet.destroy_empty_for_testing();
     abort
 }
+
+// `destroy_empty` rejects a wallet whose object address still holds settled funds that
+// have not been swept into the on-book balance (the `sweep_settled` source).
+//
+// TODO: un-ignore (uncomment and add `#[test, expected_failure(...)]`) once
+// `accumulator::create_for_testing` ships in the published Sui mainnet framework. It also
+// needs the imports `use sui::accumulator::{Self, AccumulatorRoot};` and
+// `use sui::test_scenario::Scenario;`, plus the `seed_root` helper below. The unit VM may
+// also need to actually settle the funds parked at the address for the gate to fire.
+//
+// fun seed_root(scenario: &mut Scenario, resume: address) {
+//     scenario.next_tx(@0x0);
+//     accumulator::create_for_testing(scenario.ctx());
+//     scenario.next_tx(resume);
+// }
+//
+// #[test, expected_failure(abort_code = vesting_wallet::EUnsweptFunds)]
+// fun destroy_empty_rejects_unswept_settled_funds() {
+//     let mut scenario = test_scenario::begin(@0x1);
+//     seed_root(&mut scenario, @0x1);
+//
+//     let wallet = new_wallet(BENEFICIARY, scenario.ctx());
+//     // Park settled funds at the wallet's object address without sweeping them in.
+//     balance::send_funds(mint(1), object::id(&wallet).to_address());
+//     scenario.next_tx(@0x1);
+//
+//     let root = scenario.take_shared<AccumulatorRoot>();
+//     let _receipt = wallet.destroy_empty(&root);
+//     abort
+// }
 
 // === State immutability ===
 

--- a/contracts/finance/tests/vesting_wallet_tests.move
+++ b/contracts/finance/tests/vesting_wallet_tests.move
@@ -620,6 +620,73 @@ fun destroy_empty_rejects_nonempty_balance() {
 //     abort
 // }
 
+// === Sweep ===
+
+// `sweep_settled` pulls settled funds parked at the wallet's object address into its
+// on-book `balance`, emits a single `Swept` (not `Deposited`), and conserves value.
+//
+// TODO: un-ignore once `accumulator::create_for_testing` ships in the published Sui
+// mainnet framework. Shares the same harness as the commented teardown tests above:
+// the `seed_root` helper, the `use sui::accumulator::{Self, AccumulatorRoot};` and
+// `use sui::test_scenario::Scenario;` imports, the `Swept` import from `vesting_wallet`,
+// and a VM that actually settles the funds parked at the address so `settled_funds_value`
+// returns non-zero.
+//
+// #[test]
+// fun sweep_settled_pulls_in_settled_funds_and_emits_swept() {
+//     let mut scenario = test_scenario::begin(@0x1);
+//     seed_root(&mut scenario, @0x1);
+//
+//     let wallet = new_wallet(BENEFICIARY, scenario.ctx());
+//     let wallet_id = object::id(&wallet);
+//     // Settle funds at the wallet's object address, then share it.
+//     balance::send_funds(mint(1000), wallet_id.to_address());
+//     transfer::public_share_object(wallet);
+//     scenario.next_tx(@0x1);
+//
+//     let mut wallet = scenario.take_shared<VestingWallet<TestCurve, TestParams, USDC>>();
+//     let root = scenario.take_shared<AccumulatorRoot>();
+//     wallet.sweep_settled(&root);
+//
+//     assert_eq!(wallet.balance(), 1000);
+//     let swept = event::events_by_type<Swept<TestCurve, USDC>>();
+//     assert_eq!(swept.length(), 1);
+//     assert_eq!(swept[0], vesting_wallet::test_new_swept<TestCurve, USDC>(wallet_id, 1000));
+//     // A sweep emits `Swept`, never `Deposited`.
+//     assert_eq!(event::events_by_type<Deposited<TestCurve, USDC>>().length(), 0);
+//
+//     test_scenario::return_shared(root);
+//     test_scenario::return_shared(wallet);
+//     scenario.end();
+// }
+
+// Sweeping a wallet with no settled funds at its address is a no-op: balance and
+// ledger are untouched and no `Swept` event is emitted.
+//
+// TODO: un-ignore once `accumulator::create_for_testing` ships (same harness as above).
+//
+// #[test]
+// fun sweep_settled_no_settled_funds_is_noop() {
+//     let mut scenario = test_scenario::begin(@0x1);
+//     seed_root(&mut scenario, @0x1);
+//
+//     let wallet = new_wallet(BENEFICIARY, scenario.ctx());
+//     transfer::public_share_object(wallet);
+//     scenario.next_tx(@0x1);
+//
+//     let mut wallet = scenario.take_shared<VestingWallet<TestCurve, TestParams, USDC>>();
+//     let root = scenario.take_shared<AccumulatorRoot>();
+//     wallet.sweep_settled(&root);
+//
+//     assert_eq!(wallet.balance(), 0);
+//     assert_eq!(wallet.released(), 0);
+//     assert_eq!(event::events_by_type<Swept<TestCurve, USDC>>().length(), 0);
+//
+//     test_scenario::return_shared(root);
+//     test_scenario::return_shared(wallet);
+//     scenario.end();
+// }
+
 // === State immutability ===
 
 // The beneficiary, schedule params, and id are all fixed across

--- a/contracts/finance/tests/vesting_wallet_tests.move
+++ b/contracts/finance/tests/vesting_wallet_tests.move
@@ -358,13 +358,6 @@ fun release_pays_releasable_to_beneficiary() {
     );
 
     destroy(wallet);
-
-    // The beneficiary owns exactly the released coin.
-    scenario.next_tx(BENEFICIARY);
-    let coin = scenario.take_from_sender<Coin<USDC>>();
-    assert_eq!(coin.value(), 400);
-
-    destroy(coin);
     scenario.end();
 }
 
@@ -585,34 +578,43 @@ fun beneficiary_params_and_id_are_immutable() {
     destroy(wallet);
 }
 
-// Released coins belong to the beneficiary and no later wallet operation
-// can reduce them - there is no clawback path.
+// Released funds belong to the beneficiary and no later wallet operation
+// can reduce them - there is no clawback path. The two payouts to the
+// beneficiary are attested by their `Released` events, which together sum to
+// exactly what was released.
 #[test]
 fun released_coins_stay_with_beneficiary() {
     let mut scenario = test_scenario::begin(@0x1);
 
     let mut wallet = new_wallet(BENEFICIARY, scenario.ctx());
+    let wallet_id = object::id(&wallet);
     wallet.deposit(mint(1000));
 
+    // First payout to the beneficiary: 400.
     let first = wallet.mint_vested_amount(TestCurve {}, 400);
     wallet.release(&first);
+    let released = event::events_by_type<Released<TestCurve, USDC>>();
+    assert_eq!(released.length(), 1);
+    assert_eq!(
+        released[0],
+        vesting_wallet::test_new_released<TestCurve, USDC>(wallet_id, BENEFICIARY, 400),
+    );
 
-    // Further wallet activity in a later transaction.
+    // Further wallet activity in a later transaction pays the newly-vested
+    // remainder (900 - 400 = 500); the earlier 400 is never reduced.
     scenario.next_tx(@0x1);
     let second = wallet.mint_vested_amount(TestCurve {}, 900);
     wallet.release(&second);
     assert_eq!(wallet.released(), 900);
+
+    let released = event::events_by_type<Released<TestCurve, USDC>>();
+    assert_eq!(released.length(), 1);
+    assert_eq!(
+        released[0],
+        vesting_wallet::test_new_released<TestCurve, USDC>(wallet_id, BENEFICIARY, 500),
+    );
+
     destroy(wallet);
-
-    // Both released coins are intact in the beneficiary's inventory; their total is
-    // exactly what was released, never reduced.
-    scenario.next_tx(BENEFICIARY);
-    let coin_a = scenario.take_from_sender<Coin<USDC>>();
-    let coin_b = scenario.take_from_sender<Coin<USDC>>();
-    assert_eq!(coin_a.value() + coin_b.value(), 900);
-
-    destroy(coin_a);
-    destroy(coin_b);
     scenario.end();
 }
 
@@ -627,6 +629,7 @@ fun beneficiary_can_be_object_address() {
     let object_addr = object::id_address(&placeholder);
 
     let mut wallet = new_wallet(object_addr, scenario.ctx());
+    let wallet_id = object::id(&wallet);
     wallet.deposit(mint(1000));
     let vested = wallet.mint_vested_amount(TestCurve {}, 1000);
     wallet.release(&vested);
@@ -634,12 +637,14 @@ fun beneficiary_can_be_object_address() {
     destroy(wallet);
     destroy(placeholder);
 
-    // The released coin landed in the object's address inventory.
-    scenario.next_tx(@0x1);
-    let coin = scenario.take_from_address<Coin<USDC>>(object_addr);
-    assert_eq!(coin.value(), 1000);
+    // The payout was directed at the object's address.
+    let released = event::events_by_type<Released<TestCurve, USDC>>();
+    assert_eq!(released.length(), 1);
+    assert_eq!(
+        released[0],
+        vesting_wallet::test_new_released<TestCurve, USDC>(wallet_id, object_addr, 1000),
+    );
 
-    destroy(coin);
     scenario.end();
 }
 
@@ -655,6 +660,7 @@ fun release_through_third_party_wrapper() {
     let mut scenario = test_scenario::begin(@0xCAFE); // unrelated sender drives the wrapper
 
     let mut wallet = new_wallet(BENEFICIARY, scenario.ctx());
+    let wallet_id = object::id(&wallet);
     wallet.deposit(mint(1000));
     let mut wrapper = wrap(wallet, scenario.ctx());
 
@@ -667,12 +673,14 @@ fun release_through_third_party_wrapper() {
 
     destroy(wrapper);
 
-    // The construction-time beneficiary received the released coin.
-    scenario.next_tx(BENEFICIARY);
-    let coin = scenario.take_from_sender<Coin<USDC>>();
-    assert_eq!(coin.value(), 400);
+    // The payout went to the construction-time beneficiary, not the driver.
+    let released = event::events_by_type<Released<TestCurve, USDC>>();
+    assert_eq!(released.length(), 1);
+    assert_eq!(
+        released[0],
+        vesting_wallet::test_new_released<TestCurve, USDC>(wallet_id, BENEFICIARY, 400),
+    );
 
-    destroy(coin);
     scenario.end();
 }
 
@@ -686,6 +694,7 @@ fun owned_handoff_does_not_redirect_cashflow() {
 
     // Alice is the beneficiary; the wallet is funded then handed to Bob.
     let mut wallet = new_wallet(alice, scenario.ctx());
+    let wallet_id = object::id(&wallet);
     wallet.deposit(mint(1000));
     transfer::public_transfer(wallet, bob);
 
@@ -697,10 +706,12 @@ fun owned_handoff_does_not_redirect_cashflow() {
     destroy(wallet);
 
     // Alice - not Bob - received the funds.
-    scenario.next_tx(alice);
-    let coin = scenario.take_from_sender<Coin<USDC>>();
-    assert_eq!(coin.value(), 400);
+    let released = event::events_by_type<Released<TestCurve, USDC>>();
+    assert_eq!(released.length(), 1);
+    assert_eq!(
+        released[0],
+        vesting_wallet::test_new_released<TestCurve, USDC>(wallet_id, alice, 400),
+    );
 
-    destroy(coin);
     scenario.end();
 }

--- a/contracts/finance/tests/vesting_wallet_tests.move
+++ b/contracts/finance/tests/vesting_wallet_tests.move
@@ -564,8 +564,8 @@ fun destroy_empty_returns_params_and_emits() {
     // TODO: use `destroy_empty` with a real `AccumulatorRoot` once
     // `accumulator::create_for_testing` ships in the published Sui mainnet framework.
     let receipt = wallet.destroy_empty_for_testing();
-    assert_eq!(vesting_wallet::test_receipt_beneficiary(&receipt), BENEFICIARY);
-    assert_eq!(vesting_wallet::test_receipt_params(&receipt), TestParams { tag: PARAMS_TAG });
+    assert_eq!(receipt.test_receipt_beneficiary(), BENEFICIARY);
+    assert_eq!(receipt.test_receipt_params(), TestParams { tag: PARAMS_TAG });
 
     let destroyed = event::events_by_type<Destroyed<TestCurve, USDC>>();
     assert_eq!(destroyed.length(), 1);


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Making contracts work with address balances first has been requested by MystenLabs.

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

#### PR Checklist

<!-- For the PRs that introduce new features, all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items below may not apply to your case (for example: fixing a typo). -->

- [x] Tests
- [x] Documentation
- [ ] Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vesting wallet funding and payouts are now balance/accumulator-based, with context-free release.
  * Splitter payouts fan out from accumulator-settled funds and emit `Dispersed` details, including a permissionless “receive and disperse” entry point.
* **Bug Fixes**
  * Teardown is more robust by requiring explicit handling of unswept settled funds before emptying.
* **Documentation**
  * Updated vesting wallet README and examples to reflect the new deposit/release/teardown patterns.
* **Tests**
  * Tests now assert outcomes via emitted `Released`/`Dispersed` events rather than extracting payout coins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->