### PR TITLE
test: use abort instead of teardown in contracts/access failure tests

### DIFF
--- a/contracts/access/tests/access_control_tests.move
+++ b/contracts/access/tests/access_control_tests.move
@@ -1158,7 +1158,6 @@ fun cancel_admin_transfer_rejects_non_root() {
     scenario.next_tx(@0xC);
     let mut ac = take_ac(&scenario);
     ac.cancel_default_admin_transfer(scenario.ctx());
-    clock::destroy_for_testing(clk);
     abort
 }
 
@@ -1946,7 +1945,6 @@ fun cancel_delay_change_rejects_non_root() {
     scenario.next_tx(@0xB);
     let mut ac = take_ac(&scenario);
     ac.cancel_default_admin_delay_change(&clk, scenario.ctx());
-    clock::destroy_for_testing(clk);
     abort
 }
 

--- a/contracts/access/tests/access_control_tests.move
+++ b/contracts/access/tests/access_control_tests.move
@@ -3,7 +3,7 @@ module openzeppelin_access::access_control_tests;
 use openzeppelin_access::access_control::{Self, AccessControl};
 use openzeppelin_access::foreign_role::ForeignRole;
 use std::type_name::with_original_ids;
-use std::unit_test::assert_eq;
+use std::unit_test::{assert_eq, destroy};
 use sui::clock;
 use sui::event;
 use sui::test_scenario::{Self, Scenario};
@@ -37,7 +37,7 @@ public struct RoleY {}
 /// Deploys an `AccessControl` rooted at `ACCESS_CONTROL_TESTS`, shares it,
 /// and advances to a fresh transaction so `take_shared` is immediately
 /// available.
