### PR TITLE
[N-06] VestingWallet audit

### DIFF
--- a/contracts/finance/README.md
+++ b/contracts/finance/README.md
@@ -54,7 +54,11 @@ is not required up front.
    after the schedule starts participate retroactively.
 3. **Release** - `release` evaluates the curve at the current `Clock` and pays the
    not-yet-released portion to the beneficiary. Permissionless and idempotent: if
-   nothing new has vested it is a no-op.
+   nothing new has vested it is a no-op. Each call pays the newly vested amount as a
+   fresh `Coin<C>`, so a third party (not only the beneficiary) can call it repeatedly
+   as the schedule progresses and split the payout into many small coins - bounded
+   (one coin per distinct clock value over the window), costly to force (gas per tx),
+   and with totals always preserved.
 4. **Inspect** - `releasable` returns what `release` would pay right now; `start_ms`,
    `period_ms`, `steps`, `duration_ms`, `end_ms`, and `cliff_ms` read the schedule.
 5. **Tear down** - once drained, `vesting_wallet::destroy_empty` reclaims the storage
@@ -119,6 +123,12 @@ and you pick the topology:
 - **Shared** (recommended) - `transfer::public_share_object(wallet)`, or use
   `create_and_share`/`create_and_share_continuous`. Anyone can poke `release`,
   and the beneficiary always receives the funds regardless of who triggered it.
+  Because `release` is permissionless and pays each newly vested tranche as a fresh
+  `Coin<C>`, a third party can call it repeatedly as the schedule progresses and split
+  the payout into many small coins - bounded (one coin per distinct clock value over
+  the window) and costly to force, with totals always preserved. An integrator pointing
+  a wallet at an object beneficiary should plan for possibly many `Receiving`s to
+  process rather than a few large payouts.
 - **Owned** (fast path) - `transfer::public_transfer(wallet, holder)`. Only the
   holder can pass the wallet by `&mut`, so release is reachable from the holder's
   transactions only. Outside parties fund an owned wallet by `public_transfer`-ing a

--- a/contracts/finance/sources/vesting_wallet.move
+++ b/contracts/finance/sources/vesting_wallet.move
@@ -75,6 +75,11 @@
 ///
 /// - **Shared** (recommended): `transfer::public_share_object(wallet)` - anyone
 ///   can poke `release`. `vesting_wallet_linear` exposes `create_and_share` sugar.
+///   Because `release` is permissionless and pays each newly vested tranche as a
+///   fresh `Coin<C>`, a third party can call it repeatedly as the schedule progresses
+///   and split the payout into many small coins - bounded (one coin per distinct clock
+///   value over the window) and costly to force, with totals always preserved. Plan
+///   for possibly many small payouts, especially when the beneficiary is an object.
 /// - **Owned** (fast path): `transfer::public_transfer(wallet, addr)` - only the
 ///   holder can pass the wallet by `&mut`, so funding and release are reachable
 ///   from the holder's transactions only. Outside parties fund it by
@@ -372,6 +377,15 @@ public fun receive_and_deposit<S: drop, P: copy + drop + store, C>(
 /// If nothing new is vested since the last release (the wallet is already drained
 /// at this clock), the call is a no-op: no coin is transferred and no event is
 /// emitted.
+///
+/// Each call pays the portion vested since the last release as one fresh `Coin<C>`.
+/// Because it is permissionless, a third party - not only the beneficiary - can call
+/// it repeatedly as the schedule progresses, splitting the payout into many small
+/// coins rather than a few large ones. The fragmentation is bounded (at most one coin
+/// per distinct clock value over the vesting window) and costly to force (gas per
+/// transaction), and totals are always preserved. Still, an integrator pointing a
+/// wallet at an object beneficiary should plan for possibly many `Receiving`s to
+/// process rather than a few large payouts.
 ///
 /// #### Parameters
 /// - `wallet`: The wallet to release from.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified vesting release behavior, including that it can be triggered by anyone, may be called repeatedly as vesting progresses, and always preserves the total amount.
  * Added guidance that payouts may arrive as multiple small coins over time, so integrators should be prepared to handle many incoming transfers for object-based beneficiaries.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->