### PR TITLE
ci: ignore `differential_tests` and `quick_sort_random_is_sorted_and_preserves_elements` from tracing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,8 +170,11 @@ jobs:
             trap 'git checkout -- $files' EXIT
             perl -0pi -e 's/#\[test\]\nfun differential_1200_ops/#[allow(unused_function)]\nfun differential_1200_ops/g' $files
             # Fail loudly if the disable didn't happen (e.g. after a reformat),
-            # otherwise the traced run silently hangs again.
-            if sui move test --list 2>/dev/null | grep -q '::differential_1200_ops:'; then
+            # otherwise the traced run silently hangs again. Capture the list
+            # first so `sui move test` can't die from SIGPIPE (which under
+            # pipefail would mask a match and skip this guard).
+            test_list=$(sui move test --list 2>/dev/null || true)
+            if grep -q '::differential_1200_ops:' <<<"$test_list"; then
               echo "::error::failed to disable differential_1200_ops before tracing" >&2
               exit 1
             fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -154,10 +154,32 @@ jobs:
           version: ${{ env.SUI_VERSION }}
 
       - name: Run tests with tracing
+        # `collections` package times out due to `differential_1200_ops` tests,
+        # so we handle that in a separate job.
+        if: matrix.package != 'collections'
         # `--rand-num-iters 1`: coverage only needs each line executed once. The
         # full randomized property iterations run in the `test` job above, so a
         # single iteration here keeps trace volume down without losing coverage.
         run: sui move test --trace --rand-num-iters 1
+        working-directory: ./${{ matrix.package }}
+
+      - name: Run tests with tracing (collections)
+        # `collections` only: `differential_1200_ops`'s 1,200-op loop produces a
+        # multi-GB trace that never finishes under `--trace` (>40 min), and
+        # `sui move test` has no exclude flag. Drive the traced run from the test
+        # list and skip that one function; traces accumulate across invocations,
+        # so the union covers every other test. The 1,200-op correctness proof
+        # still runs untraced in the `test` job above.
+        if: matrix.package == 'collections'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t TESTS < <(sui move test --list 2>/dev/null \
+            | sed -n 's/: test$//p' \
+            | grep -v '::differential_1200_ops$')
+          for t in "${TESTS[@]}"; do
+            sui move test --trace --rand-num-iters 1 "$t"
+          done
         working-directory: ./${{ matrix.package }}
 
       - name: Generate Codecov report

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -157,26 +157,33 @@ jobs:
         # `--rand-num-iters 1`: coverage only needs each line executed once; the
         # full randomized property iterations run in the `test` job above.
         #
-        # `collections`'s differential test suites (the `*_differential_tests`
-        # modules) build large maps/sets whose traces run into multiple GB - the
-        # heaviest never finish under `--trace` (>40 min) - and `sui move test`
-        # has no exclude flag. Disable every `#[test]` in those modules at the
-        # source level for the traced run, then restore via git. They still run
-        # untraced in the `test` job above.
+        # Some suites build large collections whose traces run into multiple GB -
+        # the heaviest never finish under `--trace` (>40 min) - and `sui move
+        # test` has no exclude flag, so we disable them at the source level for
+        # the traced run and restore via git. They still run untraced in the
+        # `test` job above. Two scopes:
+        #   * `collections`: the whole `*_differential_tests` modules.
+        #   * others: individually named heavy tests (any test attribute).
         shell: bash
         run: |
           set -euo pipefail
