### PR TITLE
[N-01] VestingWallet audit

### DIFF
--- a/contracts/finance/README.md
+++ b/contracts/finance/README.md
@@ -165,6 +165,8 @@ checks:
 module my_protocol::gated_vault;
 
 use openzeppelin_finance::vesting_wallet::{Self, VestingWallet, VestedAmount};
+use sui::transfer::Receiving;
+use sui::coin::Coin;
 
 /// Adds protocol gating around any vesting curve - note it stays generic over `S`, `P`.
 public struct GatedVault<phantom S: drop, P: copy + drop + store, phantom C> has key {
@@ -188,6 +190,16 @@ public fun release<S: drop, P: copy + drop + store, C>(
 ) {
     // ... enforce protocol invariants (not paused, caller approved, ...) ...
     self.inner.release(vested, ctx);
+}
+
+/// Re-expose `receive_and_deposit` so address-targeted funding can still be claimed
+/// while wrapped - it needs the same private `&mut inner`. Omit this and any `Coin<C>`
+/// `public_transfer`'d to the inner wallet's address stays stranded until unwrapped.
+public fun receive_and_deposit<S: drop, P: copy + drop + store, C>(
+    self: &mut GatedVault<S, P, C>,
+    receiving: Receiving<Coin<C>>,
+) {
+    self.inner.receive_and_deposit(receiving);
 }
 ```
 
@@ -292,6 +304,12 @@ one per integration boundary described above:
   coin would push the lifetime total (`balance + released`) past `u64::MAX` the call
   aborts, leaving the already-transferred coin parked at the wallet address. High
   volume emitters should track headroom before transferring.
+- **A wrapped wallet strands address-targeted funding until unwrapped.**
+  `receive_and_deposit` needs `&mut wallet`. A wrapper that keeps `&mut inner` private
+  (the recommended pattern above) must re-expose `receive_and_deposit` alongside
+  `release` to support address-targeted funding; otherwise a `Coin<C>`
+  `public_transfer`'d to the inner wallet's address cannot be claimed until the
+  wallet is unwrapped and `&mut` is restored. The funds are recoverable, not lost.
 
 ## Learn More
 

--- a/contracts/finance/sources/vesting_wallet.move
+++ b/contracts/finance/sources/vesting_wallet.move
@@ -183,6 +183,13 @@ public struct VestingWallet<phantom S: drop, P: copy + drop + store, phantom C> 
 /// exposes. If `release` instead required `S`, this would be impossible - a
 /// curve-agnostic wrapper cannot construct `S`, so it would have to expose
 /// `&mut inner` and lose all control over deposits and releases.
+///
+/// A wrapper that supports address-targeted funding should also re-expose
+/// `receive_and_deposit` alongside `release`, since claiming a `Coin<C>`
+/// `public_transfer`'d to the inner wallet's object address needs the same private
+/// `&mut inner`. If it does not, such a coin cannot be claimed while the wallet is
+/// wrapped - anyone can still send one to the address, but it stays stranded until
+/// the wallet is unwrapped and `&mut` is restored.
 public struct VestedAmount<phantom S> has drop {
     /// Id of the wallet this attestation was minted for.
     wallet_id: ID,
@@ -347,6 +354,10 @@ public fun deposit<S: drop, P: copy + drop + store, C>(
 /// Claim a coin that an upstream emitter `public_transfer`'d to this wallet's
 /// object address, then funnel it through the standard deposit path. Used by
 /// emission schedules and payroll robots that don't hold a wallet reference.
+///
+/// Requires `&mut wallet`. If the wallet is nested in a wrapper that keeps
+/// `&mut inner` private and does not re-expose this function, a coin sent to the
+/// inner wallet's address stays stranded until the wallet is unwrapped.
 ///
 /// #### Aborts
 /// - `EBalanceOverflow` if claiming the coin would overflow the wallet's


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified wrapper usage for wallet/vault examples to show that address-targeted funding must be forwarded through the wrapper.
  * Added guidance on re-exposing the claim-and-deposit flow so funds sent to an inner wallet remain accessible and do not appear stranded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->