### PR TITLE
[N-05] Collections audit

### DIFF
--- a/collections/examples/sorted_map/order_book.move
+++ b/collections/examples/sorted_map/order_book.move
@@ -30,11 +30,19 @@ module openzeppelin_collections::sorted_map_order_book;
 
 use openzeppelin_collections::sorted_map::{Self, SortedMap};
 
+// === Errors ===
+
+/// `place_ask`/`place_bid` was called with a zero size. Rejected up front so an empty level
+/// can never exist - and can never become the reported top of book via `best_ask`/`best_bid`.
+#[error(code = 0)]
+const EZeroSize: vector<u8> = "Size must be greater than zero";
+
 // === Structs ===
 
 /// Aggregate resting size at one price.
 public struct Level has copy, drop, store {
-    /// Total resting size aggregated at this price level.
+    /// Total resting size aggregated at this price level. Always positive: zero-size
+    /// placements are rejected and merges only add.
     size: u64,
 }
 
@@ -61,13 +69,15 @@ public fun deploy_and_share(ctx: &mut TxContext): ID {
     id
 }
 
-/// Add `size` at `price` on the ask side, merging into an existing level if present.
+/// Add positive `size` at `price` on the ask side, merging into an existing level if present.
 ///
 /// #### Aborts
+/// - `EZeroSize` if `size` is zero.
 /// - Arithmetic overflow if merging `size` into an existing level exceeds `u64`.
 /// - `sorted_map::EKeyNotFound` from `borrow_mut!` (guarded by the `contains!` branch;
 ///   unreachable in normal operation).
 public fun place_ask(book: &mut OrderBook, price: u64, size: u64) {
+    assert!(size > 0, EZeroSize);
     if (book.asks.contains!(&price)) {
         let lvl = book.asks.borrow_mut!(&price);
         lvl.size = lvl.size + size;
@@ -76,14 +86,16 @@ public fun place_ask(book: &mut OrderBook, price: u64, size: u64) {
     }
 }
 
-/// Add `size` at `price` on the bid side, merging if present. Bids descend, so every
+/// Add positive `size` at `price` on the bid side, merging if present. Bids descend, so every
 /// call threads the same `|a, b| outbids(a, b)`.
 ///
 /// #### Aborts
+/// - `EZeroSize` if `size` is zero.
 /// - Arithmetic overflow if merging `size` into an existing level exceeds `u64`.
 /// - `sorted_map::EKeyNotFound` from `borrow_mut_by!` (guarded by the `contains_by!` branch;
 ///   unreachable in normal operation).
 public fun place_bid(book: &mut OrderBook, price: u64, size: u64) {
+    assert!(size > 0, EZeroSize);
     if (book.bids.contains_by!(&price, |a, b| outbids(a, b))) {
         let lvl = book.bids.borrow_mut_by!(&price, |a, b| outbids(a, b));
         lvl.size = lvl.size + size;

--- a/collections/examples/sorted_map/tests/order_book_tests.move
+++ b/collections/examples/sorted_map/tests/order_book_tests.move
@@ -1,5 +1,6 @@
 /// Scenario walkthroughs for `order_book` - the embed pattern (integer keys, bare +
-/// reverse-`_by`, pagination, the EKeyNotFound abort).
+/// reverse-`_by`, pagination, the EKeyNotFound abort, and the integrator's own zero-size
+/// guard).
 module openzeppelin_collections::sorted_map_order_book_tests;
 
 use openzeppelin_collections::sorted_map as sm;
@@ -106,6 +107,48 @@ fun ask_size_at_absent_aborts() {
     {
         let book = scenario.take_shared<OrderBook>();
         book.ask_size_at(555); // aborts here
+        ts::return_shared(book); // unreachable; satisfies the type checker
+    };
+    scenario.end();
+}
+
+// === Scenario 4 - zero-size placements are rejected, on both sides ===
+//
+// `place_ask`/`place_bid` require a positive size. An accepted zero-size level would rest
+// indefinitely and could become the reported top of book (`best_ask`/`best_bid` read the head
+// key without inspecting the level), misleading integrators into phantom quotes. The abort is
+// the integrator's OWN `EZeroSize`, at this example module's location - not a library abort.
+#[test, expected_failure(abort_code = order_book::EZeroSize, location = order_book)]
+fun place_ask_zero_size_aborts() {
+    let mut scenario = ts::begin(ALICE);
+
+    // Tx1 - ALICE: deploy.
+    {
+        order_book::deploy_and_share(scenario.ctx());
+    };
+    // Tx2 - ALICE: post a zero-size ask - aborts EZeroSize.
+    scenario.next_tx(ALICE);
+    {
+        let mut book = scenario.take_shared<OrderBook>();
+        book.place_ask(100, 0); // aborts here
+        ts::return_shared(book); // unreachable; satisfies the type checker
+    };
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = order_book::EZeroSize, location = order_book)]
+fun place_bid_zero_size_aborts() {
+    let mut scenario = ts::begin(ALICE);
+
+    // Tx1 - ALICE: deploy.
+    {
+        order_book::deploy_and_share(scenario.ctx());
+    };
+    // Tx2 - ALICE: post a zero-size bid - aborts EZeroSize.
+    scenario.next_tx(ALICE);
+    {
+        let mut book = scenario.take_shared<OrderBook>();
+        book.place_bid(99, 0); // aborts here
         ts::return_shared(book); // unreachable; satisfies the type checker
     };
     scenario.end();

--- a/collections/examples/sorted_set/allowlist.move
+++ b/collections/examples/sorted_set/allowlist.move
@@ -62,10 +62,22 @@ public struct Allowlist has key {
 // === Events ===
 
 /// Emitted only on a genuine first-time approval (gated on `upsert`'s `true`).
-public struct Approved has copy, drop { id: u64 }
+public struct Approved has copy, drop {
+    /// ID of the allowlist that emitted the event. Creation is permissionless, so consumers
+    /// bind events to one instance by this id.
+    allowlist_id: ID,
+    /// The approved token id.
+    id: u64,
+}
 
 /// Emitted on every successful revocation (`remove!` aborts if the id was absent).
-public struct Revoked has copy, drop { id: u64 }
+public struct Revoked has copy, drop {
+    /// ID of the allowlist that emitted the event. Creation is permissionless, so consumers
+    /// bind events to one instance by this id.
+    allowlist_id: ID,
+    /// The revoked token id.
+    id: u64,
+}
 
 // === Public Functions ===
 
@@ -112,7 +124,7 @@ public fun transfer_to(list: Allowlist, recipient: address) {
 /// - `true` if `id` was newly approved, `false` if it was already present.
 public fun approve(list: &mut Allowlist, id: u64): bool {
     let added = list.members.upsert!(id);
-    if (added) event::emit(Approved { id });
+    if (added) event::emit(Approved { allowlist_id: object::id(list), id });
     added
 }
 
@@ -127,7 +139,7 @@ public fun approve(list: &mut Allowlist, id: u64): bool {
 /// - `EAlreadyApproved` if `id` is already present.
 public fun approve_strict(list: &mut Allowlist, id: u64) {
     assert!(list.members.upsert!(id), EAlreadyApproved);
-    event::emit(Approved { id });
+    event::emit(Approved { allowlist_id: object::id(list), id });
 }
 
 /// Revoke `id`, aborting if it is not approved (the set's `remove!` aborts on an absent key).
@@ -141,7 +153,7 @@ public fun approve_strict(list: &mut Allowlist, id: u64) {
 /// - `sorted_map::EKeyNotFound` if `id` is not approved.
 public fun revoke(list: &mut Allowlist, id: u64) {
     list.members.remove!(&id);
-    event::emit(Revoked { id });
+    event::emit(Revoked { allowlist_id: object::id(list), id });
 }
 
 /// True iff `id` is currently approved. Routes through the same search the writes use, so
@@ -186,4 +198,16 @@ public fun members(list: &Allowlist): vector<u64> {
 #[test_only]
 public fun members_well_formed(list: &Allowlist): bool {
     list.members.inner().is_well_formed!()
+}
+
+/// Reconstruct an `Approved` event for test assertions.
+#[test_only]
+public fun approved_event(allowlist_id: ID, id: u64): Approved {
+    Approved { allowlist_id, id }
+}
+
+/// Reconstruct a `Revoked` event for test assertions.
+#[test_only]
+public fun revoked_event(allowlist_id: ID, id: u64): Revoked {
+    Revoked { allowlist_id, id }
 }

--- a/collections/examples/sorted_set/tests/allowlist_tests.move
+++ b/collections/examples/sorted_set/tests/allowlist_tests.move
@@ -39,7 +39,12 @@ fun membership_lifecycle() {
 
         let added = list.approve(5);
         assert!(added); // newly added -> true
-        assert_eq!(event::events_by_type<Approved>().length(), 1); // emitted once
+        // Emitted once, carrying THIS allowlist's id - consumers watching another (permissionless)
+        // instance can tell the events apart.
+        assert_eq!(
+            event::events_by_type<Approved>(),
+            vector[allowlist::approved_event(object::id(&list), 5)],
+        );
         assert_eq!(list.count(), 3);
         scenario.return_to_sender(list);
     };
@@ -53,8 +58,11 @@ fun membership_lifecycle() {
         assert_eq!(event::events_by_type<Approved>().length(), 0); // polarity: no emit on re-add
         assert_eq!(list.count(), 3); // unchanged
 
-        list.revoke(3); // was present -> succeeds and emits
-        assert_eq!(event::events_by_type<Revoked>().length(), 1);
+        list.revoke(3); // was present -> succeeds and emits, bound to this list's id
+        assert_eq!(
+            event::events_by_type<Revoked>(),
+            vector[allowlist::revoked_event(object::id(&list), 3)],
+        );
         assert!(!list.is_approved(3));
         assert!(list.members_well_formed()); // order oracle: still sorted
 
@@ -116,6 +124,34 @@ fun approve_strict_rejects_duplicate() {
         let mut list = scenario.take_from_sender<Allowlist>();
         list.approve_strict(1); // aborts here: 1 is already approved
         scenario.return_to_sender(list); // unreachable; satisfies the type checker
+    };
+
+    scenario.end();
+}
+
+// === Scenario 2b - strict approval of a NEW id succeeds and emits ===
+//
+// The abort above is the exceptional path; on a fresh id `approve_strict` behaves like
+// `approve`: membership flips and one `Approved` is emitted, bound to this list's id.
+#[test]
+fun approve_strict_new_id_approves_and_emits() {
+    let mut scenario = ts::begin(ALICE);
+
+    // Tx1 - ALICE: seed an allowlist with {1, 2}.
+    allowlist::create_and_keep(vector[1, 2], scenario.ctx());
+
+    // Tx2 - ALICE: strict-approve a fresh id - succeeds and emits, bound to this list's id.
+    scenario.next_tx(ALICE);
+    {
+        let mut list = scenario.take_from_sender<Allowlist>();
+        list.approve_strict(3);
+        assert!(list.is_approved(3));
+        assert_eq!(list.count(), 3);
+        assert_eq!(
+            event::events_by_type<Approved>(),
+            vector[allowlist::approved_event(object::id(&list), 3)],
+        );
+        scenario.return_to_sender(list);
     };
 
     scenario.end();

--- a/collections/examples/sorted_set/tests/unlock_queue_tests.move
+++ b/collections/examples/sorted_set/tests/unlock_queue_tests.move
@@ -1,8 +1,13 @@
 module openzeppelin_collections::sorted_set_unlock_queue_tests;
 
 use openzeppelin_collections::sorted_set as ss;
-use openzeppelin_collections::sorted_set_unlock_queue::{Self as unlock_queue, UnlockQueue};
+use openzeppelin_collections::sorted_set_unlock_queue::{
+    Self as unlock_queue,
+    UnlockQueue,
+    Unlocked,
+};
 use std::unit_test::assert_eq;
+use sui::event;
 use sui::test_scenario as ts;
 
 const ALICE: address = @0x0A;
@@ -48,6 +53,18 @@ fun drain_earliest_first() {
         q.cancel(30); // remove the tail
         assert_eq!(q.pending(), 1); // {25}
         assert_eq!(q.process_latest(), 25); // pop_back: largest (now only)
+
+        // Each pop emitted an `Unlocked` carrying THIS queue's id - consumers watching another
+        // (permissionless) instance can tell the events apart.
+        let qid = object::id(&q);
+        assert_eq!(
+            event::events_by_type<Unlocked>(),
+            vector[
+                unlock_queue::unlocked_event(qid, 10),
+                unlock_queue::unlocked_event(qid, 20),
+                unlock_queue::unlocked_event(qid, 25),
+            ],
+        );
 
         assert!(q.is_empty());
         assert!(q.deadlines_well_formed()); // an empty set is well-formed

--- a/collections/examples/sorted_set/unlock_queue.move
+++ b/collections/examples/sorted_set/unlock_queue.move
@@ -46,7 +46,13 @@ public struct UnlockQueue has key {
 
 /// Emitted by `process_earliest` / `process_latest` when a deadline is processed (popped) off
 /// the queue.
-public struct Unlocked has copy, drop { deadline: u64 }
+public struct Unlocked has copy, drop {
+    /// ID of the queue that emitted the event. Creation is permissionless, so consumers bind
+    /// events to one instance by this id.
+    queue_id: ID,
+    /// The processed deadline.
+    deadline: u64,
+}
 
 // === Public Functions ===
 
@@ -101,7 +107,7 @@ public fun is_empty(q: &UnlockQueue): bool {
 ///   `next_deadline` first.
 public fun process_earliest(q: &mut UnlockQueue): u64 {
     let deadline = q.deadlines.pop_front();
-    event::emit(Unlocked { deadline });
+    event::emit(Unlocked { queue_id: object::id(q), deadline });
     deadline
 }
 
@@ -111,7 +117,7 @@ public fun process_earliest(q: &mut UnlockQueue): u64 {
 /// - `EEmpty` if the queue is empty (same as `process_earliest`).
 public fun process_latest(q: &mut UnlockQueue): u64 {
     let deadline = q.deadlines.pop_back();
-    event::emit(Unlocked { deadline });
+    event::emit(Unlocked { queue_id: object::id(q), deadline });
     deadline
 }
 
@@ -121,4 +127,10 @@ public fun process_latest(q: &mut UnlockQueue): u64 {
 #[test_only]
 public fun deadlines_well_formed(q: &UnlockQueue): bool {
     q.deadlines.inner().is_well_formed!()
+}
+
+/// Reconstruct an `Unlocked` event for test assertions.
+#[test_only]
+public fun unlocked_event(queue_id: ID, deadline: u64): Unlocked {
+    Unlocked { queue_id, deadline }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Order book placements now reject zero-sized bids and asks.
  * Approval and revocation events now identify the associated allowlist.
  * Unlock events now identify the queue that emitted them.

* **Bug Fixes**
  * Improved event accuracy and context for allowlist and unlock-queue operations.

* **Tests**
  * Added coverage for zero-size order rejection and verified event payloads and ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->