-          files=$(grep -rlE --include='*.move' 'module .*_differential_tests;' tests 2>/dev/null || true)
-          if [ -n "$files" ]; then
-            trap 'git checkout -- $files' EXIT
-            perl -0pi -e 's/#\[test\]/#[allow(unused_function)]/g' $files
+          diff_files=$(grep -rlE --include='*.move' 'module .*_differential_tests;' tests 2>/dev/null || true)
+          heavy_tests='quick_sort_random_is_sorted_and_preserves_elements'
+          heavy_files=$(grep -rlE --include='*.move' "fun ($heavy_tests)" tests 2>/dev/null || true)
+          disabled=()
+          [ -n "$diff_files" ] && disabled+=($diff_files)
+          [ -n "$heavy_files" ] && disabled+=($heavy_files)
+          if [ ${#disabled[@]} -gt 0 ]; then
+            trap 'git checkout -- "${disabled[@]}"' EXIT
+            [ -n "$diff_files" ] && perl -0pi -e 's/#\[test\]/#[allow(unused_function)]/g' $diff_files
+            [ -n "$heavy_files" ] && perl -0pi -e "s/#\[(test|random_test)\]\n(fun ($heavy_tests))/#[allow(unused_function)]\n\$2/g" $heavy_files
             # Fail loudly if the disable didn't happen (e.g. after a reformat),
             # otherwise the traced run silently hangs again. Capture the list
             # first so `sui move test` can't die from SIGPIPE (which under
             # pipefail would mask a match and skip this guard).
             test_list=$(sui move test --list 2>/dev/null || true)
-            if grep -qE '_differential_tests::' <<<"$test_list"; then
-              echo "::error::failed to disable differential tests before tracing" >&2
+            if grep -qE "_differential_tests::|::($heavy_tests)" <<<"$test_list"; then
+              echo "::error::failed to disable heavy tests before tracing" >&2
               exit 1
             fi
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -181,7 +181,11 @@ jobs:
             # otherwise the traced run silently hangs again. Capture the list
             # first so `sui move test` can't die from SIGPIPE (which under
             # pipefail would mask a match and skip this guard).
-            test_list=$(sui move test --list 2>/dev/null || true)
+            if ! test_list=$(sui move test --list 2>&1); then
+              echo "::error::failed to enumerate Move tests before tracing" >&2
+              printf '%s\n' "$test_list" >&2
+              exit 1
+            fi
             if grep -qE "_differential_tests::|::($heavy_tests)" <<<"$test_list"; then
               echo "::error::failed to disable heavy tests before tracing" >&2
               exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -154,32 +154,29 @@ jobs:
           version: ${{ env.SUI_VERSION }}
 
       - name: Run tests with tracing
-        # `collections` package times out due to `differential_1200_ops` tests,
-        # so we handle that in a separate job.
-        if: matrix.package != 'collections'
-        # `--rand-num-iters 1`: coverage only needs each line executed once. The
-        # full randomized property iterations run in the `test` job above, so a
-        # single iteration here keeps trace volume down without losing coverage.
-        run: sui move test --trace --rand-num-iters 1
-        working-directory: ./${{ matrix.package }}
-
-      - name: Run tests with tracing (collections)
-        # `collections` only: `differential_1200_ops`'s 1,200-op loop produces a
-        # multi-GB trace that never finishes under `--trace` (>40 min), and
-        # `sui move test` has no exclude flag. Drive the traced run from the test
-        # list and skip that one function; traces accumulate across invocations,
-        # so the union covers every other test. The 1,200-op correctness proof
-        # still runs untraced in the `test` job above.
-        if: matrix.package == 'collections'
+        # `--rand-num-iters 1`: coverage only needs each line executed once; the
+        # full randomized property iterations run in the `test` job above.
+        #
+        # `collections`'s two `differential_1200_ops` tests run a 1,200-op loop
+        # that produces a multi-GB trace and never finishes under `--trace`
+        # (>40 min), and `sui move test` has no exclude flag. Disable them at the
+        # source level for the traced run, then restore via git. They still run
+        # untraced in the `test` job above.
         shell: bash
         run: |
           set -euo pipefail
-          mapfile -t TESTS < <(sui move test --list 2>/dev/null \
-            | sed -n 's/: test$//p' \
-            | grep -v '::differential_1200_ops$')
-          for t in "${TESTS[@]}"; do
-            sui move test --trace --rand-num-iters 1 "$t"
-          done
+          files=$(grep -rl --include='*.move' 'fun differential_1200_ops' tests 2>/dev/null || true)
+          if [ -n "$files" ]; then
+            trap 'git checkout -- $files' EXIT
+            perl -0pi -e 's/#\[test\]\nfun differential_1200_ops/#[allow(unused_function)]\nfun differential_1200_ops/g' $files
+            # Fail loudly if the disable didn't happen (e.g. after a reformat),
+            # otherwise the traced run silently hangs again.
+            if sui move test --list 2>/dev/null | grep -q '::differential_1200_ops$'; then
+              echo "::error::failed to disable differential_1200_ops before tracing" >&2
+              exit 1
+            fi
+          fi
+          sui move test --trace --rand-num-iters 1
         working-directory: ./${{ matrix.package }}
 
       - name: Generate Codecov report

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -157,27 +157,26 @@ jobs:
         # `--rand-num-iters 1`: coverage only needs each line executed once; the
         # full randomized property iterations run in the `test` job above.
         #
-        # `collections`'s heavy differential tests (`differential_1200_ops`, a
-        # 1,200-op loop, and `large_n_build_and_full_walk`, a ~1,000-entry build)
-        # produce multi-GB traces and never finish under `--trace` (>40 min), and
-        # `sui move test` has no exclude flag. Disable them at the source level
-        # for the traced run, then restore via git. They still run untraced in
-        # the `test` job above.
+        # `collections`'s differential test suites (the `*_differential_tests`
+        # modules) build large maps/sets whose traces run into multiple GB - the
+        # heaviest never finish under `--trace` (>40 min) - and `sui move test`
+        # has no exclude flag. Disable every `#[test]` in those modules at the
+        # source level for the traced run, then restore via git. They still run
+        # untraced in the `test` job above.
         shell: bash
         run: |
           set -euo pipefail
-          heavy='differential_1200_ops|large_n_build_and_full_walk'
-          files=$(grep -rlE --include='*.move' "fun ($heavy)" tests 2>/dev/null || true)
+          files=$(grep -rlE --include='*.move' 'module .*_differential_tests;' tests 2>/dev/null || true)
           if [ -n "$files" ]; then
             trap 'git checkout -- $files' EXIT
-            perl -0pi -e "s/#\[test\]\n(fun ($heavy))/#[allow(unused_function)]\n\$1/g" $files
+            perl -0pi -e 's/#\[test\]/#[allow(unused_function)]/g' $files
             # Fail loudly if the disable didn't happen (e.g. after a reformat),
             # otherwise the traced run silently hangs again. Capture the list
             # first so `sui move test` can't die from SIGPIPE (which under
             # pipefail would mask a match and skip this guard).
             test_list=$(sui move test --list 2>/dev/null || true)
-            if grep -qE "::($heavy):" <<<"$test_list"; then
-              echo "::error::failed to disable heavy tests before tracing" >&2
+            if grep -qE '_differential_tests::' <<<"$test_list"; then
+              echo "::error::failed to disable differential tests before tracing" >&2
               exit 1
             fi
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -171,7 +171,7 @@ jobs:
             perl -0pi -e 's/#\[test\]\nfun differential_1200_ops/#[allow(unused_function)]\nfun differential_1200_ops/g' $files
             # Fail loudly if the disable didn't happen (e.g. after a reformat),
             # otherwise the traced run silently hangs again.
-            if sui move test --list 2>/dev/null | grep -q '::differential_1200_ops$'; then
+            if sui move test --list 2>/dev/null | grep -q '::differential_1200_ops:'; then
               echo "::error::failed to disable differential_1200_ops before tracing" >&2
               exit 1
             fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -157,25 +157,27 @@ jobs:
         # `--rand-num-iters 1`: coverage only needs each line executed once; the
         # full randomized property iterations run in the `test` job above.
         #
-        # `collections`'s two `differential_1200_ops` tests run a 1,200-op loop
-        # that produces a multi-GB trace and never finishes under `--trace`
-        # (>40 min), and `sui move test` has no exclude flag. Disable them at the
-        # source level for the traced run, then restore via git. They still run
-        # untraced in the `test` job above.
+        # `collections`'s heavy differential tests (`differential_1200_ops`, a
+        # 1,200-op loop, and `large_n_build_and_full_walk`, a ~1,000-entry build)
+        # produce multi-GB traces and never finish under `--trace` (>40 min), and
+        # `sui move test` has no exclude flag. Disable them at the source level
+        # for the traced run, then restore via git. They still run untraced in
+        # the `test` job above.
         shell: bash
         run: |
           set -euo pipefail
-          files=$(grep -rl --include='*.move' 'fun differential_1200_ops' tests 2>/dev/null || true)
+          heavy='differential_1200_ops|large_n_build_and_full_walk'
+          files=$(grep -rlE --include='*.move' "fun ($heavy)" tests 2>/dev/null || true)
           if [ -n "$files" ]; then
             trap 'git checkout -- $files' EXIT
-            perl -0pi -e 's/#\[test\]\nfun differential_1200_ops/#[allow(unused_function)]\nfun differential_1200_ops/g' $files
+            perl -0pi -e "s/#\[test\]\n(fun ($heavy))/#[allow(unused_function)]\n\$1/g" $files
             # Fail loudly if the disable didn't happen (e.g. after a reformat),
             # otherwise the traced run silently hangs again. Capture the list
             # first so `sui move test` can't die from SIGPIPE (which under
             # pipefail would mask a match and skip this guard).
             test_list=$(sui move test --list 2>/dev/null || true)
-            if grep -q '::differential_1200_ops:' <<<"$test_list"; then
-              echo "::error::failed to disable differential_1200_ops before tracing" >&2
+            if grep -qE "::($heavy):" <<<"$test_list"; then
+              echo "::error::failed to disable heavy tests before tracing" >&2
               exit 1
             fi
           fi


### PR DESCRIPTION
## Summary

The `coverage` job hangs and times out (>40 min) on `collections`
(e.g. see [latest run](https://github.com/OpenZeppelin/contracts-sui/actions/runs/29902927539/job/88867805073)).
 `math/core` has had a "hang" issue, which was resolved by increasing the timeout, but the fix here might drastically reduce the run time anyway.

A handful of tests build large collections or drive long randomized loops that produce
multi-gigabyte traces which never finish under `sui move test --trace`. This change
disables those tests for the traced coverage run only, while keeping them in the regular
`test` gate.

## The problem

`sui move coverage lcov` requires `sui move test --trace`, which records every VM
instruction. A few tests are fine untraced (they pass in seconds in the `test` job) but,
under tracing, emit multi-GB traces and blow past the 40-minute timeout:

- the `collections` `*_differential_tests` modules (`sorted_map` + `sorted_set`) — e.g.
  `differential_1200_ops` (a 1,200-op randomized loop) and `large_n_build_and_full_walk`
  (a 1,000-entry build + full walk);
- `math/core`'s `quick_sort_random_is_sorted_and_preserves_elements` (a `#[random_test]`).

`sui move test` has no exclude filter (only a positive substring match), and `#[mode(...)]`
gating is a no-op in the pinned Sui `1.75.2`, so these can't be skipped via the CLI.

## The fix

For the traced coverage run, disable the offending tests at the source level, run the full
package trace in a single pass, then restore the sources via git. Two scopes, so we don't
have to enumerate every test inside the collections suites:

- **`collections` (module-scoped):** find files declaring a `*_differential_tests` module
  and replace every `#[test]` in them with `#[allow(unused_function)]`. This covers the
  whole differential suite for both `sorted_map` and `sorted_set` regardless of which
  individual tests it contains.
- **Other packages (named tests):** find files containing the named heavy tests
  (currently just `quick_sort_random_is_sorted_and_preserves_elements`) and neutralize
  their attribute — the regex matches both `#[test]` and `#[random_test]`, since the
  quick_sort test is a property test.

The step then:

- Assembles the set of touched files and installs an `EXIT` trap that `git checkout`s them
  back, so sources are always restored even on failure.
- **Guards the disable actually took effect:** captures `sui move test --list` into a
  variable first (so `sui move test` can't die from SIGPIPE into a `grep -q`, which under
  `set -euo pipefail` would mask a match and silently skip the guard), then greps for
  `_differential_tests::` / the named tests. If any survive, it fails loudly instead of
  hanging for 40 minutes.
- Runs `sui move test --trace --rand-num-iters 1`.

The block is a no-op for packages that contain none of these tests, so it stays a single
bulk traced run everywhere — no per-package branching in the matrix.

The correctness proofs are unaffected in CI: they still run (untraced) in the fast `test`
job, which is the actual regression gate. **Only their line coverage is dropped from the
report, and every code path they touch is already exercised by other tests in the same
package (abort, comparator, `large_n`, membership/ordering suites for `collections`; the
deterministic sort/partition suites for `math/core`), so the coverage delta is negligible.**

## Notes / trade-offs

- **Coverage impact:** only lines exercised *exclusively* by the disabled tests are dropped
  from lcov — effectively none, given overlapping tests.
- **Restore safety:** sources are restored via an `EXIT`-trap `git checkout`; the CI
  checkout is ephemeral regardless.
- **Robustness:** the post-edit `--list` assertion turns any future breakage (e.g. attribute
  reformatting that dodges the regex) into an immediate, clear failure rather than a
  40-minute hang.
- **Adding more heavy tests:** append the test name to the `heavy_tests` alternation; new
  tests inside a `*_differential_tests` module are picked up automatically.

## Alternatives considered

- **Per-test traced loop** (`--list` minus the heavy tests): works because traces accumulate
  across runs, but ~150 invocations per package and slower.
- **`#[mode]` gating:** the clean long-term fix, but requires Sui to support it (no-op in
  `1.75.2`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Temporarily excludes a set of resource-intensive differential and other heavy tests during traced coverage runs (including full `*_differential_tests` modules plus specific named cases).
  * Adds a verification step to ensure the excluded tests no longer appear in the test listing before continuing.
  * Automatically restores any modified test sources after the run to keep the repository unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
