### PR TITLE
[N-02 and N-04] Collections audit

### DIFF
--- a/collections/README.md
+++ b/collections/README.md
@@ -64,10 +64,12 @@ public struct PriceBook has key {
     levels: SortedMap<u64, u64>,
 }
 
-/// Create and share an empty price book.
-public fun deploy_and_share(ctx: &mut TxContext) {
+/// Create and share an empty price book, returning its `ID`.
+public fun deploy_and_share(ctx: &mut TxContext): ID {
     let book = PriceBook { id: object::new(ctx), levels: sorted_map::new() };
+    let id = object::id(&book);
     transfer::share_object(book);
+    id
 }
 
 /// Add positive `size` at `price`, merging into an existing level if present. Price zero is valid.
@@ -200,7 +202,7 @@ The comparator footgun applies to both modules and is stated once at the top of 
 
 ### SortedSet
 
-- **No resource value is ever lost; a coarse comparator can still drop a key.** Unlike the map (which can strand a `Coin` on misuse), the set's value is the trivial `Unit`, so there is no resource to conserve - the decisive simplification over the map. Two comparator failure modes remain, and they need different oracles. An inconsistent or non-strict comparator *desorts* the set: membership answers go wrong but every key is physically present and recoverable via `keys()`; `sorted_map::is_well_formed_by!(sorted_set::inner(&s), lt)` catches it (returns `false`). A **coarse (non-injective)** comparator is worse - it reports two byte-distinct keys as equal and `upsert` collapses them to one: the earlier key is dropped and is *not* recoverable, yet the set stays sorted so `is_well_formed_by!` still returns `true`. Detect that failure with a cardinality check (`length(&s)` vs. the expected distinct count), not the order oracle.
+- **No resource value is ever lost; a coarse comparator can still drop a key.** Unlike the map (which can strand a `Coin` on misuse), the set's value is the trivial `Unit`, so there is no resource to conserve - the decisive simplification over the map. Two comparator failure modes remain, and they need different oracles. An inconsistent or non-strict comparator *desorts* the set: membership answers go wrong but every key is physically present - snapshot them via `keys()` (needs `K: copy`) or drain them via `pop_*`. `sorted_map::is_well_formed_by!(sorted_set::inner(&s), lt)` checks only that adjacent keys are strictly increasing under the `lt` it is given: it returns `false` on a desorted vector, but a non-strict comparator threaded into the oracle masks its own duplicates (under `<=` an equal adjacent pair satisfies the relation), so also assert strictness directly (`!lt(&k, &k)`) or check cardinality. A **coarse (non-injective)** comparator is worse - it reports two byte-distinct keys as equal and `upsert` collapses them to one: the earlier key is dropped and is *not* recoverable, yet the set stays sorted so `is_well_formed_by!` still returns `true`. Detect that failure with a cardinality check (`length(&s)` vs. the expected distinct count), not the order oracle.
 - **`upsert` returns `bool` and does not abort; `add`/`remove` abort.** `upsert -> true` iff newly added (diverges from `vec_set`'s abort-on-duplicate). To recover `vec_set`'s strict insert, call `add!`/`add_by!` (a duplicate aborts) or wrap the bool with one `assert!`. `remove!` aborts `EKeyNotFound` on an absent key, matching `vec_set::remove`. `from_keys!` de-duplicates.
 - **Five library-owned aborts.** `pop_front`/`pop_back` on an empty set abort `EEmpty`, `from_sorted_keys!`/`_by` on unsorted input abort `EKeysNotSorted`, and `destroy_empty` on a non-empty set aborts `ENotEmpty`, all three at this module's location. Two more are DELEGATED to the wrapped map and abort at the *map's* location: `remove!` on an absent key (`sorted_map::EKeyNotFound`) and `add!`/`add_by!` on a duplicate key (`sorted_map::EKeyAlreadyExists`). Consumer `#[expected_failure]` tests must pin `location` accordingly (`openzeppelin_collections::sorted_set` for the first three, `::sorted_map` for the delegated pair). Every other supported operation is total provided the caller-supplied comparator does not itself abort.
 - **Forced-public internals are not an API.** `inner`, `inner_mut`, `unit`, and `assert_sorted` are `public` only for macro hygiene. Driving the wrapped map through `inner_mut` with an inconsistent comparator can desort the set (order-only, local to that set). Use the macro API.

--- a/collections/README.md
+++ b/collections/README.md
@@ -39,7 +39,7 @@ Abilities materialize jointly over `K` and `V`: `SortedMap<u64, u64>` is `copy +
 
 1. **Construct** - `new()` (empty), `singleton(k, v)`, or `from_sorted_keys_values!(keys, values)` (parallel vectors that must be strictly increasing under the comparator - aborts otherwise; unlike `sorted_set`'s de-duplicating `from_keys!`). None take a `TxContext`; embed the result as a field on your object.
 2. **Read / write** - use the bare macros (`upsert`, `borrow!`, `remove!`, ...) for integer keys; use the `_by` macros with a consistently threaded comparator for non-integer keys.
-3. **Drain** - a store-only `V` (e.g. `Coin`) cannot be dropped: remove every value, then `destroy_empty`.
+3. **Drain** - if either `K` or `V` lacks `drop`, remove every entry, consume both returned parts, then call `destroy_empty`.
 
 ### Usage
 
@@ -49,20 +49,36 @@ A price book embeds a `SortedMap<u64, u64>` (price -> resting size) in a `has ke
 module my_protocol::price_book;
 
 use openzeppelin_collections::sorted_map::{Self, SortedMap};
+use sui::object::{Self, UID};
+use sui::transfer;
+use sui::tx_context::TxContext;
+
+/// `place` was called with a zero size.
+#[error(code = 0)]
+const EZeroSize: vector<u8> = "Size must be greater than zero";
 
 /// A shared book embedding one ascending price->size map.
 public struct PriceBook has key {
     id: UID,
-    levels: SortedMap<u64, u64>, // price -> resting size, ascending (best = head)
+    /// Price -> resting size, ascending (best = head).
+    levels: SortedMap<u64, u64>,
 }
 
+/// Create and share an empty price book.
 public fun deploy_and_share(ctx: &mut TxContext) {
     let book = PriceBook { id: object::new(ctx), levels: sorted_map::new() };
     transfer::share_object(book);
 }
 
-/// Add `size` at `price`, merging into an existing level if present.
+/// Add positive `size` at `price`, merging into an existing level if present. Price zero is valid.
+///
+/// #### Aborts
+/// - `EZeroSize` if `size` is zero.
+/// - Arithmetic overflow if the merged size exceeds `u64`.
+/// - `sorted_map::EKeyNotFound` from `borrow_mut!` (guarded by `contains!`; unreachable in normal
+///   operation).
 public fun place(book: &mut PriceBook, price: u64, size: u64) {
+    assert!(size > 0, EZeroSize);
     if (sorted_map::contains!(&book.levels, &price)) {
         let cur = sorted_map::borrow_mut!(&mut book.levels, &price);
         *cur = *cur + size;
@@ -77,7 +93,11 @@ public fun best_price(book: &PriceBook): Option<u64> {
 }
 
 /// Up to `limit` prices ascending from the first price `>= from`. Resume a page by
-/// passing the last returned price back as `from` with `include = false`.
+/// passing the last returned price back as `from` with `include = false`. Pages tile while the
+/// ordered level-price key set is unchanged. Across transactions this is a keyset cursor over
+/// current prices: inserts at or before the cursor are skipped, inserts after it can appear, and
+/// removed prices do not appear. With a positive `limit`, an empty page means no later price exists
+/// at that moment.
 public fun levels_from(book: &PriceBook, from: u64, include: bool, limit: u64): vector<u64> {
     sorted_map::keys_from!(&book.levels, &from, include, limit)
 }
@@ -104,7 +124,7 @@ Complete integration examples live in [`examples/sorted_map/`](examples/sorted_m
 ### Lifecycle
 
 1. **Construct** - `new()` / `singleton(k)` / `from_keys!(keys)` (any order, de-duplicates, never aborts) / `from_sorted_keys!(keys)` (pre-sorted input, O(N), de-duplicates; aborts `EKeysNotSorted` otherwise). Takes no `TxContext`; embed the result as a field.
-2. **Membership** - `upsert` returns `bool` (`true` = newly added, never aborts); `remove!` aborts `EKeyNotFound` on an absent key; `contains!` tests presence. Bare macros for integer keys, `_by` macros with a consistent comparator otherwise.
+2. **Membership** - `upsert` returns `bool` (`true` = newly added, never aborts); `remove!` returns the removed key and aborts `EKeyNotFound` on an absent key; `contains!` tests presence. Bare macros for integer keys, `_by` macros with a consistent comparator otherwise.
 3. **Iterate** - `head`/`tail`, `next_key!`/`prev_key!`, `find_next!`/`find_prev!`, `keys_from!` pages, `pop_front`/`pop_back`. A set with a `drop` key (the common case) just falls out of scope; a set with a non-`drop` key must be drained then `destroy_empty`'d.
 
 ### Usage
@@ -116,24 +136,42 @@ module my_app::watchlist;
 
 use openzeppelin_collections::sorted_set::{Self, SortedSet};
 use sui::event;
+use sui::object::{Self, ID, UID};
+use sui::transfer;
+use sui::tx_context::TxContext;
 
-public struct Watchlist has key { id: UID, ids: SortedSet<u64> }
+/// A shareable set of watched token IDs.
+public struct Watchlist has key {
+    id: UID,
+    /// Watched token IDs in ascending order.
+    ids: SortedSet<u64>,
+}
 
-public struct Added has copy, drop { id: u64 }
+/// Emitted by `watch` when an id is newly added.
+public struct Added has copy, drop { watchlist_id: ID, id: u64 }
 
+/// Create a watchlist for optional setup before sharing.
 public fun new(ctx: &mut TxContext): Watchlist {
     Watchlist { id: object::new(ctx), ids: sorted_set::new() }
+}
+
+/// Share a freshly created watchlist after optional setup in the same transaction.
+public fun share(w: Watchlist) {
+    transfer::share_object(w);
 }
 
 /// Add a token id; emit only the FIRST time it is watched - the `bool` return earns its keep.
 public fun watch(w: &mut Watchlist, id: u64) {
     if (sorted_set::upsert!(&mut w.ids, id)) {
-        event::emit(Added { id });
+        event::emit(Added { watchlist_id: object::id(w), id });
     }
 }
 
 /// Ascending page of up to `limit` ids at or after `from`. Resume by passing the last id
-/// back with `include = false`.
+/// back with `include = false`. Pages tile while the ordered id set is unchanged. Across
+/// transactions this is a keyset cursor over current ids: inserts at or before the cursor are
+/// skipped, inserts after it can appear, and removed ids do not appear. With a positive `limit`, an
+/// empty page means no later id exists at that moment.
 public fun page(w: &Watchlist, from: u64, include: bool, limit: u64): vector<u64> {
     sorted_set::keys_from!(&w.ids, &from, include, limit)
 }
@@ -153,18 +191,18 @@ The comparator footgun applies to both modules and is stated once at the top of 
 
 ### SortedMap
 
-- **Aborts, all at the library's location.** Only these abort: `borrow`/`borrow_mut`/`remove`/`remove_by` -> `EKeyNotFound`; `add`/`add_by` on a duplicate key -> `EKeyAlreadyExists`; `destroy_empty` on a non-empty map -> `ENotEmpty`; `pop_front`/`pop_back` on an empty map -> `EEmpty`; `from_sorted_keys_values`/`_by` -> `EUnequalLengths` or `EKeysNotStrictlyIncreasing` on invalid input. Everything else is total (returns `Option`/`bool`/`vector`). Consumer `#[expected_failure]` tests must pin `location = openzeppelin_collections::sorted_map`.
-- **Resource conservation.** `upsert`'s upsert returns the displaced value (`some(old)`) rather than dropping it; `remove`/`remove_by` return the removed `(K, V)` pair (so a non-`drop` key is conserved, not just the value) and `pop_*` move values out; `destroy_empty` refuses a non-empty map. A store-only `V` like `Coin<T>` is never silently burned.
-- **Forced-public internals are not an API.** Macro hygiene forces several helpers - `search!`, `insert_at`, `remove_at`, `key`, and similar - to be `public`. `insert_at`/`remove_at` write at a caller-given position with no order check - calling them directly can corrupt order. They exist only to serve the macro bodies; use the macro API.
+- **Library-owned aborts in the supported macro API, all at the library's location.** `borrow`/`borrow_by`/`borrow_mut`/`borrow_mut_by`/`remove`/`remove_by` abort `EKeyNotFound`; `add`/`add_by` abort `EKeyAlreadyExists` on a duplicate key; `destroy_empty` aborts `ENotEmpty` on a non-empty map; `pop_front`/`pop_back` abort `EEmpty` on an empty map; and `from_sorted_keys_values`/`_by` abort `EUnequalLengths` or `EKeysNotStrictlyIncreasing` on invalid input. Other supported operations are total provided the caller-supplied comparator does not itself abort. Consumer `#[expected_failure]` tests must pin `location = openzeppelin_collections::sorted_map`. Forced-public internals are outside the supported API and can propagate `std::vector` aborts or native vector errors.
+- **Resource conservation.** `upsert` returns the displaced value (`some(old)`) rather than dropping it; `remove`/`remove_by` return the removed `(K, V)` pair (so a non-`drop` key is conserved, not just the value) and `pop_*` move values out; `destroy_empty` refuses a non-empty map. A store-only `V` like `Coin<T>` is never silently burned.
+- **Forced-public internals are not an API.** Macro hygiene forces several helpers - `search!`, `insert_at`, `remove_at`, `value_at`, `value_at_mut`, `key`, and similar - to be `public`. `insert_at`/`remove_at` write at a caller-given position with no order check - calling them directly can corrupt order. Invalid positions can also surface `std::vector::EINDEX_OUT_OF_BOUNDS` from `insert_at`/`remove_at` or a native vector bounds error from `value_at`/`value_at_mut`. They exist only to serve the macro bodies; use the macro API.
 - **No events.** A UID-less value has no on-chain identity; emit events yourself at your entry functions. Embedding in a shared object serializes writers per object, not per key - shard into multiple maps or use an owned object for hot paths.
 - **Capacity.** Every operation loads exactly one stored object, so the map is structurally immune to Sui's per-transaction dynamic-field-access cap; byte size is the only ceiling. Illustratively, measured on localnet (Sui 1.74.1), a `SortedMap<u64, u64>` holds 15,997 entries before `upsert` aborts at the Sui runtime with `MoveObjectTooBig` - treat this as a guide, not a guarantee (the protocol size cap is config-governed and can change). `remove` always survives at the ceiling, so a full map is never soft-bricked (hence no `ECapacityExceeded` guard). The ceiling scales inversely with entry size.
-- **Deliberate omissions.** No non-aborting `Option<&V>` borrow (Move cannot put a reference in `Option`) - use `if (contains!(..)) borrow!(..)`. No `values()`/`entries()` copy-out - `V` is only `store` (it may be a non-copyable resource like `Coin`), so values cannot be copied into a `vector`; read them per key via `borrow!`, or snapshot keys with `keys()` (or page with `keys_from!`) and `borrow!` each. No descending pagination - use a reverse comparator.
+- **Deliberate omissions.** No non-aborting `Option<&V>` borrow (Move cannot put a reference in `Option`) - use `if (contains!(..)) borrow!(..)`. No `values()`/`entries()` copy-out - `V` may be a non-copyable resource such as `Coin`, so values cannot generally be copied into a `vector`; read them per key via `borrow!`, or snapshot keys with `keys()` (or page with `keys_from!`) and `borrow!` each. No descending pagination - use a reverse comparator.
 
 ### SortedSet
 
 - **No resource value is ever lost; a coarse comparator can still drop a key.** Unlike the map (which can strand a `Coin` on misuse), the set's value is the trivial `Unit`, so there is no resource to conserve - the decisive simplification over the map. Two comparator failure modes remain, and they need different oracles. An inconsistent or non-strict comparator *desorts* the set: membership answers go wrong but every key is physically present and recoverable via `keys()`; `sorted_map::is_well_formed_by!(sorted_set::inner(&s), lt)` catches it (returns `false`). A **coarse (non-injective)** comparator is worse - it reports two byte-distinct keys as equal and `upsert` collapses them to one: the earlier key is dropped and is *not* recoverable, yet the set stays sorted so `is_well_formed_by!` still returns `true`. Detect that failure with a cardinality check (`length(&s)` vs. the expected distinct count), not the order oracle.
 - **`upsert` returns `bool` and does not abort; `add`/`remove` abort.** `upsert -> true` iff newly added (diverges from `vec_set`'s abort-on-duplicate). To recover `vec_set`'s strict insert, call `add!`/`add_by!` (a duplicate aborts) or wrap the bool with one `assert!`. `remove!` aborts `EKeyNotFound` on an absent key, matching `vec_set::remove`. `from_keys!` de-duplicates.
-- **Five aborts.** `pop_front`/`pop_back` on an empty set abort `EEmpty`, `from_sorted_keys!`/`_by` on unsorted input abort `EKeysNotSorted`, and `destroy_empty` on a non-empty set aborts `ENotEmpty`, all three at this module's location. Two more are DELEGATED to the wrapped map and abort at the *map's* location: `remove!` on an absent key (`sorted_map::EKeyNotFound`) and `add!`/`add_by!` on a duplicate key (`sorted_map::EKeyAlreadyExists`). Consumer `#[expected_failure]` tests must pin `location` accordingly (`openzeppelin_collections::sorted_set` for the first three, `::sorted_map` for the delegated pair). Every other operation is total.
+- **Five library-owned aborts.** `pop_front`/`pop_back` on an empty set abort `EEmpty`, `from_sorted_keys!`/`_by` on unsorted input abort `EKeysNotSorted`, and `destroy_empty` on a non-empty set aborts `ENotEmpty`, all three at this module's location. Two more are DELEGATED to the wrapped map and abort at the *map's* location: `remove!` on an absent key (`sorted_map::EKeyNotFound`) and `add!`/`add_by!` on a duplicate key (`sorted_map::EKeyAlreadyExists`). Consumer `#[expected_failure]` tests must pin `location` accordingly (`openzeppelin_collections::sorted_set` for the first three, `::sorted_map` for the delegated pair). Every other supported operation is total provided the caller-supplied comparator does not itself abort.
 - **Forced-public internals are not an API.** `inner`, `inner_mut`, `unit`, and `assert_sorted` are `public` only for macro hygiene. Driving the wrapped map through `inner_mut` with an inconsistent comparator can desort the set (order-only, local to that set). Use the macro API.
 - **No capabilities, `Clock`, `Random`, global state, or events.** The library never checks the caller; gate your own entry functions and emit your own events.
 - **Capacity.** Every operation loads exactly one stored object, so the set is structurally immune to Sui's per-transaction dynamic-field-access cap; byte size is the only ceiling. Illustratively, measured on localnet (Sui 1.74.1), the ceiling is 28,440 `u64` keys (≈1.78× the map's 15,997 `u64`/`u64` entries - each set entry is 9 bytes: an 8-byte key plus the 1-byte `Unit`); treat it as a guide, not a guarantee. Past it, `upsert` self-limits via `MoveObjectTooBig` (no capacity guard); the set is never soft-bricked.

--- a/collections/examples/sorted_map/order_book.move
+++ b/collections/examples/sorted_map/order_book.move
@@ -106,16 +106,19 @@ public fun best_bid(book: &OrderBook): Option<u64> {
 /// Level-2 ask snapshot: up to `limit` ask prices, ascending, starting at the first
 /// price `>= from` (when `include`) or `> from` (strict). Page a deep book by reading
 /// the first page with `include = true`, then resuming from the last returned price
-/// with `include = false` - the pages tile with no gap or overlap.
+/// with `include = false`. Pages tile with no gap or overlap while the ordered ask-price key set is
+/// unchanged. A cursor reused across transactions has keyset semantics over the current asks:
+/// prices inserted at or before the cursor are skipped, prices inserted after it can appear, and
+/// removed prices do not appear. With a positive `limit`, an empty page means no later price exists
+/// at that moment, not that a persisted scan is complete.
 public fun ask_levels(book: &OrderBook, from: u64, include: bool, limit: u64): vector<u64> {
     book.asks.keys_from!(&from, include, limit)
 }
 
-/// Resting size at a specific ask `price` - gate with `contains!`, or read live prices via
-/// `best_ask` / `ask_levels`.
+/// Resting size at a specific ask `price`.
 ///
 /// #### Aborts
-/// - `EKeyNotFound` if no level rests at `price`.
+/// - `sorted_map::EKeyNotFound` if no level rests at `price`.
 public fun ask_size_at(book: &OrderBook, price: u64): u64 {
     let lvl = book.asks.borrow!(&price);
     lvl.size
@@ -124,7 +127,7 @@ public fun ask_size_at(book: &OrderBook, price: u64): u64 {
 /// Remove and return the best (lowest) ask as `(price, size)`.
 ///
 /// #### Aborts
-/// - `EEmpty` if the ask side is empty - guard with `best_ask` first.
+/// - `sorted_map::EEmpty` if the ask side is empty - guard with `best_ask` first.
 public fun fill_best_ask(book: &mut OrderBook): (u64, u64) {
     let (price, lvl) = book.asks.pop_front();
     let Level { size } = lvl;

--- a/collections/examples/sorted_map/prize_vault.move
+++ b/collections/examples/sorted_map/prize_vault.move
@@ -99,7 +99,7 @@ public fun fund(vault: &mut PrizeVault, cap: &OrganizerCap, coin: Coin<SUI>, ran
 ///
 /// #### Aborts
 /// - `EWrongVault` if `cap` does not authorize `vault`.
-/// - `EEmpty` if the vault is empty.
+/// - `sorted_map::EEmpty` if the vault is empty.
 public fun pay_next(vault: &mut PrizeVault, cap: &OrganizerCap): (u64, Coin<SUI>) {
     assert_cap(vault, cap);
     vault.prizes.pop_front()
@@ -129,11 +129,11 @@ public fun unclaimed(vault: &PrizeVault): u64 {
 ///
 /// #### Aborts
 /// - `EWrongVault` if `cap` does not authorize `vault`.
-/// - `ENotEmpty` if any prize is still unclaimed.
+/// - `sorted_map::ENotEmpty` if any prize is still unclaimed.
 public fun close(vault: PrizeVault, cap: OrganizerCap) {
     assert_cap(&vault, &cap);
     let PrizeVault { id, prizes } = vault;
-    prizes.destroy_empty(); // ENotEmpty here if prizes remain
+    prizes.destroy_empty(); // `sorted_map::ENotEmpty` here if prizes remain
     id.delete();
     let OrganizerCap { id: cap_id, vault: _ } = cap;
     cap_id.delete();

--- a/collections/examples/sorted_map/tick_registry.move
+++ b/collections/examples/sorted_map/tick_registry.move
@@ -78,8 +78,8 @@ public fun contains_tick(reg: &TickRegistry, tick: u64): bool {
 /// State at an active `tick`.
 ///
 /// #### Aborts
-/// - `EKeyNotFound` if the tick is inactive - gate with `contains_tick`, or discover live
-///   ticks via the navigation ops.
+/// - `sorted_map::EKeyNotFound` if the tick is inactive - gate with `contains_tick`, or discover
+///   live ticks via the navigation ops.
 public fun borrow_tick(reg: &TickRegistry, tick: u64): &TickInfo {
     reg.ticks.borrow!(&tick)
 }
@@ -87,8 +87,9 @@ public fun borrow_tick(reg: &TickRegistry, tick: u64): &TickInfo {
 /// Accumulate fee growth into an active tick in place.
 ///
 /// #### Aborts
-/// - `EKeyNotFound` (from `borrow_mut!`) if the tick is inactive - gate with `contains_tick`.
-/// - Native `u128` overflow if `fee_growth + delta` exceeds `u128::MAX`.
+/// - `sorted_map::EKeyNotFound` (from `borrow_mut!`) if the tick is inactive - gate with
+///   `contains_tick`.
+/// - Arithmetic overflow if `fee_growth + delta` exceeds `u128::MAX`.
 public fun accrue_fees(reg: &mut TickRegistry, tick: u64, delta: u128) {
     let info = reg.ticks.borrow_mut!(&tick);
     info.fee_growth = info.fee_growth + delta;
@@ -144,6 +145,7 @@ public fun ticks_well_formed(reg: &TickRegistry): bool {
     reg.ticks.is_well_formed!()
 }
 
+/// Reconstruct a tick value for test assertions.
 #[test_only]
 public fun new_tick(liquidity_net: u64, fee_growth: u128): TickInfo {
     TickInfo {

--- a/collections/examples/sorted_set/tests/unlock_queue_tests.move
+++ b/collections/examples/sorted_set/tests/unlock_queue_tests.move
@@ -57,13 +57,13 @@ fun drain_earliest_first() {
     scenario.end();
 }
 
-// === Scenario 4 - the library's ONE abort: pop on an empty set ===
+// === Scenario 4 - processing an empty queue aborts at the set ===
 //
-// `pop_front`/`pop_back` are the only operations in the whole library that abort, and only on an
-// EMPTY set (`EEmpty`). The set asserts its OWN `EEmpty` (code 0) BEFORE delegating to the wrapped
-// map, so the abort surfaces at `location = openzeppelin_collections::sorted_set`. Pinning the
-// wrapped map's location (`openzeppelin_collections::sorted_map`, code 2) here would make this test
-// FAIL - that branch is never reached through the set's own `pop_*`.
+// This scenario isolates the queue's empty-pop path (`EEmpty`). The set asserts its OWN `EEmpty`
+// (code 0) BEFORE delegating to the wrapped map, so the abort surfaces at
+// `location = openzeppelin_collections::sorted_set`. Pinning the wrapped map's location
+// (`openzeppelin_collections::sorted_map`, code 2) here would make this test FAIL - that branch is
+// never reached through the set's own `pop_*`.
 #[test, expected_failure(abort_code = ss::EEmpty, location = ss)]
 fun process_empty_queue_aborts() {
     let mut scenario = ts::begin(ALICE);

--- a/collections/examples/sorted_set/unlock_queue.move
+++ b/collections/examples/sorted_set/unlock_queue.move
@@ -1,16 +1,17 @@
-/// Ordered-drain / priority-queue pattern - and the home of the set's `EEmpty` abort.
+/// Ordered-drain / priority-queue pattern - and the home of the set's `sorted_set::EEmpty` abort.
 ///
 /// A `SortedSet<u64>` of unique unlock TIMESTAMPS in a SHARED vesting object, drained
 /// earliest-first. Because the set keeps its keys sorted, the smallest is always at the front
 /// and the largest at the back, so it doubles as a min/max priority queue with O(1) peeks.
 ///
-/// # The one operation that aborts
-/// Every operation this queue uses is total (returns `Option` / `bool` / `vector` / `u64`)
-/// except one: popping an extreme of an EMPTY set - `pop_front` / `pop_back` abort `EEmpty`.
-/// Crucially the set asserts its OWN `EEmpty` (code 0) FIRST, before delegating to the wrapped
-/// map, so the abort surfaces at `openzeppelin_collections::sorted_set` - a consumer's
-/// `#[expected_failure]` must pin that location, NOT the map's. We expose both a guarded drain
-/// (`is_empty` first) and the raw `pop_front`/`pop_back` wrappers so a test can trigger the abort.
+/// # Operations that abort
+/// Most reads and `schedule` are total. `cancel` aborts with `sorted_map::EKeyNotFound` when the
+/// deadline is absent. `process_earliest` and `process_latest` abort with `sorted_set::EEmpty` when
+/// the queue is empty. The set asserts its own `EEmpty` (code 0) before delegating to the wrapped
+/// map. The abort surfaces at `openzeppelin_collections::sorted_set`; consumer
+/// `#[expected_failure]` tests must pin that location, not the map's. Callers can check `is_empty`
+/// before processing; the process functions intentionally expose the raw pop behavior so tests
+/// can trigger the abort.
 ///
 /// `head` / `tail` are the non-aborting counterparts: they PEEK the earliest / latest deadline
 /// as an `Option`, returning `none` on an empty queue instead of aborting.
@@ -96,7 +97,7 @@ public fun is_empty(q: &UnlockQueue): bool {
 /// Pop and process the EARLIEST deadline, returning it.
 ///
 /// #### Aborts
-/// - `EEmpty` if the queue is empty (the set's own, code 0, at
+/// - `sorted_set::EEmpty` if the queue is empty (the set's own, code 0, at
 ///   `location = openzeppelin_collections::sorted_set`) - guard with `is_empty` or peek
 ///   `next_deadline` first.
 public fun process_earliest(q: &mut UnlockQueue): u64 {
@@ -108,7 +109,7 @@ public fun process_earliest(q: &mut UnlockQueue): u64 {
 /// Pop and process the LATEST deadline (the other extreme), returning it.
 ///
 /// #### Aborts
-/// - `EEmpty` if the queue is empty (same as `process_earliest`).
+/// - `sorted_set::EEmpty` if the queue is empty (same as `process_earliest`).
 public fun process_latest(q: &mut UnlockQueue): u64 {
     let deadline = q.deadlines.pop_back();
     event::emit(Unlocked { deadline });

--- a/collections/sources/sorted_map.move
+++ b/collections/sources/sorted_map.move
@@ -17,8 +17,8 @@
 /// - **Bare vs `_by`.** Bare ops (`upsert`, `borrow!`) assume the built-in integer `<` and
 ///   compile only for integer keys; `_by` ops take your `lt` lambda and are required for
 ///   `address`, struct, or any non-integer key.
-/// - **Resource values must be drained.** `SortedMap<K, Coin<T>>` is store-only: it cannot be
-///   dropped, so empty it and then `destroy_empty`.
+/// - **Non-droppable entries must be drained.** If either `K` or `V` lacks `drop`, the map cannot
+///   be dropped. Remove every entry, consume both returned parts, and then call `destroy_empty`.
 /// - **Bounded by object size.** O(log N) lookup, O(N) insert/remove, one object loaded per
 ///   call - so the only ceiling is Sui's ~250 KB object cap.
 ///
@@ -26,8 +26,7 @@
 ///
 /// Move has no storable function values, so the comparator can't live in the struct - and a
 /// phantom witness couldn't validate the actual `lt` passed at runtime anyway. Move also has no
-/// standard ordering trait. `std::compare` orders by BCS bytes, not semantic value. So ordering
-/// is a lambda you supply, not a property of `K`.
+/// standard ordering trait, so ordering is a lambda you supply, not a property of `K`.
 ///
 /// You pass a strict less-than; equality is derived as `!lt(a, b) && !lt(b, a)`. It MUST be a
 /// strict total order (irreflexive, asymmetric, transitive, total) and MUST be the same on every
@@ -108,7 +107,9 @@ const EKeyAlreadyExists: vector<u8> = "Key already exists";
 /// Abilities materialize jointly over `K` and `V`: `Entry<u64, u64>` is `copy + drop +
 /// store`, while `Entry<u64, Coin<T>>` is store-only.
 public struct Entry<K, V> has copy, drop, store {
+    /// The entry's key.
     key: K,
+    /// The entry's value.
     value: V,
 }
 
@@ -156,9 +157,9 @@ public fun singleton<K, V>(key: K, value: V): SortedMap<K, V> {
 
 /// Destroy an empty map.
 ///
-/// This is the only terminal for a map whose value type lacks `drop` (e.g.
-/// `SortedMap<K, Coin<T>>`): drain every value via `remove`/`pop_*` first, then call
-/// this.
+/// This is the terminal for a map whose key or value type lacks `drop` (for example,
+/// `SortedMap<K, Coin<T>>`). Drain every entry via `remove` or `pop_*`, consume both the returned
+/// key and value, and then call this function.
 ///
 /// #### Aborts
 /// - `ENotEmpty` if the map still holds entries.
@@ -257,7 +258,8 @@ public fun value<K, V>(e: &Entry<K, V>): &V {
 /// - `i`: Insertion index.
 ///
 /// #### Aborts
-/// - Native out-of-bounds abort inside `std::vector` if `i > length`.
+/// - `std::vector::EINDEX_OUT_OF_BOUNDS` (code `0x20000`, location `std::vector`) if
+///   `i > length`.
 public fun insert_at<K, V>(map: &mut SortedMap<K, V>, key: K, value: V, i: u64) {
     map.entries.insert(Entry { key, value }, i);
 }
@@ -272,7 +274,8 @@ public fun insert_at<K, V>(map: &mut SortedMap<K, V>, key: K, value: V, i: u64) 
 /// - The (key, value) pair at index `i`.
 ///
 /// #### Aborts
-/// - Native out-of-bounds abort inside `std::vector` if `i >= length`.
+/// - `std::vector::EINDEX_OUT_OF_BOUNDS` (code `0x20000`, location `std::vector`) if
+///   `i >= length`.
 public fun remove_at<K, V>(map: &mut SortedMap<K, V>, i: u64): (K, V) {
     let Entry { key, value } = map.entries.remove(i);
     (key, value)
@@ -288,7 +291,7 @@ public fun remove_at<K, V>(map: &mut SortedMap<K, V>, i: u64): (K, V) {
 /// - Reference to the value at index `i`.
 ///
 /// #### Aborts
-/// - Native out-of-bounds abort inside `std::vector` if `i >= length`.
+/// - A native vector bounds error (`vector_error`, minor status 1) if `i >= length`.
 public fun value_at<K, V>(map: &SortedMap<K, V>, i: u64): &V {
     &map.entries.borrow(i).value
 }
@@ -304,7 +307,7 @@ public fun value_at<K, V>(map: &SortedMap<K, V>, i: u64): &V {
 /// - Mutable reference to the value at index `i`.
 ///
 /// #### Aborts
-/// - Native out-of-bounds abort inside `std::vector` if `i >= length`.
+/// - A native vector bounds error (`vector_error`, minor status 1) if `i >= length`.
 public fun value_at_mut<K, V>(map: &mut SortedMap<K, V>, i: u64): &mut V {
     &mut map.entries.borrow_mut(i).value
 }
@@ -668,7 +671,8 @@ public macro fun upsert<$K: drop, $V>(
     upsert_by!($map, $key, $value, |a, b| *a < *b)
 }
 
-/// Remove `key`'s entry and return its value, under `$lt` (length - 1, order preserved).
+/// Remove `key`'s entry and return its `(key, value)` pair, under `$lt` (length - 1, order
+/// preserved).
 ///
 /// Uses a shifting `vector::remove`, never `swap_remove`, which would break strict order.
 ///
@@ -870,10 +874,14 @@ public macro fun prev_key<$K: copy, $V>($map: &SortedMap<$K, $V>, $key: &$K): Op
 /// key `>= from` (when `include`) or `> from` (strict). Returns at most `limit` keys;
 /// fewer if the tail is reached.
 ///
-/// Resume a page by passing the last returned key back as `from` with `include == false`:
-/// successive pages have no overlap and no gap, so concatenating them reconstructs the
-/// tail exactly. `limit == 0`, an empty map, or `from` past the tail all yield the empty
-/// vector.
+/// Resume a page by passing the last returned key back as `from` with `include == false`.
+/// While the ordered key set is unchanged, successive pages have no overlap or gap, so
+/// concatenating them reconstructs the tail exactly. A cursor reused after a key-set mutation has
+/// keyset semantics: each call reads the keys currently after `from`. Keys inserted at or before
+/// the cursor are skipped, keys inserted after it can appear, and removed keys do not appear. With
+/// a positive `limit`, an empty page means no key follows the cursor at that moment, not that a
+/// persisted scan is permanently complete. `limit == 0`, an empty map, or `from` past the current
+/// tail all yield the empty vector.
 ///
 /// #### Parameters
 /// - `map`: The map to read.
@@ -938,7 +946,8 @@ public macro fun keys_from<$K: copy, $V>(
 /// #### Aborts
 /// - `EEmpty` if the map is empty.
 public fun pop_front<K, V>(map: &mut SortedMap<K, V>): (K, V) {
-    // Check first: `remove(0)` on an empty vector would abort with a native code, not `EEmpty`.
+    // Check first: `remove(0)` on an empty vector would abort with
+    // `std::vector::EINDEX_OUT_OF_BOUNDS` (code `0x20000`), not `EEmpty`.
     assert!(!map.is_empty(), EEmpty);
     let Entry { key, value } = map.entries.remove(0);
     (key, value)
@@ -952,7 +961,8 @@ public fun pop_front<K, V>(map: &mut SortedMap<K, V>): (K, V) {
 /// #### Aborts
 /// - `EEmpty` if the map is empty.
 public fun pop_back<K, V>(map: &mut SortedMap<K, V>): (K, V) {
-    // Check first: `pop_back` on an empty vector would abort with a native code, not `EEmpty`.
+    // Check first: `pop_back` on an empty vector would raise a native vector bounds error
+    // (`vector_error`, minor status 2), not `EEmpty`.
     assert!(!map.is_empty(), EEmpty);
     let Entry { key, value } = map.entries.pop_back();
     (key, value)

--- a/collections/sources/sorted_set.move
+++ b/collections/sources/sorted_set.move
@@ -26,7 +26,8 @@
 /// - **Five aborts:** `pop_front` / `pop_back` on an empty set (`EEmpty`), `remove!` on an absent
 ///   key (`sorted_map::EKeyNotFound`), `add!` / `add_by!` on a duplicate key
 ///   (`sorted_map::EKeyAlreadyExists`), `from_sorted_keys!` on unsorted input (`EKeysNotSorted`),
-///   and `destroy_empty` on a non-empty set (`ENotEmpty`); every other op is total.
+///   and `destroy_empty` on a non-empty set (`ENotEmpty`); every other supported op is total
+///   provided the caller-supplied comparator does not itself abort.
 ///
 /// # The comparator
 ///
@@ -56,8 +57,9 @@
 ///
 /// Costs mirror `SortedMap`, which the set wraps: O(log N) membership, O(N) insert and remove, one
 /// object loaded per call, and the same ~250 KB object-size ceiling. `pop_front` is O(N) - it
-/// shifts every remaining key - while `pop_back` is O(1). `from_keys!` is O(N^2) (a search per
-/// key); `from_sorted_keys!` skips the search on pre-sorted input, building in O(N).
+/// shifts every remaining key - while `pop_back` is O(1). `from_keys!` is O(N^2) in the worst
+/// case: each upsert does a logarithmic search, then can shift a linear suffix.
+/// `from_sorted_keys!` validates once and appends pre-sorted input, building in O(N).
 ///
 /// The set's `_by` macros expand the map's `search!` inline. A single function with many distinct
 /// macro calls can therefore hit Move's ~256 local-variable limit (compiler error `value (N)
@@ -122,8 +124,9 @@ public struct Unit has copy, drop, store {}
 /// with a `copy + drop + store` key it is `copy + drop + store`; with a non-`drop` (e.g.
 /// resource) key it is store-only and must be `destroy_empty`'d, like `SortedMap<K, Coin<T>>`.
 ///
-/// Across every public operation, by delegation to the inner map, the keys are strictly
-/// increasing under the (consistently supplied) comparator: sorted, no duplicates.
+/// Across the supported macro API, by delegation to the inner map, the keys are strictly
+/// increasing under the consistently supplied comparator: sorted, no duplicates. The
+/// forced-public internals described above can bypass this guarantee and are not supported.
 public struct SortedSet<K> has copy, drop, store {
     /// Backing map: every key is a set member; every value is the inert `Unit` marker.
     inner: SortedMap<K, Unit>,
@@ -220,9 +223,9 @@ public fun assert_sorted(sorted: bool) {
 /// instead, build then `assert!(length(&s) == keys.length(), E)`.
 ///
 /// Under a coarse `_by` comparator, byte-distinct compare-equal keys collapse to one
-/// element keeping the last one's bytes (each re-insert is a last-write-wins upsert). Drives the
-/// inserts via a `do!` loop body (one reused expansion), never a straight-line sequence, to stay
-/// under Move's locals limit.
+/// element keeping the last one's bytes (each re-insert is a last-write-wins upsert). Uses a
+/// `fold!` loop body (one reused expansion), never a straight-line sequence, to stay under Move's
+/// locals limit.
 ///
 /// #### Parameters
 /// - `keys`: Keys to insert; duplicates are collapsed.
@@ -619,11 +622,15 @@ public macro fun prev_key<$K: copy>($set: &SortedSet<$K>, $key: &$K): Option<$K>
 
 // === Bounded iteration / pagination (macros: bare + `_by`) ===
 
-/// Up to `limit` keys in strict ascending order - a contiguous run starting at the first
-/// key `>= from` (when `include`) or `> from` (strict); fewer than `limit` only at the
-/// tail. Resume a page by passing the last returned key back as `from` with `include ==
-/// false`: successive pages have no overlap and no gap. `limit == 0`, an empty set, or
-/// `from` past the tail all yield the empty vector.
+/// Up to `limit` keys in strict ascending order - a contiguous run starting at the first key
+/// `>= from` (when `include`) or `> from` (strict); fewer than `limit` if the current tail is
+/// reached. Resume a page by passing the last returned key back as `from` with `include == false`.
+/// While the ordered key set is unchanged, successive pages have no overlap or gap. A cursor reused
+/// after a key-set mutation has keyset semantics: each call reads the keys currently after `from`.
+/// Keys inserted at or before the cursor are skipped, keys inserted after it can appear, and
+/// removed keys do not appear. With a positive `limit`, an empty page means no key follows the
+/// cursor at that moment, not that a persisted scan is permanently complete. `limit == 0`, an
+/// empty set, or `from` past the current tail yields the empty vector.
 ///
 /// #### Parameters
 /// - `set`: The set to read.

--- a/collections/tests/sorted_map/comparator_tests.move
+++ b/collections/tests/sorted_map/comparator_tests.move
@@ -75,7 +75,7 @@ fun nonstrict_comparator_duplicates() {
 
 // === Footgun (b): mixing `<` (build) and `>` (remove) strands a present key ===
 
-#[test, expected_failure(abort_code = sm::EKeyNotFound)]
+#[test, expected_failure(abort_code = sm::EKeyNotFound, location = sm)]
 fun remove_with_mixed_comparator_aborts() {
     let mut m = sm::new<u64, u64>();
     u::ins(&mut m, 10, 1); // ascending build under `<`
@@ -101,10 +101,10 @@ fun insert_at_wrong_index_corrupts() {
     assert!(!u::wf(&m)); // the well-formedness check catches what production never re-checks
 }
 
-// === remove_at misuse still returns the value (no silent loss) ===
+// === remove_at misuse still returns the entry (no silent loss) ===
 
 #[test]
-fun remove_at_misuse_returns_value() {
+fun remove_at_misuse_returns_entry() {
     let mut m = sm::new<u64, u64>();
     u::ins(&mut m, 10, 1);
     u::ins(&mut m, 20, 2);

--- a/collections/tests/sorted_map/conservation_tests.move
+++ b/collections/tests/sorted_map/conservation_tests.move
@@ -125,7 +125,7 @@ fun coin_value_roundtrip() {
     assert_eq!(old.value(), 100);
     old.burn_for_testing();
     assert_eq!(m.borrow!(&1).value(), 999);
-    // remove returns the value (coin); the key is dropped
+    // remove returns both the key and coin; the caller consumes both.
     let (k, r1) = m.remove!(&1);
     assert_eq!(k, 1);
     assert_eq!(r1.value(), 999);

--- a/collections/tests/sorted_map/type_tests.move
+++ b/collections/tests/sorted_map/type_tests.move
@@ -18,7 +18,7 @@ use openzeppelin_collections::sorted_map_test_util::{
     Ask,
     StoreKey,
     CopyKey,
-    DropKey
+    DropKey,
 };
 use std::unit_test::assert_eq;
 

--- a/collections/tests/sorted_map/type_tests.move
+++ b/collections/tests/sorted_map/type_tests.move
@@ -6,8 +6,8 @@
 /// lattice (each op instantiated at the minimal K/V abilities its body needs). The NEGATIVE
 /// half (a resource-V map cannot be copied/dropped, `e.key` cannot be read, `entries_mut`
 /// does not exist, a bare macro rejects `address`, a bare `SortedMap` cannot be transferred)
-/// is a build-time fact - documented as the commented non-compiling snippets at the bottom,
-/// to be exercised by review/CI, not a runnable `#[test]`.
+/// is a build-time fact - documented as reviewed non-compiling snippets at the bottom, not a
+/// runnable `#[test]`. Positive counterparts above pin the supported side of each boundary.
 module openzeppelin_collections::sorted_map_type_tests;
 
 use openzeppelin_collections::sorted_map::{Self as sm, SortedMap};
@@ -18,7 +18,7 @@ use openzeppelin_collections::sorted_map_test_util::{
     Ask,
     StoreKey,
     CopyKey,
-    DropKey,
+    DropKey
 };
 use std::unit_test::assert_eq;
 
@@ -239,7 +239,8 @@ fun ops_leave_value_unconstrained() {
 
 // ===========================================================================
 // NEGATIVE compile-facts (NOT runnable `#[test]`s - they must FAIL to compile).
-// Kept as commented snippets; exercised by review / a CI compile-fail harness.
+// Kept as commented snippets for review; the positive counterparts above exercise the minimal
+// ability bounds without requiring a compile-fail harness.
 // ===========================================================================
 //
 // A resource-V map is NOT copyable / droppable:
@@ -276,16 +277,16 @@ fun ops_leave_value_unconstrained() {
 //
 // A bare macro on a non-integer key is a hard compile error:
 //   let mut m = sm::new<address, u64>();
-//   sm::upsert!(&mut m, &@0x1, 1);   // E04003: `<` not defined for address -> use upsert_by!
+//   sm::upsert!(&mut m, @0x1, 1);    // E04003: `<` not defined for address -> use upsert_by!
 //
 // A bare (UID-less) map cannot be transferred:
 //   sui::transfer::public_transfer(sm::new<u64, u64>(), @0x1); // needs T: key
 //
 // A comparator cannot re-enter to mutate the map mid-search:
-//   sm::upsert_by!(&mut m, &1, 1, |a, b| { sm::upsert!(&mut m, &9, 9); *a < *b }); // borrow conflict
+//   sm::upsert_by!(&mut m, 1, 1, |a, b| { sm::upsert!(&mut m, 9, 9); *a < *b }); // borrow conflict
 //
 // is_well_formed[_by] is `#[test_only]`, absent from the published module: a
 // PRODUCTION (non-#[test_only]) consumer function cannot resolve it (zero on-chain cost; an
-// O(n) per-op walk would erase the single-object thesis). Build-time/visibility fact,
-// exercised by review / a CI compile-fail harness, not a runnable `#[test]`:
+// O(n) per-op walk would erase the single-object thesis). This is a review-only
+// build-time/visibility fact, not a runnable `#[test]`:
 //   public fun prod_check(m: &SortedMap<u64, u64>): bool { sm::is_well_formed!(m) } // unresolved: test-only

--- a/collections/tests/sorted_set/abort_tests.move
+++ b/collections/tests/sorted_set/abort_tests.move
@@ -3,8 +3,9 @@
 /// non-empty set) - each asserted at THIS module's location/code; two more are DELEGATED and
 /// surface at the wrapped MAP - `remove!` on an absent key (`sorted_map::EKeyNotFound`) and `add!` /
 /// `add_by!` on a duplicate key (`sorted_map::EKeyAlreadyExists`). The rest is the affirmative
-/// total-API contract for mid-PTB chaining: every op except `remove!`, `add!` / `add_by!`,
-/// `destroy_empty`, and the pops is total.
+/// total-API contract for mid-PTB chaining: every supported op except `remove!`, `add!` /
+/// `add_by!`, `from_sorted_keys!` / `from_sorted_keys_by!`, `destroy_empty`, and the pops is total
+/// (assuming the caller-supplied comparator itself does not abort).
 ///
 /// Every set-owned `#[expected_failure]` pins BOTH `abort_code = ...sorted_set::E*` AND
 /// `location = openzeppelin_collections::sorted_set` - the SET's location. The bypass and
@@ -17,7 +18,7 @@ use openzeppelin_collections::sorted_set as ss;
 use openzeppelin_collections::sorted_set_test_util as u;
 use std::unit_test::assert_eq;
 
-// === the ONE abort: pop_front/pop_back on empty -> set-owned EEmpty ===
+// === Empty pop aborts: pop_front/pop_back -> set-owned EEmpty ===
 
 #[test, expected_failure(abort_code = ss::EEmpty, location = ss)]
 fun pop_front_empty_aborts_at_set() {
@@ -139,7 +140,7 @@ fun add_coarse_equal_key_aborts_at_map() {
     u::add_k(&mut s, u::mk(1, 200)); // id=1 already present -> EKeyAlreadyExists at the map
 }
 
-// === affirmative total API: every op except remove!/pop returns none/false/empty, never aborts ===
+// === Affirmative total API: selected empty/miss operations are total ===
 
 #[test]
 fun total_api_no_abort_on_empty() {

--- a/collections/tests/sorted_set/comparator_tests.move
+++ b/collections/tests/sorted_set/comparator_tests.move
@@ -355,7 +355,7 @@ fun nonstrict_comparator_misses_equal_key() {
 #[test]
 fun from_keys_by_reverse_integer() {
     // The reverse direction was only ever built via upsert_by (ups_rev); this pins the BULK builder
-    // (from_keys_by's do!-loop) threading a reverse lt - yields descending-numeric, well-formed
+    // (from_keys_by's fold!-loop) threading a reverse lt - yields descending-numeric, well-formed
     // under `>` and NOT under `<`.
     let s = ss::from_keys_by!(vector[10u64, 30, 20], |a, b| *a > *b);
     assert_eq!(s.keys(), vector[30u64, 20, 10]); // descending-numeric (ascending under >)

--- a/collections/tests/sorted_set/polarity_tests.move
+++ b/collections/tests/sorted_set/polarity_tests.move
@@ -8,10 +8,11 @@
 /// catches it. These tests assert both directions explicitly and cross-check every bool against
 /// `contains!` before/after.
 ///
-/// `remove!` has no bool to invert - it returns nothing and ABORTS on an absent key (the
+/// `remove!` has no bool to invert - it returns the removed key and ABORTS on an absent key (the
 /// abort itself is pinned in `abort_tests`). What can still silently break is DELEGATION: a
-/// wrapper that drops the wrong element, or none at all, still type-checks. So the remove tests
-/// here assert the EFFECT (the `contains!` flip and the length/keys delta) on every position.
+/// wrapper that returns the wrong element, or removes none at all, can still type-check. So the
+/// remove tests here intentionally discard each droppable `u64` return and assert the EFFECT (the
+/// `contains!` flip and the length/keys delta) on every position.
 module openzeppelin_collections::sorted_set_polarity_tests;
 
 use openzeppelin_collections::sorted_set as ss;
@@ -105,7 +106,8 @@ fun polarity_counters_over_sequence() {
     // deliberately ASYMMETRIC so the counter can be hit ONLY under correct polarity - an inverted
     // projection changes the total, not just which call in a pair returns true. (A symmetric
     // fresh/duplicate split would be inversion-invariant and thus vacuous.) The remove half then
-    // drains a present cohort and pins the exact length delta by EFFECT (remove! has no bool).
+    // drains a present cohort and pins the exact length delta by EFFECT (`remove!` returns the
+    // removed key, not a bool; these droppable `u64` returns are intentionally discarded).
     let mut s = ss::new<u64>();
     let mut true_inserts = 0u64;
 

--- a/collections/tests/sorted_set/test_util.move
+++ b/collections/tests/sorted_set/test_util.move
@@ -228,8 +228,9 @@ public fun page_k(s: &SortedSet<Key>, from_id: u64, inc: bool, lim: u64): vector
 // cannot fall out of scope, so it must be drained (keys leave via `pop_*`/`remove_by!`, each
 // consumed by `ndk_unwrap`) and then `destroy_empty`'d. Ordered on `id`. The ops that need nothing
 // of K all apply: `add_by!` inserts, `contains_by!` probes, `remove_by!` RETURNS the key, and
-// `pop_*` return the bare key. Only `upsert!` and `from_keys!` (which drop a key) need `K: drop`
-// and are unavailable here; the key-copying reads (head/tail/keys/navigation) need `K: copy`.
+// `pop_*` return the bare key. `upsert!`, `from_keys!`, and `from_sorted_keys!` can drop a key, so
+// they need `K: drop` and are unavailable here; the key-copying reads
+// (head/tail/keys/navigation) need `K: copy`.
 
 public struct NoDropKey has store { id: u64 }
 
@@ -264,9 +265,9 @@ public fun rem_ndk(s: &mut SortedSet<NoDropKey>, id: u64): u64 {
 // === Copy+store key (no `drop`): copy-requiring ops need `copy`, not `drop` ===
 //
 // CopyKey has `copy` but not `drop`. head/tail/keys/navigation/pagination copy keys OUT (need
-// `copy`) and `add_by!` moves a key in (needs nothing); `upsert!`/`from_keys!` (which drop a key)
-// are unavailable - see the type_tests negatives. Ordered on `id`; returned no-`drop` keys are
-// mapped to ids and unwrapped.
+// `copy`) and `add_by!` moves a key in (needs nothing); `upsert!`, `from_keys!`, and
+// `from_sorted_keys!` can drop a key and are unavailable - see the type_tests negatives. Ordered
+// on `id`; returned no-`drop` keys are mapped to ids and unwrapped.
 
 public struct CopyKey has copy, store { id: u64 }
 
@@ -324,9 +325,9 @@ public fun page_ck(s: &SortedSet<CopyKey>, from_id: u64, inc: bool, lim: u64): v
 
 // === Drop+store key (no `copy`): drop-requiring ops need `drop`, not `copy` ===
 //
-// DropKey has `drop` but not `copy`. `upsert!` (drops the displaced key) and `from_keys!` (built
-// on upsert) need `drop`, so they compile here; head/tail/keys/navigation (which copy keys out)
-// do NOT - see the type_tests negatives. A `drop` key needs no manual disposal. Ordered on `id`.
+// DropKey has `drop` but not `copy`. `upsert!`, `from_keys!`, and `from_sorted_keys!` can drop a
+// key, so they need `drop` and compile here; head/tail/keys/navigation (which copy keys out) do NOT
+// - see the type_tests negatives. A `drop` key needs no manual disposal. Ordered on `id`.
 
 public struct DropKey has drop, store { id: u64 }
 
@@ -352,6 +353,11 @@ public fun rem_dk(s: &mut SortedSet<DropKey>, id: u64) {
 /// from_keys over a no-`copy` key: needs `drop` (the dedup upsert), never `copy`.
 public fun fromk_dk(ids: vector<u64>): SortedSet<DropKey> {
     ss::from_keys_by!(ids.map!(|id| drop_key(id)), |a, b| a.id < b.id)
+}
+
+/// from_sorted_keys over a no-`copy` key: needs `drop` for adjacent de-duplication, never `copy`.
+public fun from_sorted_dk(ids: vector<u64>): SortedSet<DropKey> {
+    ss::from_sorted_keys_by!(ids.map!(|id| drop_key(id)), |a, b| a.id < b.id)
 }
 
 // === Builders ===

--- a/collections/tests/sorted_set/test_util.move
+++ b/collections/tests/sorted_set/test_util.move
@@ -356,6 +356,7 @@ public fun fromk_dk(ids: vector<u64>): SortedSet<DropKey> {
 }
 
 /// from_sorted_keys over a no-`copy` key: needs `drop` for adjacent de-duplication, never `copy`.
+/// Aborts `sorted_set::EKeysNotSorted` if `ids` is not ascending.
 public fun from_sorted_dk(ids: vector<u64>): SortedSet<DropKey> {
     ss::from_sorted_keys_by!(ids.map!(|id| drop_key(id)), |a, b| a.id < b.id)
 }

--- a/collections/tests/sorted_set/type_tests.move
+++ b/collections/tests/sorted_set/type_tests.move
@@ -57,10 +57,10 @@ fun destroy_empty_on_empty_droppable_set() {
 #[test]
 fun store_only_key_drain_then_destroy_empty() {
     // A store-only key makes SortedSet<NoDropKey> itself store-only - it CANNOT fall out of scope,
-    // so it must be drained then explicitly torn down. Keys leave only via pop_* (each consumed by
-    // ndk_unwrap, since NoDropKey has no `drop`); the emptied set is then closed by destroy_empty -
-    // the ONLY terminal for a non-`drop`-key set. Omitting destroy_empty would not compile, which
-    // is the structural proof that the terminal is load-bearing here.
+    // so it must be drained then explicitly torn down. Keys leave through remove! or pop_* and must
+    // be consumed because NoDropKey has no `drop`; this walkthrough drains in order with pop_front.
+    // The emptied set is then closed by destroy_empty. Omitting it would not compile, which is the
+    // structural proof that the terminal is load-bearing here.
     let mut s = ss::new<u::NoDropKey>();
     u::add_ndk(&mut s, u::ndk(2));
     u::add_ndk(&mut s, u::ndk(1));
@@ -230,7 +230,7 @@ fun pop_returns_bare_key_not_tuple() {
 #[test]
 fun from_keys_macro_depth_compiles() {
     // macro_inlining_headroom pins 3-layer BARE ops in-body; this pins the HEADLINE
-    // 4-layer from_keys expansion (do! -> set upsert -> map upsert_by! -> search!) compiling in a
+    // 4-layer from_keys expansion (fold! -> set upsert -> map upsert_by! -> search!) compiling in a
     // #[test] body directly - both the bare and a _by form - not only via test_util helpers.
     let s = ss::from_keys!(vector[3u64, 1, 2]); // bare 4-layer expansion in-body
     assert_eq!(s.keys(), vector[1u64, 2, 3]);
@@ -247,8 +247,8 @@ fun from_keys_macro_depth_compiles() {
 #[test]
 fun value_conserving_ops_need_nothing_of_key() {
     // K = NoDropKey (store only: no copy, no drop). add/contains/remove and the lifecycle ops all
-    // instantiate - they constrain K with nothing. (upsert/from_keys need drop; the reads need
-    // copy - see the negatives.)
+    // instantiate - they constrain K with nothing. (upsert/from_keys/from_sorted_keys need drop;
+    // the reads need copy - see the negatives.)
     let mut s = ss::new<u::NoDropKey>();
     u::add_ndk(&mut s, u::ndk(20));
     u::add_ndk(&mut s, u::ndk(10));
@@ -267,8 +267,8 @@ fun value_conserving_ops_need_nothing_of_key() {
 #[test]
 fun key_copying_ops_need_copy_not_drop() {
     // K = CopyKey (copy + store, NO drop). head/tail/keys and all navigation/pagination copy keys
-    // out, so `copy` alone suffices - `drop` is not required. `add` also works. (upsert/from_keys
-    // do NOT compile here - see the negatives.)
+    // out, so `copy` alone suffices - `drop` is not required. `add` also works.
+    // (upsert/from_keys/from_sorted_keys do NOT compile here - see the negatives.)
     let mut s = ss::new<u::CopyKey>();
     u::add_ck(&mut s, 10);
     u::add_ck(&mut s, 20);
@@ -290,10 +290,10 @@ fun key_copying_ops_need_copy_not_drop() {
 
 #[test]
 fun key_dropping_ops_need_drop_not_copy() {
-    // K = DropKey (drop + store, NO copy). upsert and from_keys drop a key, so `drop` alone
-    // suffices - `copy` is not required. add/contains/remove also work. (head/tail/keys/navigation
-    // do NOT compile here - see the negatives.) SortedSet<DropKey> is itself `drop`, so it falls
-    // out of scope - no destroy_empty needed.
+    // K = DropKey (drop + store, NO copy). upsert, from_keys, and from_sorted_keys can drop a key,
+    // so `drop` alone suffices - `copy` is not required. add/contains/remove also work.
+    // (head/tail/keys/navigation do NOT compile here - see the negatives.) SortedSet<DropKey> is
+    // itself `drop`, so it falls out of scope - no destroy_empty needed.
     let mut s = ss::new<u::DropKey>();
     assert!(u::ups_dk(&mut s, 10)); // newly added
     assert!(u::ups_dk(&mut s, 20));
@@ -302,10 +302,15 @@ fun key_dropping_ops_need_drop_not_copy() {
     u::add_dk(&mut s, 30); // strict insert
     assert!(u::has_dk(&s, 30));
     u::rem_dk(&mut s, 20);
-    assert!(!u::has_dk(&s, 20) && s.length() == 2);
+    assert!(!u::has_dk(&s, 20));
+    assert_eq!(s.length(), 2);
     // from_keys over a no-copy key de-duplicates (needs drop only, never copy)
     let s2 = u::fromk_dk(vector[3, 1, 2, 1, 3]);
     assert_eq!(s2.length(), 3);
+    // from_sorted_keys has the same minimal `drop` bound and de-duplicates adjacent equals.
+    let s3 = u::from_sorted_dk(vector[1, 1, 2, 3, 3]);
+    assert_eq!(s3.length(), 3);
+    assert!(u::has_dk(&s3, 1) && u::has_dk(&s3, 2) && u::has_dk(&s3, 3));
 }
 
 // ===========================================================================
@@ -326,14 +331,16 @@ fun key_dropping_ops_need_drop_not_copy() {
 //
 // Key abilities are demanded PER-OPERATION. A store-only key (`NoDropKey`: no `copy`, no `drop`)
 // works with everything that needs nothing of K - new/singleton/add_by!/contains_by!/remove_by!
-// (which RETURNS the key)/pop_*/destroy_empty (exercised positively above). Two op families
+// (which RETURNS the key)/pop_*/destroy_empty (exercised positively above). Two ability categories
 // constrain K at the expansion site:
 //     let mut s = ss::new<u::NoDropKey>();
 //     let p = u::ndk(1);
 //     // (a) key-DROPPING ops -> need K: drop. upsert drops the displaced key; from_keys is built
-//     //     on upsert. (add_by! never drops - a duplicate ABORTS; remove_by! RETURNS the key.)
+//     //     on upsert; from_sorted_keys drops adjacent duplicates. (add_by! never drops - a
+//     //     duplicate ABORTS; remove_by! RETURNS the key.)
 //     ss::upsert_by!(&mut s, u::ndk(1), |_, _| true);           // E05001: upsert needs `drop`
 //     let _ = ss::from_keys_by!(vector[u::ndk(1)], |_, _| true); // E05001: from_keys needs `drop`
+//     let _ = ss::from_sorted_keys_by!(vector[u::ndk(1)], |_, _| true); // E05001: needs `drop`
 //     // (b) key-COPYING ops copy a key OUT -> need K: copy. The comparator is irrelevant to this
 //     //     error (the copy is from returning the key), hence the trivial `|_, _| true`:
 //     s.keys(); s.head(); s.tail();                             // E05001: need `copy` (no comparator)
@@ -343,11 +350,14 @@ fun key_dropping_ops_need_drop_not_copy() {
 //     ss::prev_key_by!(&s, &p, |_, _| true);                    // E05001: need `copy`
 //     ss::keys_from_by!(&s, &p, true, 10, |_, _| true);         // E05001: need `copy`
 //
-// upsert's need is specifically `drop`, not `copy`: it fails even for a copy-but-not-`drop` key
-// (`CopyKey`), isolating `drop`, while add_by! and the copy-requiring reads all compile on that
+// These operations need specifically `drop`, not `copy`: they fail even for a copy-but-not-`drop`
+// key (`CopyKey`), isolating `drop`, while add_by! and the copy-requiring reads all compile on that
 // same key (exercised positively above):
 //     let mut sc = ss::new<u::CopyKey>();
 //     ss::upsert_by!(&mut sc, u::copy_key(1), |_, _| true);     // E05001: needs `drop`
+//     let _ = ss::from_keys_by!(vector[u::copy_key(1)], |_, _| true); // E05001: needs `drop`
+//     let _ = ss::from_sorted_keys_by!(vector[u::copy_key(1)], |_, _| true);
+//     // E05001: needs `drop`
 //
 // A bare macro on a non-integer key fails (no built-in `<`); use the _by form:
 //     let mut s = ss::new<address>();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified SortedMap/SortedSet draining requirements, including how to handle non-droppable keys/values.
  * Expanded pagination and keyset-cursor semantics across mutations, and clarified empty-collection behavior.
  * Improved error-name qualification and tightened security guidance and expected-failure notes.

* **Tests**
  * Updated expected-failure location pinning and clarified entry/key-return behavior and scenario comments.
  * Added a test helper to construct `SortedSet<DropKey>` from a `vector<u64>` of ids.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->