### PR TITLE
[N-05] Allowance Audit

### DIFF
--- a/contracts/allowance/sources/spend_vault.move
+++ b/contracts/allowance/sources/spend_vault.move
@@ -1097,7 +1097,9 @@ public fun delete_orphaned_cap(cap: SpenderCap) {
 ///
 /// Recovers only strays sent to THIS vault: a generic cross-address squash is
 /// unbuildable (you cannot consume a coin you do not control). It needs
-/// `&mut v.id` only for `public_receive`.
+/// `&mut v.id` only for `public_receive`. It is the vault's only object-receive
+/// path and is `Coin`-typed, so any non-`Coin` object sent to the vault address
+/// cannot be recovered.
 ///
 /// #### Parameters
 /// - `v`: The vault whose pool receives the recovered stray.


### PR DESCRIPTION
Fixes [N-05](https://audits.openzeppelin.com/sui-contracts/sui-01-11-allowance-/issue/non-coin-objects-transferred-to-a-vault-are-permanently-unrecoverable-e3c5c8e9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified vault handling notes so it’s clear that only the supported receive path is available and that non-coin objects sent to the vault address cannot be recovered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->