### PR TITLE
docs: correct vault lifecycle comment

### DIFF
--- a/contracts/allowance/sources/spend_vault.move
+++ b/contracts/allowance/sources/spend_vault.move
@@ -189,8 +189,9 @@ const EUnexpectedAllowance: vector<u8> = "Current allowance does not match expec
 // === Structs ===
 
 /// Shared, UNTYPED escrow + per-`(cap, coin)` allowance ledger. One vault holds
-/// N coin types at once; its lifecycle is exactly `new -> share` or
-/// `new -> destroy`.
+/// N coin types at once. The tx that calls `new` must consume the fresh vault
+/// with `share` or `destroy`; a shared vault can still be `destroy`ed later at
+/// teardown, so the shape is `new -> destroy` or `new -> share -> ... -> destroy`.
 ///
 /// The pool is NOT a struct field: per-coin funds live as object-owned address
 /// balances at `object::id_address(&v)`. The `key`-only ability protects `id`


### PR DESCRIPTION
The `Vault` doc comment stated the lifecycle is exactly `new -> share` or `new -> destroy`, which reads as if `share` is terminal. A shared vault can still be destroyed later at teardown, so the comment now states the creating-transaction constraint (consume the fresh vault with `share` or `destroy`) and the full `new -> share -> ... -> destroy` shape. Comment-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the vault lifecycle description to show that a vault can now be created, shared, and later destroyed.
  * Updated wording to better explain the full set of supported vault states and transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->