### PR TITLE
ref: [CR-01]: use DestroyCap design for destroying the wallet

### DIFF
--- a/contracts/finance/README.md
+++ b/contracts/finance/README.md
@@ -48,8 +48,9 @@ is not required up front.
 ### Lifecycle
 
 1. **Create** - call `new` (stepped) or `new_continuous`, both returning the wallet
-   by value so you can fund and choose a topology in the same PTB. `create_and_share`/
-   `create_and_share_continuous` are sugar that builds the wallet and shares it in one call.
+   by value (plus a `DestroyCap` that authorizes its later teardown) so you can fund and
+   choose a topology in the same PTB. `create_and_share`/`create_and_share_continuous`
+   are sugar that builds the wallet, shares it, and returns the `DestroyCap` in one call.
 2. **Fund** - `deposit` a `Coin<C>`. Permissionless: anyone may fund, and funds added
    after the schedule starts participate retroactively.
 3. **Release** - `release` evaluates the curve at the current `Clock` and pays the
@@ -58,9 +59,11 @@ is not required up front.
 4. **Inspect** - `releasable` returns what `release` would pay right now; `start_ms`,
    `period_ms`, `steps`, `duration_ms`, `end_ms`, and `cliff_ms` read the schedule.
 5. **Tear down** - once drained, `vesting_wallet::destroy_empty` reclaims the storage
-   rebate and returns a `DestroyReceipt`; hand that to `vesting_wallet_linear::destroy`,
-   which requires the schedule to have ended and the caller to be the beneficiary
-   before accepting the teardown.
+   rebate and returns a `DestroyReceipt`; hand that, together with the wallet's
+   `DestroyCap`, to `vesting_wallet_linear::destroy`, which requires the schedule to have
+   ended before accepting the teardown. Authority is the cap, not the caller's address,
+   so a wallet whose `beneficiary` is an object (never a transaction sender) can still be
+   torn down by whoever holds its cap.
 
 ### Usage
 
@@ -75,9 +78,10 @@ use sui::coin::Coin;
 const DAY_MS: u64 = 86_400_000;
 
 // Four monthly tranches (~30 days each), no cliff, funded up front and shared so