-#[test_only, allow(lint(share_owned))]
+#[test_only]
 fun setup(deployer: address, delay: u64): Scenario {
     let mut scenario = test_scenario::begin(deployer);
     let ac = access_control::new<ACCESS_CONTROL_TESTS>(
@@ -59,7 +59,6 @@ fun take_ac(scenario: &Scenario): AccessControl<ACCESS_CONTROL_TESTS> {
 // === Constructor ===
 
 #[test]
-#[allow(lint(share_owned))]
 fun new_with_otw_succeeds() {
     let deployer = @0xA;
     let mut scenario = test_scenario::begin(deployer);
@@ -84,12 +83,11 @@ fun new_with_otw_succeeds() {
     );
     assert_eq!(granted[0], expected);
 
-    transfer::public_share_object(ac);
+    destroy(ac);
     scenario.end();
 }
 
 #[test]
-#[allow(lint(share_owned))]
 fun new_with_admin_sets_explicit_root_holder() {
     let deployer = @0xA;
     let initial_admin = @0xB;
@@ -114,7 +112,7 @@ fun new_with_admin_sets_explicit_root_holder() {
     );
     assert_eq!(granted[0], expected);
 
-    transfer::public_share_object(ac);
+    destroy(ac);
     scenario.end();
 }
 

--- a/contracts/access/tests/access_control_tests.move
+++ b/contracts/access/tests/access_control_tests.move
@@ -1,15 +1,3 @@
-// `abort 999` sentinels appear after each known-aborting call in the
-// `expected_failure` tests - they're deliberate, unreachable, and exist only
-// to satisfy the type checker on the `ac` / `clk` bindings without rewriting
-// every test as a by-value helper. Suppressed module-wide so individual
-// tests stay clean.
-// `#[test_only]` is required here, not redundant: this module constructs its
-// own OTW (`ACCESS_CONTROL_TESTS {}`) in `setup`. The Sui verifier only allows
-// manual OTW construction when the enclosing module/function carries the
-// `#[test]`/`#[test_only]` attribute - it keys off the attribute, not the
-// `tests/` directory - so dropping it reintroduces the "Invalid one-time
-// witness construction" error.
-#[test_only, allow(lint(abort_without_constant))]
 module openzeppelin_access::access_control_tests;
 
 use openzeppelin_access::access_control::{Self, AccessControl};
@@ -41,10 +29,15 @@ public struct RoleY {}
 
 // === Setup helpers ===
 
+// `#[test_only]` is required here. The Sui verifier only allows
+// manual OTW construction when the enclosing function carries the
+// `#[test]`/`#[test_only]` attribute - it keys off the attribute, not the
+// `tests/` directory - so dropping it reintroduces the "Invalid one-time
+// witness construction" error.
 /// Deploys an `AccessControl` rooted at `ACCESS_CONTROL_TESTS`, shares it,
 /// and advances to a fresh transaction so `take_shared` is immediately
 /// available.
-#[allow(lint(share_owned))]
+#[test_only, allow(lint(share_owned))]
 fun setup(deployer: address, delay: u64): Scenario {
     let mut scenario = test_scenario::begin(deployer);
     let ac = access_control::new<ACCESS_CONTROL_TESTS>(
@@ -130,7 +123,7 @@ fun new_rejects_non_otw() {
     let deployer = @0xA;
     let mut scenario = test_scenario::begin(deployer);
     let _ac = access_control::new<NotAnOtw>(NotAnOtw {}, 0, scenario.ctx());
-    abort 999
+    abort
 }
 
 #[test, expected_failure(abort_code = access_control::EDelayTooLarge)]
@@ -142,7 +135,7 @@ fun new_rejects_excessive_delay() {
         access_control::max_default_admin_delay_ms() + 1,
         scenario.ctx(),
     );
-    abort 999
+    abort
 }
 
 #[test, expected_failure(abort_code = access_control::EZeroAddress)]
@@ -155,7 +148,7 @@ fun new_with_admin_rejects_zero_address() {
         0,
         scenario.ctx(),
     );
-    abort 999
+    abort
 }
 
 #[test]
@@ -278,7 +271,7 @@ fun grant_role_rejects_root() {
     let mut scenario = setup(deployer, 0);
     let mut ac = take_ac(&scenario);
     ac.grant_role<_, ACCESS_CONTROL_TESTS>(@0xB, scenario.ctx());
-    abort 999
+    abort
 }
 
 #[test, expected_failure(abort_code = access_control::EUnauthorized)]
@@ -290,7 +283,7 @@ fun grant_role_rejects_non_admin() {
     scenario.next_tx(alice);
     let mut ac = take_ac(&scenario);
     ac.grant_role<_, AdminA>(alice, scenario.ctx());
-    abort 999
+    abort
 }
 
 #[test, expected_failure(abort_code = access_control::EForeignRole)]
@@ -299,7 +292,7 @@ fun grant_role_rejects_foreign() {
     let mut scenario = setup(deployer, 0);
     let mut ac = take_ac(&scenario);
     ac.grant_role<_, ForeignRole>(@0xB, scenario.ctx());
-    abort 999
+    abort
 }
 
 #[test, expected_failure(abort_code = access_control::EZeroAddress)]
@@ -308,7 +301,7 @@ fun grant_role_rejects_zero_address() {
     let mut scenario = setup(deployer, 0);
     let mut ac = take_ac(&scenario);
     ac.grant_role<_, AdminA>(@0x0, scenario.ctx());
-    abort 999
+    abort
 }
 
 // === revoke_role ===
@@ -384,7 +377,7 @@ fun revoke_role_rejects_root() {
     let mut scenario = setup(deployer, 0);
     let mut ac = take_ac(&scenario);
     ac.revoke_role<_, ACCESS_CONTROL_TESTS>(deployer, scenario.ctx());
-    abort 999
+    abort
 }
 
 #[test, expected_failure(abort_code = access_control::EUnauthorized)]
@@ -400,7 +393,7 @@ fun revoke_role_rejects_non_admin() {
     scenario.next_tx(@0xC);
     let mut ac = take_ac(&scenario);
     ac.revoke_role<_, AdminA>(alice, scenario.ctx());
-    abort 999
+    abort
 }
 
 #[test, expected_failure(abort_code = access_control::EForeignRole)]
@@ -409,7 +402,7 @@ fun revoke_role_rejects_foreign() {
     let mut scenario = setup(deployer, 0);
     let mut ac = take_ac(&scenario);
     ac.revoke_role<_, ForeignRole>(@0xB, scenario.ctx());
-    abort 999
+    abort
 }
 
 // === renounce_role ===
@@ -452,7 +445,7 @@ fun renounce_role_rejects_root() {
     let mut scenario = setup(deployer, 0);
     let mut ac = take_ac(&scenario);
     ac.renounce_role<_, ACCESS_CONTROL_TESTS>(scenario.ctx());
-    abort 999
+    abort
 }
 
 #[test]
@@ -509,7 +502,7 @@ fun renounce_role_rejects_foreign() {
     let mut scenario = setup(deployer, 0);
     let mut ac = take_ac(&scenario);
     ac.renounce_role<_, ForeignRole>(scenario.ctx());
-    abort 999
+    abort
 }
 
 // === set_role_admin ===
@@ -608,7 +601,7 @@ fun set_role_admin_rejects_root_subject() {
     let mut scenario = setup(deployer, 0);
     let mut ac = take_ac(&scenario);
     ac.set_role_admin<_, ACCESS_CONTROL_TESTS, AdminA>(scenario.ctx());
-    abort 999
+    abort
 }
 
 #[test, expected_failure(abort_code = access_control::EUnauthorized)]
@@ -618,7 +611,7 @@ fun set_role_admin_rejects_non_admin() {
     scenario.next_tx(@0xB);
     let mut ac = take_ac(&scenario);
     ac.set_role_admin<_, RoleX, AdminA>(scenario.ctx());
-    abort 999
+    abort
 }
 
 // Companion to `set_role_admin_rejects_non_admin`. The original test
@@ -640,7 +633,7 @@ fun set_role_admin_rejects_non_admin_existing_entry() {
     // Second call hits the update-existing branch. `previous_admin_role` is
     // now AdminA - deployer holds root but NOT AdminA, so this must abort.
     ac.set_role_admin<_, RoleX, AdminB>(scenario.ctx());
-    abort 999
+    abort
 }
 
 #[test, expected_failure(abort_code = access_control::EForeignRole)]
@@ -649,7 +642,7 @@ fun set_role_admin_rejects_foreign_role() {
     let mut scenario = setup(deployer, 0);
     let mut ac = take_ac(&scenario);
     ac.set_role_admin<_, ForeignRole, AdminA>(scenario.ctx());
-    abort 999
+    abort
 }
 
 #[test, expected_failure(abort_code = access_control::EForeignRole)]
@@ -658,7 +651,7 @@ fun set_role_admin_rejects_foreign_admin_role() {
     let mut scenario = setup(deployer, 0);
     let mut ac = take_ac(&scenario);
     ac.set_role_admin<_, RoleX, ForeignRole>(scenario.ctx());
-    abort 999
+    abort
 }
 
 // === Read-only queries ===
@@ -715,7 +708,7 @@ fun assert_has_role_aborts_for_non_member() {
     let scenario = setup(deployer, 0);
     let ac = take_ac(&scenario);
     ac.assert_has_role<_, AdminA>(@0xB);
-    abort 999
+    abort
 }
 
 #[test]
@@ -746,7 +739,7 @@ fun get_role_admin_rejects_foreign() {
     let scenario = setup(deployer, 0);
     let ac = take_ac(&scenario);
     let _ = ac.get_role_admin<_, ForeignRole>();
-    abort 999
+    abort
 }
 
 #[test]
@@ -797,7 +790,7 @@ fun new_auth_aborts_for_non_member() {
     scenario.next_tx(@0xB);
     let ac = take_ac(&scenario);
     let _auth = ac.new_auth<_, AdminA>(scenario.ctx());
-    abort 999
+    abort
 }
 
 #[test, expected_failure(abort_code = access_control::EForeignRole)]
@@ -806,7 +799,7 @@ fun new_auth_rejects_foreign() {
     let mut scenario = setup(deployer, 0);
     let ac = take_ac(&scenario);
     let _auth = ac.new_auth<_, ForeignRole>(scenario.ctx());
-    abort 999
+    abort
 }
 
 #[test]
@@ -862,7 +855,7 @@ fun begin_admin_transfer_rejects_non_root() {
     let mut ac = take_ac(&scenario);
     let clk = clock::create_for_testing(scenario.ctx());
     ac.begin_default_admin_transfer(@0xC, &clk, scenario.ctx());
-    abort 999
+    abort
 }
 
 #[test, expected_failure(abort_code = access_control::EZeroAddress)]
@@ -872,7 +865,7 @@ fun begin_admin_transfer_rejects_zero_address() {
     let mut ac = take_ac(&scenario);
     let clk = clock::create_for_testing(scenario.ctx());
     ac.begin_default_admin_transfer(@0x0, &clk, scenario.ctx());
-    abort 999
+    abort
 }
 
 #[test, expected_failure(abort_code = access_control::EDefaultAdminTransferToSelf)]
@@ -882,7 +875,7 @@ fun begin_admin_transfer_rejects_self() {
     let mut ac = take_ac(&scenario);
     let clk = clock::create_for_testing(scenario.ctx());
     ac.begin_default_admin_transfer(deployer, &clk, scenario.ctx());
-    abort 999
+    abort
 }
 
 #[test]
@@ -1040,7 +1033,7 @@ fun old_admin_cannot_manage_root_role_administered_roles_after_transfer() {
     scenario.next_tx(deployer);
     let mut ac = take_ac(&scenario);
     ac.grant_role<_, AdminA>(user, scenario.ctx());
-    abort 999
+    abort
 }
 
 #[test, expected_failure(abort_code = access_control::ENoPendingAdminTransfer)]
@@ -1050,7 +1043,7 @@ fun accept_admin_transfer_rejects_no_pending() {
     let mut ac = take_ac(&scenario);
     let clk = clock::create_for_testing(scenario.ctx());
     ac.accept_default_admin_transfer(&clk, scenario.ctx());
-    abort 999
+    abort
 }
 
 #[test, expected_failure(abort_code = access_control::ENotPendingAdmin)]
@@ -1068,7 +1061,7 @@ fun accept_admin_transfer_rejects_wrong_caller() {
     scenario.next_tx(@0xC);
     let mut ac = take_ac(&scenario);
     ac.accept_default_admin_transfer(&clk, scenario.ctx());
-    abort 999
+    abort
 }
 
 #[test, expected_failure(abort_code = access_control::EDelayNotElapsed)]
@@ -1087,7 +1080,7 @@ fun accept_admin_transfer_rejects_too_early() {
     let mut ac = take_ac(&scenario);
     clk.set_for_testing(delay - 1);
     ac.accept_default_admin_transfer(&clk, scenario.ctx());
-    abort 999
+    abort
 }
 
 #[test]
@@ -1150,7 +1143,7 @@ fun cancel_admin_transfer_rejects_no_pending() {
     let mut scenario = setup(deployer, 0);
     let mut ac = take_ac(&scenario);
     ac.cancel_default_admin_transfer(scenario.ctx());
-    abort 999
+    abort
 }
 
 #[test, expected_failure(abort_code = access_control::EUnauthorized)]
@@ -1166,7 +1159,7 @@ fun cancel_admin_transfer_rejects_non_root() {
     let mut ac = take_ac(&scenario);
     ac.cancel_default_admin_transfer(scenario.ctx());
     clock::destroy_for_testing(clk);
-    abort 999
+    abort
 }
 
 // `cancel_default_admin_transfer` clears either kind of pending action and
@@ -1304,7 +1297,7 @@ fun role_hierarchy_chain_root_loses_grant_authority() {
 
     // Deployer still has root, but root is not RoleX's admin anymore.
     ac.grant_role<_, RoleX>(user, scenario.ctx());
-    abort 999
+    abort
 }
 
 // === begin_default_admin_renounce ===
@@ -1354,7 +1347,7 @@ fun renounced_admin_cannot_manage_root_role_administered_roles() {
     ac.begin_default_admin_renounce(&clk, scenario.ctx());
     ac.accept_default_admin_renounce(&clk, scenario.ctx());
     ac.grant_role<_, AdminA>(user, scenario.ctx());
-    abort 999
+    abort
 }
 
 #[test, expected_failure(abort_code = access_control::EUnauthorized)]
@@ -1365,7 +1358,7 @@ fun begin_admin_renounce_rejects_non_root() {
     let mut ac = take_ac(&scenario);
     let clk = clock::create_for_testing(scenario.ctx());
     ac.begin_default_admin_renounce(&clk, scenario.ctx());
-    abort 999
+    abort
 }
 
 // Scheduling a renounce cancels and overwrites an existing pending transfer
@@ -1531,7 +1524,7 @@ fun accept_admin_renounce_rejects_no_pending() {
     let mut ac = take_ac(&scenario);
     let clk = clock::create_for_testing(scenario.ctx());
     ac.accept_default_admin_renounce(&clk, scenario.ctx());
-    abort 999
+    abort
 }
 
 // `accept_default_admin_renounce` rejects when the pending action is a
@@ -1544,7 +1537,7 @@ fun accept_admin_renounce_rejects_pending_transfer() {
     let clk = clock::create_for_testing(scenario.ctx());
     ac.begin_default_admin_transfer(@0xB, &clk, scenario.ctx());
     ac.accept_default_admin_renounce(&clk, scenario.ctx());
-    abort 999
+    abort
 }
 
 // `accept_default_admin_transfer` rejects when the pending action is a
@@ -1557,7 +1550,7 @@ fun accept_admin_transfer_rejects_pending_renounce() {
     let clk = clock::create_for_testing(scenario.ctx());
     ac.begin_default_admin_renounce(&clk, scenario.ctx());
     ac.accept_default_admin_transfer(&clk, scenario.ctx());
-    abort 999
+    abort
 }
 
 #[test, expected_failure(abort_code = access_control::EUnauthorized)]
@@ -1573,7 +1566,7 @@ fun accept_admin_renounce_rejects_non_root() {
     scenario.next_tx(@0xB);
     let mut ac = take_ac(&scenario);
     ac.accept_default_admin_renounce(&clk, scenario.ctx());
-    abort 999
+    abort
 }
 
 #[test, expected_failure(abort_code = access_control::EDelayNotElapsed)]
@@ -1587,7 +1580,7 @@ fun accept_admin_renounce_rejects_too_early() {
     ac.begin_default_admin_renounce(&clk, scenario.ctx());
     clk.set_for_testing(delay - 1);
     ac.accept_default_admin_renounce(&clk, scenario.ctx());
-    abort 999
+    abort
 }
 
 #[test]
@@ -1739,7 +1732,7 @@ fun begin_delay_change_rejects_non_root() {
     let mut ac = take_ac(&scenario);
     let clk = clock::create_for_testing(scenario.ctx());
     ac.begin_default_admin_delay_change(100, &clk, scenario.ctx());
-    abort 999
+    abort
 }
 
 #[test, expected_failure(abort_code = access_control::EDelayTooLarge)]
@@ -1753,7 +1746,7 @@ fun begin_delay_change_rejects_above_max() {
         &clk,
         scenario.ctx(),
     );
-    abort 999
+    abort
 }
 
 #[test]
@@ -1938,7 +1931,7 @@ fun cancel_delay_change_rejects_no_pending() {
     let mut ac = take_ac(&scenario);
     let clk = clock::create_for_testing(scenario.ctx());
     ac.cancel_default_admin_delay_change(&clk, scenario.ctx());
-    abort 999
+    abort
 }
 
 #[test, expected_failure(abort_code = access_control::EUnauthorized)]
@@ -1954,7 +1947,7 @@ fun cancel_delay_change_rejects_non_root() {
     let mut ac = take_ac(&scenario);
     ac.cancel_default_admin_delay_change(&clk, scenario.ctx());
     clock::destroy_for_testing(clk);
-    abort 999
+    abort
 }
 
 #[test, expected_failure(abort_code = access_control::ENoPendingDelayChange)]
@@ -1970,7 +1963,7 @@ fun cancel_delay_change_rejects_elapsed_pending() {
 
     clk.set_for_testing(two_hours);
     ac.cancel_default_admin_delay_change(&clk, scenario.ctx());
-    abort 999
+    abort
 }
 
 // === Pending getters: delay change ===

--- a/contracts/access/tests/access_control_tests.move
+++ b/contracts/access/tests/access_control_tests.move
@@ -746,8 +746,7 @@ fun get_role_admin_rejects_foreign() {
     let scenario = setup(deployer, 0);
     let ac = take_ac(&scenario);
     let _ = ac.get_role_admin<_, ForeignRole>();
-    test_scenario::return_shared(ac);
-    scenario.end();
+    abort 999
 }
 
 #[test]

--- a/contracts/access/tests/delayed_tests.move
+++ b/contracts/access/tests/delayed_tests.move
@@ -164,7 +164,7 @@ fun schedule_transfer_rejects_duplicate() {
     let wrapper = test.take_from_sender<delayed_transfer::DelayedTransferWrapper<DummyCap>>();
     let clk = clock::create_for_testing(test.ctx());
     attempt_double_schedule(wrapper, owner, clk, test.ctx());
-    test.end();
+    abort
 }
 
 #[test, expected_failure(abort_code = delayed_transfer::ETransferAlreadyScheduled)]
@@ -178,7 +178,7 @@ fun schedule_unwrap_rejects_duplicate() {
     let wrapper = test.take_from_sender<delayed_transfer::DelayedTransferWrapper<DummyCap>>();
     let clk = clock::create_for_testing(test.ctx());
     attempt_double_unwrap(wrapper, clk, test.ctx());
-    test.end();
+    abort
 }
 
 #[test, expected_failure(abort_code = delayed_transfer::EDelayNotElapsed)]
@@ -193,7 +193,7 @@ fun execute_transfer_before_delay_fails() {
     let wrapper = test.take_from_sender<delayed_transfer::DelayedTransferWrapper<DummyCap>>();
     let clk = clock::create_for_testing(test.ctx());
     attempt_execute_before_delay(wrapper, recipient, clk, test.ctx());
-    test.end();
+    abort
 }
 
 #[test, expected_failure(abort_code = delayed_transfer::EDelayNotElapsed)]
@@ -207,7 +207,7 @@ fun unwrap_before_delay_fails() {
     let wrapper = test.take_from_sender<delayed_transfer::DelayedTransferWrapper<DummyCap>>();
     let clk = clock::create_for_testing(test.ctx());
     attempt_early_unwrap(wrapper, clk, test.ctx());
-    test.end();
+    abort
 }
 
 #[test]
@@ -283,7 +283,7 @@ fun cancel_schedule_without_pending_fails() {
     test.next_tx(owner);
     let wrapper = test.take_from_sender<delayed_transfer::DelayedTransferWrapper<DummyCap>>();
     expect_cancel_without_pending(wrapper, test.ctx());
-    test.end();
+    abort
 }
 
 #[test, expected_failure(abort_code = delayed_transfer::ENoPendingTransfer)]
@@ -297,7 +297,7 @@ fun execute_transfer_without_pending_fails() {
     clk.set_for_testing(0);
     let wrapper = test.take_from_sender<delayed_transfer::DelayedTransferWrapper<DummyCap>>();
     expect_execute_without_pending(wrapper, clk, test.ctx());
-    test.end();
+    abort
 }
 
 #[test, expected_failure(abort_code = delayed_transfer::ENoPendingTransfer)]
@@ -311,7 +311,7 @@ fun unwrap_without_pending_fails() {
     clk.set_for_testing(0);
     let wrapper = test.take_from_sender<delayed_transfer::DelayedTransferWrapper<DummyCap>>();
     expect_unwrap_without_pending(wrapper, clk, test.ctx());
-    test.end();
+    abort
 }
 
 #[test, expected_failure(abort_code = delayed_transfer::EWrongPendingAction)]
@@ -327,8 +327,7 @@ fun execute_transfer_wrong_action_fails() {
     wrapper.schedule_unwrap(&clk, test.ctx());
     clk.set_for_testing(10);
     wrapper.execute_transfer(&clk, test.ctx());
-    clock::destroy_for_testing(clk);
-    test.end();
+    abort
 }
 
 #[test, expected_failure(abort_code = delayed_transfer::EWrongPendingAction)]
@@ -344,11 +343,8 @@ fun unwrap_wrong_action_fails() {
     let mut wrapper = test.take_from_sender<delayed_transfer::DelayedTransferWrapper<DummyCap>>();
     wrapper.schedule_transfer(recipient, &clk, test.ctx());
     clk.set_for_testing(10);
-    let obj = wrapper.unwrap(&clk, test.ctx());
-    let DummyCap { id } = obj;
-    id.delete();
-    clock::destroy_for_testing(clk);
-    test.end();
+    let _obj = wrapper.unwrap(&clk, test.ctx());
+    abort
 }
 
 #[test, expected_failure(abort_code = delayed_transfer::EWrongDelayedTransferWrapper)]
@@ -362,7 +358,7 @@ fun return_val_rejects_wrong_wrapper() {
     let first = test.take_from_sender<delayed_transfer::DelayedTransferWrapper<DummyCap>>();
     let second = test.take_from_sender<delayed_transfer::DelayedTransferWrapper<DummyCap>>();
     expect_return_wrong_wrapper(first, second, test.ctx());
-    test.end();
+    abort
 }
 
 #[test, expected_failure(abort_code = delayed_transfer::EWrongDelayedTransferObject)]
@@ -374,7 +370,7 @@ fun return_val_rejects_wrong_object() {
     test.next_tx(owner);
     let wrapper = test.take_from_sender<delayed_transfer::DelayedTransferWrapper<DummyCap>>();
     expect_return_wrong_object(wrapper, test.ctx());
-    test.end();
+    abort
 }
 
 fun attempt_double_schedule(

--- a/contracts/access/tests/two_step_tests.move
+++ b/contracts/access/tests/two_step_tests.move
@@ -172,7 +172,7 @@ fun accept_transfer_rejects_non_new_owner() {
         two_step_transfer::TwoStepTransferWrapper<DummyCap>,
     >(&request_id);
     request.accept_transfer(ticket, test.ctx());
-    test.end();
+    abort
 }
 
 #[test, expected_failure(abort_code = two_step_transfer::EInvalidTransferRequest)]
@@ -201,7 +201,7 @@ fun accept_transfer_rejects_mismatched_wrapper() {
         two_step_transfer::TwoStepTransferWrapper<DummyCap>,
     >(&request_id);
     request.accept_transfer(ticket, test.ctx());
-    test.end();
+    abort
 }
 
 #[test]
@@ -255,7 +255,7 @@ fun cancel_transfer_rejects_non_owner() {
         two_step_transfer::TwoStepTransferWrapper<DummyCap>,
     >(&request_id);
     request.cancel_transfer(ticket, test.ctx());
-    test.end();
+    abort
 }
 
 #[test]
@@ -308,8 +308,7 @@ fun request_borrow_val_rejects_non_owner() {
     >(&request_id);
     let (wrapper, borrow) = request.request_borrow_val(ticket, test.ctx());
     request.request_return_val(wrapper, borrow);
-    test_scenario::return_shared(request);
-    test.end();
+    abort
 }
 
 #[test, expected_failure(abort_code = two_step_transfer::EInvalidTransferRequest)]
@@ -336,8 +335,7 @@ fun request_return_val_rejects_wrong_wrapper() {
     id.delete();
 
     request.request_return_val(extra_wrapper, borrow);
-    test_scenario::return_shared(request);
-    test.end();
+    abort
 }
 
 #[test, expected_failure(abort_code = two_step_transfer::EInvalidTransferRequest)]
@@ -365,7 +363,7 @@ fun cancel_transfer_rejects_mismatched_wrapper() {
         two_step_transfer::TwoStepTransferWrapper<DummyCap>,
     >(&request_id);
     request.cancel_transfer(ticket, test.ctx());
-    test.end();
+    abort
 }
 
 #[test]
@@ -435,8 +433,7 @@ fun request_return_val_rejects_wrong_request() {
 
     bogus_request.request_return_val(wrapper, borrow);
     bogus_request.test_destroy_request();
-    test_scenario::return_shared(request);
-    test.end();
+    abort
 }
 
 #[test]


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Aligning with [STYLEGUIDE.md](https://github.com/OpenZeppelin/contracts-sui/blob/c42028f7e3d5838eeea19d569e7bf7df8c5a84a5/STYLEGUIDE.md?plain=1#L229)

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

#### PR Checklist

<!-- For the PRs that introduce new features, all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items below may not apply to your case (for example: fixing a typo). -->

- [x] Tests
- [ ] Documentation
- [ ] Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated several expected-failure test cases across access-control, delayed, and two-step suites to explicitly end with an `abort` after the failure-triggering action.
  * Adjusted termination/cleanup flows so tests no longer reach normal completion paths when failures are expected.
  * Removed or simplified test-only termination and lint/annotation allowances used by the affected test setups.
  * No user-facing product behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->