### PR TITLE
docs: fix VestingWallet teardown requirements in README

### DIFF
--- a/contracts/finance/README.md
+++ b/contracts/finance/README.md
@@ -52,7 +52,8 @@ is not required up front.
    `period_ms`, `steps`, `duration_ms`, `end_ms`, and `cliff_ms` read the schedule.
 5. **Tear down** - once drained (and any settled funds swept), `vesting_wallet::destroy_empty`
    reclaims the storage rebate and returns a `DestroyReceipt`; hand that to `vesting_wallet_linear::destroy`,
-   which requires the schedule to have ended and the `DestroyCap` object, before accepting the teardown.
+   which requires the schedule to have ended and the matching `DestroyCap` object, before accepting
+   the teardown.
 
 ### Usage
 

--- a/contracts/finance/README.md
+++ b/contracts/finance/README.md
@@ -52,8 +52,7 @@ is not required up front.
    `period_ms`, `steps`, `duration_ms`, `end_ms`, and `cliff_ms` read the schedule.
 5. **Tear down** - once drained (and any settled funds swept), `vesting_wallet::destroy_empty`
    reclaims the storage rebate and returns a `DestroyReceipt`; hand that to `vesting_wallet_linear::destroy`,
-   which requires the schedule to have ended and the caller to be the beneficiary
-   before accepting the teardown.
+   which requires the schedule to have ended and the `DestroyCap` object, before accepting the teardown.
 
 ### Usage
 


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Resolves #??? <!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

#### PR Checklist

<!-- For the PRs that introduce new features, all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items below may not apply to your case (for example: fixing a typo). -->

- [ ] Tests
- [x] Documentation
- [ ] Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated teardown guidance to clarify that teardown is permitted only after the schedule has ended.
  * Updated requirements to specify that the `DestroyCap` object is required, removing the prior “caller must be the beneficiary” condition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->