-// anyone can poke `release` on the beneficiary's behalf.
+// anyone can poke `release` on the beneficiary's behalf. The teardown cap is handed to
+// the beneficiary so they can reclaim the storage rebate once the wallet is drained.
 public fun grant<C>(beneficiary: address, start_ms: u64, funds: Coin<C>, ctx: &mut TxContext) {
-    let mut wallet = vesting_wallet_linear::new<C>(
+    let (mut wallet, cap) = vesting_wallet_linear::new<C>(
         beneficiary,
         start_ms,
         0,            // cliff_ms: no cliff
@@ -87,17 +91,19 @@ public fun grant<C>(beneficiary: address, start_ms: u64, funds: Coin<C>, ctx: &m
     );
     wallet.deposit(funds);
     transfer::public_share_object(wallet);
+    transfer::public_transfer(cap, beneficiary);
 }
 
 // Continuous one-year linear vest with a 90-day cliff.
 public fun stream<C>(beneficiary: address, start_ms: u64, ctx: &mut TxContext) {
-    vesting_wallet_linear::create_and_share_continuous<C>(
+    let cap = vesting_wallet_linear::create_and_share_continuous<C>(
         beneficiary,
         start_ms,
         90 * DAY_MS,   // cliff_ms
         365 * DAY_MS,  // duration_ms
         ctx,
     );
+    transfer::public_transfer(cap, beneficiary);
 }
 
 // Anyone can release; the beneficiary is read fresh from the wallet at call time.
@@ -210,8 +216,10 @@ while the curve module still owns validation. For the linear curve:
 
 ```move
 let params = vesting_wallet_linear::params(start_ms, cliff_ms, period_ms, steps);
-let inner = vesting_wallet::new<Linear, Params, C>(params, beneficiary, ctx);
+let (inner, cap) = vesting_wallet::new<Linear, Params, C>(params, beneficiary, ctx);
 let vault = GatedVault { id: object::new(ctx), inner, /* ... */ };
+// Keep `cap` (store it in the vault, or transfer it) - it is required to tear the
+// wallet down later.
 ```
 
 Every curve following the pattern exposes an analogous `params` constructor, so the
@@ -225,14 +233,19 @@ To author a new curve, follow the `vesting_wallet_linear` pattern:
    `public struct MyParams has copy, drop, store { /* ... */ }`.
 2. A public `params` constructor that validates and returns a `MyParams`, plus a
    `new` that is sugar over `vesting_wallet::new<MyCurve, MyParams, C>(params(..),
-   beneficiary, ctx)`. Exposing `params` separately lets a curve-agnostic protocol
-   build the wallet itself without routing through `new`.
+   beneficiary, ctx)` (returning the wallet and its `DestroyCap`). Exposing `params`
+   separately lets a curve-agnostic protocol build the wallet itself without routing
+   through `new`.
 3. A `vested_amount(&VestingWallet<MyCurve, MyParams, C>, &Clock): VestedAmount<MyCurve>`
    that evaluates the curve and ends in `wallet.mint_vested_amount(MyCurve {}, amount)`.
 4. A teardown that calls `wallet.destroy_empty()` for a `DestroyReceipt<MyCurve,
-   MyParams>`, then `vesting_wallet::consume_receipt(receipt, MyCurve {})` to recover
-   the beneficiary and parameters and destructure them. `destroy_empty` is permissionless;
-   the witness-gated `consume_receipt` is what lets the curve run teardown logic or veto.
+   MyParams>`, then `vesting_wallet::consume_receipt(receipt, cap, MyCurve {})` - passing
+   the wallet's `DestroyCap` - to recover the schedule parameters and destructure
+   them. `destroy_empty` is permissionless; `consume_receipt` is gated on both the
+   witness (so the curve can run teardown logic or veto) and the cap (the teardown
+   authority). **Gate teardown on the cap, never on `ctx.sender() == beneficiary`:** an
+   object beneficiary is never a transaction sender, so that check could never be
+   satisfied and would brick teardown for object-beneficiary wallets.
 
 The curve **must be monotonically non-decreasing in time and bounded above by
 `balance + released`.** A curve that violates either makes `release` abort before any
@@ -287,7 +300,9 @@ one per integration boundary described above:
 - **Coins sent to a destroyed wallet are stranded.** After `destroy`/`destroy_empty`
   the object address has no claim path. `vesting_wallet_linear::destroy` requires the
   schedule to have ended, which blocks front-running a pending deposit; pair teardown
-  with halting any upstream emissions that target the wallet.
+  with halting any upstream emissions that target the wallet. Teardown is gated by the
+  wallet's `DestroyCap`, so the cap holder bears this strand risk - route the cap to the
+  party that should own the teardown decision (commonly the beneficiary or its controller).
 - **`receive_and_deposit` can strand a coin on overflow.** If claiming a received
   coin would push the lifetime total (`balance + released`) past `u64::MAX` the call
   aborts, leaving the already-transferred coin parked at the wallet address. High

--- a/contracts/finance/README.md
+++ b/contracts/finance/README.md
@@ -50,7 +50,8 @@ is not required up front.
 1. **Create** - call `new` (stepped) or `new_continuous`, both returning the wallet
    by value (plus a `DestroyCap` that authorizes its later teardown) so you can fund and
    choose a topology in the same PTB. `create_and_share`/`create_and_share_continuous`
-   are sugar that builds the wallet, shares it, and returns the `DestroyCap` in one call.
+   are sugar that builds the wallet, shares it, and returns its `ID` and `DestroyCap` in
+   one call.
 2. **Fund** - `deposit` a `Coin<C>`. Permissionless: anyone may fund, and funds added
    after the schedule starts participate retroactively.
 3. **Release** - `release` evaluates the curve at the current `Clock` and pays the
@@ -96,7 +97,7 @@ public fun grant<C>(beneficiary: address, start_ms: u64, funds: Coin<C>, ctx: &m
 
 // Continuous one-year linear vest with a 90-day cliff.
 public fun stream<C>(beneficiary: address, start_ms: u64, ctx: &mut TxContext) {
-    let cap = vesting_wallet_linear::create_and_share_continuous<C>(
+    let (_wallet_id, cap) = vesting_wallet_linear::create_and_share_continuous<C>(
         beneficiary,
         start_ms,
         90 * DAY_MS,   // cliff_ms

--- a/contracts/finance/examples/vesting_wallet/tests/pausable_grant_tests.move
+++ b/contracts/finance/examples/vesting_wallet/tests/pausable_grant_tests.move
@@ -1,7 +1,7 @@
 module openzeppelin_finance::example_pausable_grant_tests;
 
 use openzeppelin_finance::example_pausable_grant::{Self, PausableGrant, GrantAdminCap};
-use openzeppelin_finance::vesting_wallet::{Self, VestingWallet};
+use openzeppelin_finance::vesting_wallet::{Self, DestroyCap};
 use openzeppelin_finance::vesting_wallet_linear::{Self as linear, Linear, Params};
 use std::unit_test::{assert_eq, destroy};
 use sui::coin::{Self, Coin};
@@ -21,14 +21,16 @@ const TOTAL: u64 = 1_000_000;
 // The grant stays generic over the curve - it only sees `VestingWallet<Linear, ..>`.
 fun create_grant(scenario: &mut ts::Scenario) {
     let params = linear::params_continuous(START_MS, 0, DURATION_MS);
-    let mut wallet = vesting_wallet::new<Linear, Params, USDC>(
+    let (mut wallet, destroy_cap) = vesting_wallet::new<Linear, Params, USDC>(
         params,
         BENEFICIARY,
         scenario.ctx(),
     );
     wallet.deposit(coin::mint_for_testing<USDC>(TOTAL, scenario.ctx()));
-    let cap = example_pausable_grant::new(wallet, scenario.ctx());
-    transfer::public_transfer(cap, EMPLOYER);
+    let admin_cap = example_pausable_grant::new(wallet, scenario.ctx());
+    transfer::public_transfer(admin_cap, EMPLOYER);
+    // The wrapper never sees the teardown cap; the admin keeps it for later teardown.
+    transfer::public_transfer(destroy_cap, EMPLOYER);
 }
 
 // Evaluate the curve through the grant's immutable `inner()` view, then release
@@ -122,9 +124,10 @@ fun resume_restores_releases() {
 }
 
 // Teardown through the wrapper: the admin dissolves the grant with `unwrap`, recovering
-// the bare wallet, then the curve module finalizes teardown. `linear::destroy` is
-// beneficiary-gated, so the admin first forwards the drained wallet to the beneficiary -
-// the custodial-holder hand-off linear's teardown docs describe.
+// the bare wallet, then finalizes teardown with the wallet's `DestroyCap`. Teardown is
+// authority-gated by the cap, not by the beneficiary address, so the admin tears the
+// wallet down directly - no hand-off to the beneficiary required (the wallet's
+// beneficiary could even be an object).
 #[test]
 fun unwrap_then_curve_teardown() {
     let mut scenario = ts::begin(EMPLOYER);
@@ -138,19 +141,15 @@ fun unwrap_then_curve_teardown() {
     clock.set_for_testing(START_MS + DURATION_MS);
     release(&mut grant, &clock, scenario.ctx());
 
-    // Admin dissolves the wrapper, recovering the bare wallet, and forwards it to the
-    // beneficiary so the beneficiary-gated curve teardown can run.
+    // Admin dissolves the wrapper, recovering the bare wallet, and finalizes teardown
+    // with the teardown cap it has held since creation: permissionless `destroy_empty`
+    // for the receipt, then the curve's gated `destroy`.
     scenario.next_tx(EMPLOYER);
-    let cap = scenario.take_from_sender<GrantAdminCap>();
-    let wallet = grant.unwrap(cap);
-    transfer::public_transfer(wallet, BENEFICIARY);
-
-    // Beneficiary finalizes: permissionless `destroy_empty` for the receipt, then the
-    // curve's witness-gated `destroy`.
-    scenario.next_tx(BENEFICIARY);
-    let wallet = scenario.take_from_sender<VestingWallet<Linear, Params, USDC>>();
+    let admin_cap = scenario.take_from_sender<GrantAdminCap>();
+    let destroy_cap = scenario.take_from_sender<DestroyCap>();
+    let wallet = grant.unwrap(admin_cap);
     let receipt = wallet.destroy_empty();
-    linear::destroy(receipt, &clock, scenario.ctx());
+    linear::destroy(receipt, destroy_cap, &clock);
 
     destroy(clock);
     scenario.end();

--- a/contracts/finance/examples/vesting_wallet/tests/splitter_tests.move
+++ b/contracts/finance/examples/vesting_wallet/tests/splitter_tests.move
@@ -32,8 +32,11 @@ fun release_to_splitter_fans_out_by_weight() {
         vector[50, 30, 20],
         scenario.ctx(),
     );
-    // Vest to the splitter object, not a person.
-    linear::create_and_share<USDC>(splitter_addr, START_MS, 0, 1, DURATION_MS, scenario.ctx());
+    // Vest to the splitter object, not a person. The teardown cap is unused here (this
+    // test exercises fan-out, not teardown); object-beneficiary teardown is covered in
+    // the linear tests.
+    let cap = linear::create_and_share<USDC>(splitter_addr, START_MS, 0, 1, DURATION_MS, scenario.ctx());
+    destroy(cap);
 
     scenario.next_tx(EMPLOYER);
     let mut wallet = scenario.take_shared<VestingWallet<Linear, Params, USDC>>();

--- a/contracts/finance/examples/vesting_wallet/tests/splitter_tests.move
+++ b/contracts/finance/examples/vesting_wallet/tests/splitter_tests.move
@@ -32,10 +32,17 @@ fun release_to_splitter_fans_out_by_weight() {
         vector[50, 30, 20],
         scenario.ctx(),
     );
-    // Vest to the splitter object, not a person. The teardown cap is unused here (this
-    // test exercises fan-out, not teardown); object-beneficiary teardown is covered in
-    // the linear tests.
-    let cap = linear::create_and_share<USDC>(splitter_addr, START_MS, 0, 1, DURATION_MS, scenario.ctx());
+    // Vest to the splitter object, not a person. The returned id and teardown cap are
+    // unused here (this test exercises fan-out, not teardown); object-beneficiary
+    // teardown is covered in the linear tests.
+    let (_wallet_id, cap) = linear::create_and_share<USDC>(
+        splitter_addr,
+        START_MS,
+        0,
+        1,
+        DURATION_MS,
+        scenario.ctx(),
+    );
     destroy(cap);
 
     scenario.next_tx(EMPLOYER);

--- a/contracts/finance/examples/vesting_wallet/tests/vesting_quadratic_tests.move
+++ b/contracts/finance/examples/vesting_wallet/tests/vesting_quadratic_tests.move
@@ -1,7 +1,7 @@
 module openzeppelin_finance::example_vesting_quadratic_tests;
 
 use openzeppelin_finance::example_vesting_quadratic::{Self as quadratic, Quadratic, Params};
-use openzeppelin_finance::vesting_wallet::{Self, VestingWallet};
+use openzeppelin_finance::vesting_wallet::{Self, VestingWallet, DestroyCap};
 use std::unit_test::{assert_eq, destroy};
 use sui::coin::{Self, Coin};
 use sui::test_scenario as ts;
@@ -21,13 +21,15 @@ const TOTAL: u64 = 1_000_000;
 // `deposit`, or `public_share_object`.
 fun create_and_share(scenario: &mut ts::Scenario) {
     let params = quadratic::params(START_MS, DURATION_MS);
-    let mut wallet = vesting_wallet::new<Quadratic, Params, USDC>(
+    let (mut wallet, cap) = vesting_wallet::new<Quadratic, Params, USDC>(
         params,
         BENEFICIARY,
         scenario.ctx(),
     );
     wallet.deposit(coin::mint_for_testing<USDC>(TOTAL, scenario.ctx()));
     transfer::public_share_object(wallet);
+    // Park the teardown cap with the beneficiary; the teardown test takes it from there.
+    transfer::public_transfer(cap, BENEFICIARY);
 }
 
 // Happy path: the integrator drives the full lifecycle across both modules. The curve
@@ -164,11 +166,12 @@ fun compose_destroy_after_drain() {
     quadratic_release(&mut wallet, &clock, scenario.ctx());
     assert_eq!(wallet.balance(), 0);
 
-    // Permissionless half reclaims the storage rebate; the witness-gated half consumes
-    // the receipt and enforces the ended and beneficiary gates (the sender is the
-    // beneficiary here).
+    // Permissionless half reclaims the storage rebate; the gated half consumes the
+    // receipt with the wallet's `DestroyCap` (parked with the beneficiary by
+    // `create_and_share`) and enforces the ended gate.
+    let cap = scenario.take_from_sender<DestroyCap>();
     let receipt = wallet.destroy_empty();
-    quadratic::destroy(receipt, &clock, scenario.ctx());
+    quadratic::destroy(receipt, cap, &clock);
 
     scenario.next_tx(BENEFICIARY);
     let paid = scenario.take_from_address<Coin<USDC>>(BENEFICIARY);
@@ -187,9 +190,8 @@ fun destroy_aborts_before_end() {
     let mut clock = sui::clock::create_for_testing(scenario.ctx());
 
     // An unfunded wallet is already empty, so `destroy_empty` succeeds - but the clock
-    // sits before the schedule's end, so `destroy` aborts on the ended gate (the caller
-    // is the beneficiary, so the beneficiary gate cannot fire first).
-    let wallet = vesting_wallet::new<Quadratic, Params, USDC>(
+    // sits before the schedule's end, so `destroy` aborts on the ended gate.
+    let (wallet, cap) = vesting_wallet::new<Quadratic, Params, USDC>(
         quadratic::params(START_MS, DURATION_MS),
         BENEFICIARY,
         scenario.ctx(),
@@ -197,30 +199,34 @@ fun destroy_aborts_before_end() {
     clock.set_for_testing(START_MS + DURATION_MS - 1);
 
     let receipt = wallet.destroy_empty();
-    quadratic::destroy(receipt, &clock, scenario.ctx());
+    quadratic::destroy(receipt, cap, &clock);
 
     abort
 }
 
-// Only the beneficiary may tear down the wallet; any other caller aborts even on a
-// drained, ended wallet.
-#[test, expected_failure(abort_code = quadratic::ENotBeneficiary)]
-fun destroy_rejects_non_beneficiary() {
+// Teardown is authorized by the matching `DestroyCap`, not the caller's address: a cap
+// minted for a different wallet is rejected even on a drained, ended wallet. (Replaces
+// the old beneficiary-gate test - the curve no longer checks `ctx.sender()`.)
+#[test, expected_failure(abort_code = vesting_wallet::EWrongCap)]
+fun destroy_rejects_wrong_cap() {
     let mut scenario = ts::begin(EMPLOYER);
     let mut clock = sui::clock::create_for_testing(scenario.ctx());
 
-    // An unfunded wallet is already empty; place the clock at the schedule's end so the
-    // ended gate cannot fire - only the beneficiary gate can. The sender is EMPLOYER,
-    // not the wallet's beneficiary.
-    let wallet = vesting_wallet::new<Quadratic, Params, USDC>(
+    let (wallet, _cap) = vesting_wallet::new<Quadratic, Params, USDC>(
         quadratic::params(START_MS, DURATION_MS),
         BENEFICIARY,
         scenario.ctx(),
     );
-    clock.set_for_testing(START_MS + DURATION_MS);
+    // A second, independent wallet's cap is foreign to the first.
+    let (_other, other_cap) = vesting_wallet::new<Quadratic, Params, USDC>(
+        quadratic::params(START_MS, DURATION_MS),
+        BENEFICIARY,
+        scenario.ctx(),
+    );
+    clock.set_for_testing(START_MS + DURATION_MS); // after end, so the ended gate cannot fire first
 
     let receipt = wallet.destroy_empty();
-    quadratic::destroy(receipt, &clock, scenario.ctx());
+    quadratic::destroy(receipt, other_cap, &clock);
 
     abort
 }

--- a/contracts/finance/examples/vesting_wallet/vesting_quadratic.move
+++ b/contracts/finance/examples/vesting_wallet/vesting_quadratic.move
@@ -36,7 +36,7 @@
 /// not be deployed as-is.
 module openzeppelin_finance::example_vesting_quadratic;
 
-use openzeppelin_finance::vesting_wallet::{VestingWallet, VestedAmount, DestroyReceipt};
+use openzeppelin_finance::vesting_wallet::{VestingWallet, VestedAmount, DestroyReceipt, DestroyCap};
 use openzeppelin_math::rounding;
 use openzeppelin_math::u64::mul_div;
 use sui::clock::Clock;
@@ -54,10 +54,6 @@ const EScheduleOverflow: vector<u8> = "Schedule end (start + duration) would ove
 /// `destroy` was called before the schedule's end (`start_ms + duration_ms`).
 #[error(code = 2)]
 const ENotEnded: vector<u8> = "Schedule has not ended yet";
-
-/// `destroy` was called by an address other than the wallet's beneficiary.
-#[error(code = 3)]
-const ENotBeneficiary: vector<u8> = "Only the beneficiary may destroy the wallet";
 
 // === Structs ===
 
@@ -108,29 +104,28 @@ public fun releasable<C>(wallet: &VestingWallet<Quadratic, Params, C>, clock: &C
 }
 
 /// Finalize teardown of a drained quadratic wallet by consuming the `DestroyReceipt`
-/// that `vesting_wallet::destroy_empty` returns. `destroy_empty` is the permissionless
-/// half (it reclaims the storage rebate); this is the witness-gated other half - only
-/// this module holds `Quadratic`, so only it can unwrap the receipt - and it
-/// additionally requires the schedule to have ended and the caller to be the
-/// beneficiary. Because the receipt is a hot potato consumed in the same PTB that
-/// produced it, a failed gate here aborts and reverts the whole teardown, including the
-/// `destroy_empty` call.
+/// that `vesting_wallet::destroy_empty` returns, together with the wallet's
+/// `DestroyCap`. `destroy_empty` is the permissionless half (it reclaims the storage
+/// rebate); this is the gated other half - only this module holds `Quadratic`, so only
+/// it can unwrap the receipt - and it additionally requires the schedule to have ended.
+/// Because the receipt is a hot potato consumed in the same PTB that produced it, a
+/// failed gate here (or in the core cap check) aborts and reverts the whole teardown,
+/// including the `destroy_empty` call.
 ///
-/// Both extra gates guard against stranding an in-flight deposit. The ended gate stops a
-/// wallet being torn down ahead of a deposit intended to arrive later. The beneficiary
-/// gate addresses the residual case: a coin `public_transfer`'d to the wallet's address
-/// but not yet `receive_and_deposit`'d is invisible to `destroy_empty`'s empty check, so -
-/// since `destroy_empty` is permissionless - an arbitrary actor could otherwise strand
-/// such a deposit and pocket the storage rebate. Restricting this final step to the
-/// beneficiary keeps both the strand risk and the rebate with the only party harmed by it.
+/// Teardown authority is the `DestroyCap`, not the caller's address - this is the core
+/// primitive's gate, so this curve does not (and must not) re-implement it as a
+/// `ctx.sender() == beneficiary` check, which could never be satisfied for a wallet
+/// whose beneficiary is an object address. The cap holder bears the strand risk for any
+/// coin sent to the wallet's address but not yet `receive_and_deposit`'d (invisible to
+/// `destroy_empty`'s empty check). The ended gate stops a teardown ahead of a deposit
+/// intended to arrive later.
 ///
 /// #### Aborts
+/// - `EWrongCap` if `cap` was minted for a different wallet.
 /// - `ENotEnded` if called before the schedule's end (`start_ms + duration_ms`).
-/// - `ENotBeneficiary` if the caller is not the wallet's beneficiary.
-public fun destroy(receipt: DestroyReceipt<Quadratic, Params>, clock: &Clock, ctx: &mut TxContext) {
-    let (beneficiary, params) = receipt.consume_receipt(Quadratic {});
+public fun destroy(receipt: DestroyReceipt<Quadratic, Params>, cap: DestroyCap, clock: &Clock) {
+    let params = receipt.consume_receipt(cap, Quadratic {});
     assert!(clock.timestamp_ms() >= params.calculate_end(), ENotEnded);
-    assert!(ctx.sender() == beneficiary, ENotBeneficiary);
 }
 
 // === View helpers ===

--- a/contracts/finance/sources/vesting_wallet.move
+++ b/contracts/finance/sources/vesting_wallet.move
@@ -44,6 +44,17 @@
 /// that every `VestingWallet<S, P, C>` carries exactly the `P` its curve needs and
 /// can only be advanced by the curve module that owns `S`.
 ///
+/// # Teardown authority
+///
+/// `new` mints a `DestroyCap` alongside the wallet, bound to it by id. Finalizing a
+/// teardown (`consume_receipt`) requires that cap, so teardown authority is an object
+/// the creator can hold, transfer, or wrap - deliberately decoupled from the wallet's
+/// `beneficiary`. This matters because `beneficiary` can be an object address, which is
+/// never a transaction sender: a `ctx.sender() == beneficiary` gate could never be
+/// satisfied for such a wallet, while a cap can. The cap lives in the core primitive
+/// (not in any one curve), so every curve - including downstream ones copied from the
+/// reference - inherits the same beneficiary-agnostic teardown authority.
+///
 /// # Custom schedules
 ///
 /// Downstream packages ship their own curve in their own module by following the
@@ -60,8 +71,10 @@
 ///    that ends in `vesting_wallet::mint_vested_amount(wallet, MyCurve {}, amount)`.
 /// 4. A teardown that calls `vesting_wallet::destroy_empty(wallet)` to get a
 ///    `DestroyReceipt<MyCurve, MyParams>`, then
-///    `vesting_wallet::consume_receipt(receipt, MyCurve {})` to recover the
-///    beneficiary and parameters for the curve module to destructure.
+///    `vesting_wallet::consume_receipt(receipt, cap, MyCurve {})` - passing the wallet's
+///    `DestroyCap` - to recover the schedule parameters for the curve module to
+///    destructure. Gate teardown on the cap, never on `ctx.sender() == beneficiary`: an
+///    object beneficiary is never a sender, so that check could never be satisfied.
 ///
 /// The curve must be monotonically non-decreasing in time and bounded above by
 /// `balance + released`; violating either makes `release` abort before any state
@@ -116,6 +129,11 @@ const EBalanceOverflow: vector<u8> = "Deposit would overflow the wallet's lifeti
 /// so the current balance cannot cover the releasable amount.
 #[error(code = 4)]
 const EInsufficientBalance: vector<u8> = "Releasable amount exceeds the wallet's balance";
+
+/// The `DestroyCap` passed to `consume_receipt` was minted for a different wallet than
+/// the one being torn down.
+#[error(code = 5)]
+const EWrongCap: vector<u8> = "DestroyCap does not match this wallet";
 
 // === Structs ===
 
@@ -190,14 +208,31 @@ public struct VestedAmount<phantom S> has drop {
     amount: u64,
 }
 
-/// Carries a destroyed wallet's beneficiary and schedule params back to its curve. A
-/// HOT POTATO - no abilities - so it cannot be dropped, stored, or copied: it MUST be
-/// consumed before the tx ends, and only `consume_receipt` (witness-gated) can consume
-/// it. This is what drags the curve into the PTB to finalize, and lets it veto by
-/// aborting.
+/// Carries a destroyed wallet's id and schedule params back to its curve. A HOT POTATO
+/// that only `consume_receipt` (witness-gated, and gated on the matching `DestroyCap`)
+/// can consume it. This is what drags the curve into the PTB to finalize, and lets it
+/// veto by aborting. The `wallet_id` is carried so the cap can be matched against the
+/// now-destroyed wallet at consume time.
 public struct DestroyReceipt<phantom S, P> {
-    beneficiary: address,
+    wallet_id: ID,
+    /// The curve's stored configuration. Opaque to the wallet; only the declaring
+    /// curve module interprets it.
     params: P,
+}
+
+/// Authority to finalize the teardown of one specific wallet. Minted by `new` alongside
+/// the wallet and bound to it by `wallet_id`; consumed by `consume_receipt`, which
+/// rejects any cap whose `wallet_id` does not match the wallet being torn down.
+///
+/// Teardown authority travels with the cap, not with the wallet's `beneficiary`.
+/// This is what makes teardown reachable for a wallet whose beneficiary is an object
+/// address (which can never be a `ctx.sender()`); see the module's "Teardown authority"
+/// note. The cap carries no `drop`, so it cannot be silently discarded - it is retired
+/// only by tearing the wallet down.
+public struct DestroyCap has key, store {
+    id: UID,
+    /// Id of the wallet this cap authorizes the teardown of.
+    wallet_id: ID,
 }
 
 // === Events ===
@@ -237,9 +272,11 @@ public struct Destroyed<phantom S, phantom C> has copy, drop {
 
 // === Public Functions ===
 
-/// Build a new wallet around a schedule and return it by value. Returning by value
-/// (rather than sharing internally) lets the caller chain creation, funding, and
-/// topology selection in a single PTB.
+/// Build a new wallet around a schedule and return it by value, together with the
+/// `DestroyCap` that authorizes its eventual teardown. Returning by value (rather than
+/// sharing internally) lets the caller chain creation, funding, and topology selection
+/// in a single PTB; the cap is a separate owned object the caller routes wherever
+/// teardown authority should live (see the module's "Teardown authority" note).
 ///
 /// The type parameters are:
 /// - `S` - the curve's `drop`-only schedule witness
@@ -256,11 +293,12 @@ public struct Destroyed<phantom S, phantom C> has copy, drop {
 /// #### Returns
 /// - A fresh `VestingWallet<S, P, C>` with a zero balance and nothing released,
 ///   owned by the caller (pick a topology before the PTB ends).
+/// - A `DestroyCap` bound to that wallet by id, required later by `consume_receipt`.
 public fun new<S: drop, P: copy + drop + store, C>(
     schedule_params: P,
     beneficiary: address,
     ctx: &mut TxContext,
-): VestingWallet<S, P, C> {
+): (VestingWallet<S, P, C>, DestroyCap) {
     let wallet = VestingWallet<S, P, C> {
         id: object::new(ctx),
         beneficiary,
@@ -268,14 +306,15 @@ public fun new<S: drop, P: copy + drop + store, C>(
         balance: balance::zero<C>(),
         schedule_params,
     };
+    let wallet_id = object::id(&wallet);
 
     event::emit(Created<S, P, C> {
-        wallet_id: object::id(&wallet),
+        wallet_id,
         beneficiary,
         schedule_params,
     });
 
-    wallet
+    (wallet, DestroyCap { id: object::new(ctx), wallet_id })
 }
 
 /// Mint a `VestedAmount<S>` recording `amount` as the cumulative vested total for
@@ -411,12 +450,16 @@ public fun release<S: drop, P: copy + drop + store, C>(
 /// Consume a drained wallet to reclaim its storage rebate, emit `Destroyed`, and hand
 /// its beneficiary and schedule parameters back as a `DestroyReceipt<S, P>`.
 ///
-/// This call is permissionless - it takes no witness - so a curve-agnostic holder of
-/// the wallet can tear it down without access to `S`. The receipt is a hot potato that
-/// only the declaring curve can unwrap (via `consume_receipt`), so the curve is still
-/// dragged into the teardown PTB and can veto it by aborting. This is the same authority
-/// split as `VestedAmount`: one half stays callable without the witness, the curve gates
-/// the other.
+/// This call is permissionless - it takes no witness and no cap - so a curve-agnostic
+/// holder of the wallet can drain its rebate without access to `S`. The receipt is a hot
+/// potato that only `consume_receipt` can unwrap, and that call requires both the
+/// declaring curve's witness `S` and the wallet's `DestroyCap`; so the curve is still
+/// dragged into the teardown PTB (and can veto by aborting), and the teardown only
+/// finalizes for the cap holder. A `destroy_empty` whose matching `consume_receipt`
+/// never runs - because the caller lacks the cap or the curve vetoes - reverts with the
+/// whole PTB, since the receipt cannot otherwise be retired. This is the same authority
+/// split as `VestedAmount`: one half stays callable without the witness, the other half
+/// is gated.
 ///
 /// Coins `public_transfer`'d to a destroyed wallet's address after this call have no
 /// path back - pair destruction with halting any upstream emissions that target this
@@ -426,8 +469,8 @@ public fun release<S: drop, P: copy + drop + store, C>(
 /// - `wallet`: The wallet to destroy. Must hold a zero balance.
 ///
 /// #### Returns
-/// - A `DestroyReceipt<S, P>` carrying the wallet's beneficiary and schedule
-///   parameters, to be passed to `consume_receipt`.
+/// - A `DestroyReceipt<S, P>` carrying the wallet's schedule parameters, to be passed to
+///   `consume_receipt`.
 ///
 /// #### Aborts
 /// - `ENotEmpty` if the wallet still holds a balance.
@@ -446,28 +489,41 @@ public fun destroy_empty<S: drop, P: copy + drop + store, C>(
 
     event::emit(Destroyed<S, C> { wallet_id, beneficiary, total_released });
 
-    DestroyReceipt { beneficiary, params: schedule_params }
+    DestroyReceipt { wallet_id, params: schedule_params }
 }
 
-/// Unwrap a `DestroyReceipt<S, P>` to recover the destroyed wallet's beneficiary and
-/// schedule parameters. Witness-gated by `_w: S`: only the declaring curve can call
-/// this, so it - and only it - sees the real `P`, runs any teardown logic, and can
-/// abort (reverting the whole teardown, since the wallet was destroyed in the same
-/// PTB) if destruction should not be accepted.
+/// Unwrap a `DestroyReceipt<S, P>` to recover the destroyed wallet's schedule
+/// parameters, consuming the wallet's `DestroyCap` in the process. Gated two ways:
+///
+/// - **Witness `_w: S`** - only the declaring curve can call this, so it (and only it)
+///   sees the real `P`, runs any teardown logic, and can abort (reverting the whole
+///   teardown, since the wallet was destroyed in the same PTB) if destruction should not
+///   be accepted.
+/// - **`cap: DestroyCap`** - must be the cap `new` minted for this exact wallet. This is
+///   the teardown authority, deliberately decoupled from `beneficiary` so a wallet whose
+///   beneficiary is an object address can still be torn down. The cap is retired here.
 ///
 /// #### Parameters
 /// - `receipt`: The `DestroyReceipt<S, P>` returned by `destroy_empty`.
+/// - `cap`: The `DestroyCap` `new` minted for this wallet. Consumed by the call.
 /// - `_w`: The curve witness `S`.
 ///
 /// #### Returns
-/// - The destroyed wallet's `beneficiary` and its schedule parameters `P`, for the
-///   curve module to use and destructure.
+/// - The destroyed wallet's schedule parameters `P`, for the curve module to use and
+///   destructure.
+///
+/// #### Aborts
+/// - `EWrongCap` if `cap` was minted for a different wallet than this receipt's.
 public fun consume_receipt<S: drop, P: copy + drop + store>(
     receipt: DestroyReceipt<S, P>,
+    cap: DestroyCap,
     _w: S,
-): (address, P) {
-    let DestroyReceipt { beneficiary, params } = receipt;
-    (beneficiary, params)
+): P {
+    let DestroyReceipt { wallet_id, params } = receipt;
+    let DestroyCap { id, wallet_id: cap_wallet_id } = cap;
+    assert!(cap_wallet_id == wallet_id, EWrongCap);
+    id.delete();
+    params
 }
 
 // === View helpers ===
@@ -592,13 +648,6 @@ public fun test_new_destroyed<S, C>(
     total_released: u64,
 ): Destroyed<S, C> {
     Destroyed { wallet_id, beneficiary, total_released }
-}
-
-/// Read a `DestroyReceipt`'s `beneficiary` for test assertions; the receipt is
-/// otherwise opaque (a hot potato with private fields).
-#[test_only]
-public fun test_receipt_beneficiary<S, P>(receipt: &DestroyReceipt<S, P>): address {
-    receipt.beneficiary
 }
 
 /// Read a `DestroyReceipt`'s `params` for test assertions; the receipt is otherwise

--- a/contracts/finance/sources/vesting_wallet_linear.move
+++ b/contracts/finance/sources/vesting_wallet_linear.move
@@ -239,9 +239,10 @@ public fun new_continuous<C>(
 }
 
 /// Sugar for the common case: build a stepped wallet and immediately share it via
-/// `transfer::public_share_object`, returning the wallet's `DestroyCap` for the caller
-/// to route wherever teardown authority should live (held, forwarded, or wrapped) -
-/// whoever ends up holding it can later tear the wallet down.
+/// `transfer::public_share_object`, returning the shared wallet's `ID` (so the caller
+/// can reference it once it is no longer held by value) and its `DestroyCap` for the
+/// caller to route wherever teardown authority should live (held, forwarded, or
+/// wrapped) - whoever ends up holding the cap can later tear the wallet down.
 ///
 /// #### Parameters
 /// - `beneficiary`: Address that every release pays out to.
@@ -252,6 +253,7 @@ public fun new_continuous<C>(
 /// - `ctx`: Transaction context.
 ///
 /// #### Returns
+/// - The shared wallet's `ID`.
 /// - The shared wallet's `DestroyCap`, required later by `destroy`.
 ///
 /// #### Aborts
@@ -267,15 +269,16 @@ public fun create_and_share<C>(
     period_ms: u64,
     steps: u64,
     ctx: &mut TxContext,
-): DestroyCap {
+): (ID, DestroyCap) {
     let (wallet, cap) = new<C>(beneficiary, start_ms, cliff_ms, period_ms, steps, ctx);
+    let wallet_id = object::id(&wallet);
     transfer::public_share_object(wallet);
-    cap
+    (wallet_id, cap)
 }
 
 /// Sugar for the common case: build a continuous wallet and immediately share it via
-/// `transfer::public_share_object`, returning the wallet's `DestroyCap` for the caller
-/// to route wherever teardown authority should live.
+/// `transfer::public_share_object`, returning the shared wallet's `ID` and its
+/// `DestroyCap` for the caller to route wherever teardown authority should live.
 ///
 /// #### Parameters
 /// - `beneficiary`: Address that every release pays out to.
@@ -285,6 +288,7 @@ public fun create_and_share<C>(
 /// - `ctx`: Transaction context.
 ///
 /// #### Returns
+/// - The shared wallet's `ID`.
 /// - The shared wallet's `DestroyCap`, required later by `destroy`.
 ///
 /// #### Aborts
@@ -297,10 +301,11 @@ public fun create_and_share_continuous<C>(
     cliff_ms: u64,
     duration_ms: u64,
     ctx: &mut TxContext,
-): DestroyCap {
+): (ID, DestroyCap) {
     let (wallet, cap) = new_continuous<C>(beneficiary, start_ms, cliff_ms, duration_ms, ctx);
+    let wallet_id = object::id(&wallet);
     transfer::public_share_object(wallet);
-    cap
+    (wallet_id, cap)
 }
 
 // === Curve evaluation & release ===

--- a/contracts/finance/sources/vesting_wallet_linear.move
+++ b/contracts/finance/sources/vesting_wallet_linear.move
@@ -51,7 +51,13 @@
 /// made at `t > start_ms` immediately participate at the current step proportion.
 module openzeppelin_finance::vesting_wallet_linear;
 
-use openzeppelin_finance::vesting_wallet::{Self, VestingWallet, VestedAmount, DestroyReceipt};
+use openzeppelin_finance::vesting_wallet::{
+    Self,
+    VestingWallet,
+    VestedAmount,
+    DestroyReceipt,
+    DestroyCap
+};
 use openzeppelin_math::rounding;
 use openzeppelin_math::u64::mul_div;
 use sui::clock::Clock;
@@ -78,10 +84,6 @@ const EScheduleOverflow: vector<u8> = "Schedule end (start + period * steps) wou
 /// `destroy` was called before the schedule's end (`start_ms + period_ms * steps`).
 #[error(code = 4)]
 const ENotEnded: vector<u8> = "Schedule has not ended yet";
-
-/// `destroy` was called by an address other than the wallet's beneficiary.
-#[error(code = 5)]
-const ENotBeneficiary: vector<u8> = "Only the beneficiary may destroy the wallet";
 
 // === Structs ===
 
@@ -171,9 +173,10 @@ public fun params_continuous(start_ms: u64, cliff_ms: u64, duration_ms: u64): Pa
 }
 
 /// Build a `VestingWallet<Linear, Params, C>` on the stepped (tranche) schedule.
-/// Returns the wallet by value so the caller can chain deposit and topology
-/// selection in one PTB. Use `create_and_share` for the common "share immediately"
-/// case.
+/// Returns the wallet by value, plus the `DestroyCap` that authorizes its teardown, so
+/// the caller can chain deposit and topology selection in one PTB and route the cap to
+/// wherever teardown authority should live. Use `create_and_share` for the common "share
+/// immediately" case.
 ///
 /// #### Parameters
 /// - `beneficiary`: Address that every release pays out to.
@@ -185,6 +188,7 @@ public fun params_continuous(start_ms: u64, cliff_ms: u64, duration_ms: u64): Pa
 ///
 /// #### Returns
 /// - A fresh, unfunded `VestingWallet<Linear, Params, C>` owned by the caller.
+/// - The `DestroyCap` bound to that wallet, required later by `destroy`.
 ///
 /// #### Aborts
 /// - `EZeroPeriod` if `period_ms == 0`.
@@ -199,15 +203,15 @@ public fun new<C>(
     period_ms: u64,
     steps: u64,
     ctx: &mut TxContext,
-): VestingWallet<Linear, Params, C> {
+): (VestingWallet<Linear, Params, C>, DestroyCap) {
     vesting_wallet::new(params(start_ms, cliff_ms, period_ms, steps), beneficiary, ctx)
 }
 
 /// Sugar for a continuous linear-with-cliff schedule: the stepped curve in the
 /// `period_ms = 1` limit (`steps = duration_ms`), where every millisecond is its own
 /// tranche and the curve rises linearly. Use `new` directly for coarser tranches.
-/// Returns the wallet by value; use `create_and_share` for the common "share
-/// immediately" case.
+/// Returns the wallet by value plus its `DestroyCap`; use `create_and_share` for the
+/// common "share immediately" case.
 ///
 /// #### Parameters
 /// - `beneficiary`: Address that every release pays out to.
@@ -218,6 +222,7 @@ public fun new<C>(
 ///
 /// #### Returns
 /// - A fresh, unfunded `VestingWallet<Linear, Params, C>` owned by the caller.
+/// - The `DestroyCap` bound to that wallet, required later by `destroy`.
 ///
 /// #### Aborts
 /// - `EZeroSteps` if `duration_ms == 0`.
@@ -229,13 +234,14 @@ public fun new_continuous<C>(
     cliff_ms: u64,
     duration_ms: u64,
     ctx: &mut TxContext,
-): VestingWallet<Linear, Params, C> {
+): (VestingWallet<Linear, Params, C>, DestroyCap) {
     vesting_wallet::new(params_continuous(start_ms, cliff_ms, duration_ms), beneficiary, ctx)
 }
 
-/// Sugar for the common case: build a stepped wallet and immediately share it. The
-/// wallet is made shared via `transfer::public_share_object` instead of being
-/// returned.
+/// Sugar for the common case: build a stepped wallet and immediately share it via
+/// `transfer::public_share_object`, returning the wallet's `DestroyCap` for the caller
+/// to route wherever teardown authority should live (held, forwarded, or wrapped) -
+/// whoever ends up holding it can later tear the wallet down.
 ///
 /// #### Parameters
 /// - `beneficiary`: Address that every release pays out to.
@@ -244,6 +250,9 @@ public fun new_continuous<C>(
 /// - `period_ms`: Length of each tranche period (ms).
 /// - `steps`: Number of equal tranches.
 /// - `ctx`: Transaction context.
+///
+/// #### Returns
+/// - The shared wallet's `DestroyCap`, required later by `destroy`.
 ///
 /// #### Aborts
 /// - `EZeroPeriod` if `period_ms == 0`.
@@ -258,13 +267,15 @@ public fun create_and_share<C>(
     period_ms: u64,
     steps: u64,
     ctx: &mut TxContext,
-) {
-    let wallet = new<C>(beneficiary, start_ms, cliff_ms, period_ms, steps, ctx);
+): DestroyCap {
+    let (wallet, cap) = new<C>(beneficiary, start_ms, cliff_ms, period_ms, steps, ctx);
     transfer::public_share_object(wallet);
+    cap
 }
 
-/// Sugar for the common case: build a continuous wallet and immediately share it.
-/// The wallet is made shared via `transfer::public_share_object`.
+/// Sugar for the common case: build a continuous wallet and immediately share it via
+/// `transfer::public_share_object`, returning the wallet's `DestroyCap` for the caller
+/// to route wherever teardown authority should live.
 ///
 /// #### Parameters
 /// - `beneficiary`: Address that every release pays out to.
@@ -272,6 +283,9 @@ public fun create_and_share<C>(
 /// - `cliff_ms`: Cliff length (ms from `start_ms`); `0` for no cliff.
 /// - `duration_ms`: Length of the vesting period (ms).
 /// - `ctx`: Transaction context.
+///
+/// #### Returns
+/// - The shared wallet's `DestroyCap`, required later by `destroy`.
 ///
 /// #### Aborts
 /// - `EZeroSteps` if `duration_ms == 0`.
@@ -283,9 +297,10 @@ public fun create_and_share_continuous<C>(
     cliff_ms: u64,
     duration_ms: u64,
     ctx: &mut TxContext,
-) {
-    let wallet = new_continuous<C>(beneficiary, start_ms, cliff_ms, duration_ms, ctx);
+): DestroyCap {
+    let (wallet, cap) = new_continuous<C>(beneficiary, start_ms, cliff_ms, duration_ms, ctx);
     transfer::public_share_object(wallet);
+    cap
 }
 
 // === Curve evaluation & release ===
@@ -342,42 +357,39 @@ public fun releasable<C>(wallet: &VestingWallet<Linear, Params, C>, clock: &Cloc
 }
 
 /// Finalize teardown of a drained, ended `Linear` wallet by consuming the
-/// `DestroyReceipt<Linear, Params>` that `vesting_wallet::destroy_empty` returns.
-/// `destroy_empty` is permissionless and is what actually reclaims the storage rebate;
-/// this call is the witness-gated other half - only this module holds `Linear`, so
-/// only it can unwrap the receipt - and it additionally requires the schedule to have
-/// ended and the caller to be the beneficiary. Because the receipt is a hot potato
-/// consumed in the same PTB that produced it, a failed gate here aborts and reverts
-/// the whole teardown, including the `destroy_empty` call.
+/// `DestroyReceipt<Linear, Params>` that `vesting_wallet::destroy_empty` returns, along
+/// with the wallet's `DestroyCap`. `destroy_empty` is permissionless and is what
+/// actually reclaims the storage rebate; this call is the gated other half - only this
+/// module holds `Linear`, so only it can unwrap the receipt - and it additionally
+/// requires the schedule to have ended. Because the receipt is a hot potato consumed in
+/// the same PTB that produced it, a failed gate here (or in the core cap check) aborts
+/// and reverts the whole teardown, including the `destroy_empty` call.
 ///
-/// Both extra gates guard against stranding an in-flight deposit. The ended gate stops
-/// a wallet being torn down ahead of a pending deposit, front-running funding intended
-/// to arrive later. The beneficiary gate addresses the residual case: a coin
+/// Authority comes from the `cap`, not the caller's address: whoever holds the wallet's
+/// `DestroyCap` may tear it down. This is what lets a wallet whose `beneficiary` is an
+/// object address be torn down at all - an object address is never a `ctx.sender()`, so
+/// the previous "only the beneficiary may destroy" gate could never be satisfied for it.
+/// The cap holder bears the strand risk the old beneficiary gate guarded: a coin
 /// `public_transfer`'d to the wallet's address but not yet `receive_and_deposit`'d is
-/// invisible to `destroy_empty`'s empty check, so - since `destroy_empty` is
-/// permissionless - an arbitrary actor could otherwise strand such a deposit and
-/// pocket the storage rebate. Restricting this final step to the beneficiary keeps both
-/// the strand risk and the rebate with the only party harmed by it.
+/// invisible to `destroy_empty`'s empty check, so finalizing teardown forfeits it. Route
+/// the cap to the party that should own that decision (commonly the beneficiary or its
+/// controller).
 ///
-/// In owned mode this couples teardown to the beneficiary in both halves:
-/// `destroy_empty` needs the wallet object by value (owner-only) and this call needs
-/// `ctx.sender() == beneficiary`. A custodial holder that is not the beneficiary must
-/// transfer the wallet to the beneficiary before the rebate can be reclaimed. Shared
-/// topology is unaffected.
+/// The ended gate is retained: it stops a wallet being torn down ahead of a pending
+/// deposit, front-running funding intended to arrive later.
 ///
 /// #### Parameters
 /// - `receipt`: The `DestroyReceipt<Linear, Params>` returned by
 ///   `vesting_wallet::destroy_empty`.
+/// - `cap`: The wallet's `DestroyCap`, minted by `new`. Consumed by the call.
 /// - `clock`: Sui `Clock`, used to check the schedule has ended.
-/// - `ctx`: Transaction context, used to check the caller is the beneficiary.
 ///
 /// #### Aborts
+/// - `EWrongCap` if `cap` was minted for a different wallet.
 /// - `ENotEnded` if called before the schedule's end (`start_ms + period_ms * steps`).
-/// - `ENotBeneficiary` if the caller is not the wallet's beneficiary.
-public fun destroy(receipt: DestroyReceipt<Linear, Params>, clock: &Clock, ctx: &mut TxContext) {
-    let (beneficiary, params) = vesting_wallet::consume_receipt(receipt, Linear {});
+public fun destroy(receipt: DestroyReceipt<Linear, Params>, cap: DestroyCap, clock: &Clock) {
+    let params = vesting_wallet::consume_receipt(receipt, cap, Linear {});
     assert!(clock.timestamp_ms() >= params.calculate_end(), ENotEnded);
-    assert!(ctx.sender() == beneficiary, ENotBeneficiary);
 }
 
 // === View helpers ===

--- a/contracts/finance/tests/vesting_wallet_linear_tests.move
+++ b/contracts/finance/tests/vesting_wallet_linear_tests.move
@@ -25,6 +25,9 @@ fun setup(t0: u64): (Scenario, Clock) {
     (test, clk)
 }
 
+// Curve-shape and release tests do not tear down, so these helpers discard the
+// `DestroyCap` and return just the wallet. Teardown tests call the constructors directly
+// to keep the cap.
 fun new_stepped(
     start: u64,
     cliff: u64,
@@ -32,7 +35,9 @@ fun new_stepped(
     steps: u64,
     ctx: &mut TxContext,
 ): VestingWallet<Linear, Params, USDC> {
-    vesting_wallet_linear::new<USDC>(BENEFICIARY, start, cliff, period, steps, ctx)
+    let (wallet, cap) = vesting_wallet_linear::new<USDC>(BENEFICIARY, start, cliff, period, steps, ctx);
+    destroy(cap);
+    wallet
 }
 
 fun new_continuous(
@@ -41,7 +46,9 @@ fun new_continuous(
     duration: u64,
     ctx: &mut TxContext,
 ): VestingWallet<Linear, Params, USDC> {
-    vesting_wallet_linear::new_continuous<USDC>(BENEFICIARY, start, cliff, duration, ctx)
+    let (wallet, cap) = vesting_wallet_linear::new_continuous<USDC>(BENEFICIARY, start, cliff, duration, ctx);
+    destroy(cap);
+    wallet
 }
 
 fun fund(wallet: &mut VestingWallet<Linear, Params, USDC>, amount: u64, ctx: &mut TxContext) {
@@ -170,7 +177,8 @@ fun params_drives_bare_primitive() {
     let (mut test, mut clk) = setup(0);
 
     let p = vesting_wallet_linear::params(100, 250, 1000, 4);
-    let mut wallet = vesting_wallet::new<Linear, Params, USDC>(p, BENEFICIARY, test.ctx());
+    let (mut wallet, cap) = vesting_wallet::new<Linear, Params, USDC>(p, BENEFICIARY, test.ctx());
+    destroy(cap);
     wallet.fund(1000, test.ctx());
 
     assert_eq!(vesting_wallet_linear::start_ms(&wallet), 100);
@@ -202,7 +210,8 @@ fun params_rejects_zero_period() {
 fun create_and_share_shares_wallet() {
     let (mut test, clk) = setup(0);
 
-    vesting_wallet_linear::create_and_share<USDC>(BENEFICIARY, 0, 0, 1000, 4, test.ctx());
+    let cap = vesting_wallet_linear::create_and_share<USDC>(BENEFICIARY, 0, 0, 1000, 4, test.ctx());
+    destroy(cap);
 
     test.next_tx(@0x1);
     let wallet = test.take_shared<VestingWallet<Linear, Params, USDC>>();
@@ -219,7 +228,14 @@ fun create_and_share_shares_wallet() {
 fun create_and_share_continuous_shares_wallet() {
     let (mut test, clk) = setup(0);
 
-    vesting_wallet_linear::create_and_share_continuous<USDC>(BENEFICIARY, 0, 0, 4000, test.ctx());
+    let cap = vesting_wallet_linear::create_and_share_continuous<USDC>(
+        BENEFICIARY,
+        0,
+        0,
+        4000,
+        test.ctx(),
+    );
+    destroy(cap);
 
     test.next_tx(@0x1);
     let wallet = test.take_shared<VestingWallet<Linear, Params, USDC>>();
@@ -546,12 +562,12 @@ fun full_release_after_end_then_releasable_zero() {
 
 // === Teardown ===
 
-// A drained, ended wallet can be torn down and emits `Destroyed`.
+// A drained, ended wallet can be torn down with its `DestroyCap` and emits `Destroyed`.
 #[test]
 fun destroy_after_end_on_empty_wallet() {
     let (mut test, mut clk) = setup(0);
 
-    let mut wallet = new_stepped(0, 0, 1000, 4, test.ctx());
+    let (mut wallet, cap) = vesting_wallet_linear::new<USDC>(BENEFICIARY, 0, 0, 1000, 4, test.ctx());
     let wallet_id = object::id(&wallet);
     wallet.fund(1000, test.ctx());
 
@@ -561,7 +577,7 @@ fun destroy_after_end_on_empty_wallet() {
 
     test.next_tx(BENEFICIARY);
     let receipt = wallet.destroy_empty();
-    vesting_wallet_linear::destroy(receipt, &clk, test.ctx());
+    vesting_wallet_linear::destroy(receipt, cap, &clk);
 
     let destroyed = event::events_by_type<Destroyed<Linear, USDC>>();
     assert_eq!(destroyed.length(), 1);
@@ -574,45 +590,90 @@ fun destroy_after_end_on_empty_wallet() {
     test.end();
 }
 
+// Regression for the object-beneficiary teardown bug: a wallet whose `beneficiary` is an
+// object address (never a transaction sender) can still be torn down, because teardown
+// authority is the `DestroyCap`, not `ctx.sender() == beneficiary`. An unrelated keypair
+// that merely holds the cap finalizes it.
+#[test]
+fun destroy_works_for_object_beneficiary() {
+    let (mut test, mut clk) = setup(0);
+
+    // Use another wallet's address as a stand-in object address for the beneficiary.
+    let (placeholder, placeholder_cap) = vesting_wallet_linear::new<USDC>(
+        BENEFICIARY,
+        0,
+        0,
+        1000,
+        4,
+        test.ctx(),
+    );
+    let object_addr = object::id_address(&placeholder);
+
+    let (mut wallet, cap) = vesting_wallet_linear::new<USDC>(object_addr, 0, 0, 1000, 4, test.ctx());
+    wallet.fund(1000, test.ctx());
+    clk.set_for_testing(4000);
+    vesting_wallet_linear::release(&mut wallet, &clk, test.ctx()); // drains to the object beneficiary
+    assert_eq!(wallet.balance(), 0);
+
+    // A keypair that is NOT the object beneficiary tears the wallet down with the cap.
+    test.next_tx(@0xCAFE);
+    let receipt = wallet.destroy_empty();
+    vesting_wallet_linear::destroy(receipt, cap, &clk);
+
+    assert_eq!(event::events_by_type<Destroyed<Linear, USDC>>().length(), 1);
+
+    destroy(placeholder);
+    destroy(placeholder_cap);
+    destroy(clk);
+    test.end();
+}
+
 // Tearing down before the schedule end aborts, even on an empty wallet.
 #[test, expected_failure(abort_code = vesting_wallet_linear::ENotEnded)]
 fun destroy_rejects_before_end() {
     let (mut test, mut clk) = setup(0);
 
-    let wallet = new_stepped(0, 0, 1000, 4, test.ctx());
+    let (wallet, cap) = vesting_wallet_linear::new<USDC>(BENEFICIARY, 0, 0, 1000, 4, test.ctx());
     clk.set_for_testing(3999);
     let receipt = wallet.destroy_empty();
-    vesting_wallet_linear::destroy(receipt, &clk, test.ctx());
+    vesting_wallet_linear::destroy(receipt, cap, &clk);
     abort
 }
 
-// Tearing down a wallet that still holds a balance aborts. Clock is after end and
-// the caller is the beneficiary, so neither the ended nor the beneficiary gate can
-// fire - only the empty-balance gate from the primitive.
+// Tearing down a wallet that still holds a balance aborts on the primitive's empty-balance
+// gate. Clock is after end so the ended gate cannot fire first.
 #[test, expected_failure(abort_code = vesting_wallet::ENotEmpty)]
 fun destroy_rejects_nonempty_balance() {
     let (mut test, mut clk) = setup(0);
 
-    let mut wallet = new_stepped(0, 0, 1000, 4, test.ctx());
+    let (mut wallet, cap) = vesting_wallet_linear::new<USDC>(BENEFICIARY, 0, 0, 1000, 4, test.ctx());
     wallet.fund(1, test.ctx());
     clk.set_for_testing(5000); // after end, so the ended gate cannot fire
-    test.next_tx(BENEFICIARY);
     let receipt = wallet.destroy_empty();
-    vesting_wallet_linear::destroy(receipt, &clk, test.ctx());
+    vesting_wallet_linear::destroy(receipt, cap, &clk);
     abort
 }
 
-// Only the beneficiary may tear down the wallet; any other caller aborts even on a
-// drained, ended wallet.
-#[test, expected_failure(abort_code = vesting_wallet_linear::ENotBeneficiary)]
-fun destroy_rejects_non_beneficiary() {
+// Teardown is authorized by the matching `DestroyCap`, not the caller's address: a cap
+// minted for a different wallet is rejected even on a drained, ended wallet.
+#[test, expected_failure(abort_code = vesting_wallet::EWrongCap)]
+fun destroy_rejects_wrong_cap() {
     let (mut test, mut clk) = setup(0);
 
-    let wallet = new_stepped(0, 0, 1000, 4, test.ctx());
-    clk.set_for_testing(5000); // after end, so the ended gate cannot fire
-    test.next_tx(@0xCAFE); // not the beneficiary
+    let (wallet, _cap) = vesting_wallet_linear::new<USDC>(BENEFICIARY, 0, 0, 1000, 4, test.ctx());
+    // A second, independent wallet's cap is foreign to the first.
+    let (_other_wallet, other_cap) = vesting_wallet_linear::new<USDC>(
+        BENEFICIARY,
+        0,
+        0,
+        1000,
+        4,
+        test.ctx(),
+    );
+
+    clk.set_for_testing(5000); // after end, so the ended gate cannot fire first
     let receipt = wallet.destroy_empty();
-    vesting_wallet_linear::destroy(receipt, &clk, test.ctx());
+    vesting_wallet_linear::destroy(receipt, other_cap, &clk);
     abort
 }
 
@@ -754,7 +815,8 @@ fun params_continuous_drives_bare_primitive() {
     let (mut test, clk) = setup(0);
 
     let p = vesting_wallet_linear::params_continuous(100, 250, 1000);
-    let wallet = vesting_wallet::new<Linear, Params, USDC>(p, BENEFICIARY, test.ctx());
+    let (wallet, cap) = vesting_wallet::new<Linear, Params, USDC>(p, BENEFICIARY, test.ctx());
+    destroy(cap);
 
     assert_eq!(vesting_wallet_linear::start_ms(&wallet), 100);
     assert_eq!(vesting_wallet_linear::cliff_ms(&wallet), 250);

--- a/contracts/finance/tests/vesting_wallet_linear_tests.move
+++ b/contracts/finance/tests/vesting_wallet_linear_tests.move
@@ -205,16 +205,25 @@ fun params_rejects_zero_period() {
     vesting_wallet_linear::params(0, 0, 0, 4);
 }
 
-// `create_and_share` puts the wallet into the shared topology.
+// `create_and_share` puts the wallet into the shared topology and returns its id + cap.
 #[test]
 fun create_and_share_shares_wallet() {
     let (mut test, clk) = setup(0);
 
-    let cap = vesting_wallet_linear::create_and_share<USDC>(BENEFICIARY, 0, 0, 1000, 4, test.ctx());
+    let (wallet_id, cap) = vesting_wallet_linear::create_and_share<USDC>(
+        BENEFICIARY,
+        0,
+        0,
+        1000,
+        4,
+        test.ctx(),
+    );
     destroy(cap);
 
     test.next_tx(@0x1);
     let wallet = test.take_shared<VestingWallet<Linear, Params, USDC>>();
+    // The returned id identifies the shared wallet.
+    assert_eq!(object::id(&wallet), wallet_id);
     assert_eq!(wallet.beneficiary(), BENEFICIARY);
     assert_eq!(vesting_wallet_linear::duration_ms(&wallet), 4000);
     test_scenario::return_shared(wallet);
@@ -223,12 +232,13 @@ fun create_and_share_shares_wallet() {
     test.end();
 }
 
-// `create_and_share_continuous` puts a continuous wallet into the shared topology.
+// `create_and_share_continuous` puts a continuous wallet into the shared topology and
+// returns its id + cap.
 #[test]
 fun create_and_share_continuous_shares_wallet() {
     let (mut test, clk) = setup(0);
 
-    let cap = vesting_wallet_linear::create_and_share_continuous<USDC>(
+    let (wallet_id, cap) = vesting_wallet_linear::create_and_share_continuous<USDC>(
         BENEFICIARY,
         0,
         0,
@@ -239,6 +249,7 @@ fun create_and_share_continuous_shares_wallet() {
 
     test.next_tx(@0x1);
     let wallet = test.take_shared<VestingWallet<Linear, Params, USDC>>();
+    assert_eq!(object::id(&wallet), wallet_id);
     assert_eq!(wallet.beneficiary(), BENEFICIARY);
     assert_eq!(vesting_wallet_linear::duration_ms(&wallet), 4000);
     assert_eq!(vesting_wallet_linear::period_ms(&wallet), 1);

--- a/contracts/finance/tests/vesting_wallet_tests.move
+++ b/contracts/finance/tests/vesting_wallet_tests.move
@@ -40,15 +40,20 @@ const PARAMS_TAG: u64 = 7;
 
 // === Test-Only Helpers ===
 
+// Most tests do not exercise teardown, so this helper discards the `DestroyCap` and
+// returns just the wallet. Teardown tests call `vesting_wallet::new` directly to keep
+// the cap.
 fun new_wallet(
     beneficiary: address,
     ctx: &mut TxContext,
 ): VestingWallet<TestCurve, TestParams, USDC> {
-    vesting_wallet::new<TestCurve, TestParams, USDC>(
+    let (wallet, cap) = vesting_wallet::new<TestCurve, TestParams, USDC>(
         TestParams { tag: PARAMS_TAG },
         beneficiary,
         ctx,
-    )
+    );
+    destroy(cap);
+    wallet
 }
 
 fun mint(amount: u64, ctx: &mut TxContext): Coin<USDC> {
@@ -536,7 +541,6 @@ fun destroy_empty_returns_params_and_emits() {
     let wallet_id = object::id(&wallet);
 
     let receipt = wallet.destroy_empty();
-    assert_eq!(vesting_wallet::test_receipt_beneficiary(&receipt), BENEFICIARY);
     assert_eq!(vesting_wallet::test_receipt_params(&receipt), TestParams { tag: PARAMS_TAG });
 
     let destroyed = event::events_by_type<Destroyed<TestCurve, USDC>>();
@@ -559,6 +563,48 @@ fun destroy_empty_rejects_nonempty_balance() {
     wallet.deposit(mint(1, &mut ctx));
 
     let _receipt = wallet.destroy_empty();
+    abort
+}
+
+// `consume_receipt` retires a drained wallet's receipt when handed the matching
+// `DestroyCap` and the curve witness, returning the schedule params. Teardown authority
+// is the cap, not the caller's address - so this works for any beneficiary, object
+// addresses included.
+#[test]
+fun consume_receipt_with_matching_cap_returns_params() {
+    let mut ctx = tx_context::dummy();
+
+    let (wallet, cap) = vesting_wallet::new<TestCurve, TestParams, USDC>(
+        TestParams { tag: PARAMS_TAG },
+        BENEFICIARY,
+        &mut ctx,
+    );
+
+    let receipt = wallet.destroy_empty();
+    let params = receipt.consume_receipt(cap, TestCurve {});
+
+    assert_eq!(params, TestParams { tag: PARAMS_TAG });
+}
+
+// A `DestroyCap` minted for a different wallet cannot finalize this wallet's teardown.
+#[test, expected_failure(abort_code = vesting_wallet::EWrongCap)]
+fun consume_receipt_rejects_foreign_cap() {
+    let mut ctx = tx_context::dummy();
+
+    let (wallet_a, _cap_a) = vesting_wallet::new<TestCurve, TestParams, USDC>(
+        TestParams { tag: PARAMS_TAG },
+        BENEFICIARY,
+        &mut ctx,
+    );
+    let (_wallet_b, cap_b) = vesting_wallet::new<TestCurve, TestParams, USDC>(
+        TestParams { tag: PARAMS_TAG },
+        BENEFICIARY,
+        &mut ctx,
+    );
+
+    // Tearing A's receipt down with B's cap aborts: the cap's `wallet_id` does not match.
+    let receipt_a = wallet_a.destroy_empty();
+    receipt_a.consume_receipt(cap_b, TestCurve {});
     abort
 }
 


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Resolves [[CR-01]](https://audits.openzeppelin.com/sui-contracts/sui-01-10-vesting-wallet-/issue/wallets-with-an-object-address-beneficiary-cannot-be-torn-down-e959d27f)

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

#### PR Checklist

<!-- For the PRs that introduce new features, all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items below may not apply to your case (for example: fixing a typo). -->

- [x] Tests
- [x] Documentation
- [ ] Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vesting wallets now return a teardown capability when created, enabling authorized cleanup later.
  * Teardown now works for object-based beneficiaries as long as the matching capability is held.

* **Bug Fixes**
  * Fixed teardown authorization to rely on the wallet’s capability instead of caller identity.
  * Added stronger validation to prevent using the wrong teardown capability.

* **Documentation**
  * Clarified vesting lifecycle, teardown behavior, and storage-rebate handling in the finance docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->