### PR TITLE
docs: add maintenance status disclaimers to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ longer be upgraded by OpenZeppelin or anyone else.
 ## Security
 
 This project was built by OpenZeppelin with the goal of providing a secure and reliable library of smart contract components
-for the Sui ecosystem. We address security through risk management in various areas such as engineering and open source best
+for the Sui ecosystem. We addressed security through risk management in various areas such as engineering and open-source best
 practices, scoping and API design, multi-layered review processes, and incident response preparedness.
 
 Refer to [SECURITY.md](SECURITY.md) for more details.

--- a/README.md
+++ b/README.md
@@ -48,9 +48,19 @@ differences in the Sui architecture and Move language capabilities, certain
 features and implementations may differ from their counterparts in other
 ecosystems.
 
+## Project Status
+
+This library is open source and available to use, but is no longer under
+active maintenance. No new features, bug fixes, or updates should be
+expected on existing releases.
+
+The `UpgradeCap` for packages published to the Move Registry
+under `@openzeppelin-move/*` has been made immutable, so these packages can no
+longer be upgraded by OpenZeppelin or anyone else.
+
 ## Security
 
-This project is maintained by OpenZeppelin with the goal of providing a secure and reliable library of smart contract components
+This project was built by OpenZeppelin with the goal of providing a secure and reliable library of smart contract components
 for the Sui ecosystem. We address security through risk management in various areas such as engineering and open source best
 practices, scoping and API design, multi-layered review processes, and incident response preparedness.
 

--- a/contracts/access/README.md
+++ b/contracts/access/README.md
@@ -1,7 +1,7 @@
 # `openzeppelin_access`
 
 > This package is open-source and not actively maintained.
-
+>
 > The `UpgradeCap` for packages published to the Move Registry under `@openzeppelin-move/*` has been made immutable, so these packages can no longer be upgraded by OpenZeppelin or anyone else.
 
 Role-based authorization and controlled ownership-transfer primitives for Sui Move protocols.

--- a/contracts/access/README.md
+++ b/contracts/access/README.md
@@ -1,5 +1,9 @@
 # `openzeppelin_access`
 
+> This package is open-source and not actively maintained.
+
+> The `UpgradeCap` for packages published to the Move Registry under `@openzeppelin-move/*` has been made immutable, so these packages can no longer be upgraded by OpenZeppelin or anyone else.
+
 Role-based authorization and controlled ownership-transfer primitives for Sui Move protocols.
 
 The `openzeppelin_access` package helps protocols protect privileged functions, shared state, admin capabilities, treasury capabilities, and governance-controlled operations.

--- a/contracts/allowance/README.md
+++ b/contracts/allowance/README.md
@@ -1,5 +1,10 @@
 # `openzeppelin_allowance`
 
+> This release has been professionally audited. See the security audit report in
+`audits/`.
+
+> It is available as open source code in this repository but is **not published to the Move Registry (MVR)** by OpenZeppelin. To use it, add this repository as a Move dependency directly in `Move.toml` (or vendor the source) rather than resolving it via `mvr add`. If you'd like to consume it via MVR, you can publish and register this package to the registry yourself under your own namespace.
+
 Capability-keyed, multi-coin spending allowances for Sui: an owner funds a shared vault and grants bounded, optionally expiring, revocable spend authority that delegates draw on demand, without giving up custody and without signing each spend.
 
 The `openzeppelin_allowance` package lets a treasury, protocol, or wallet delegate "you may spend up to X of coin T" to another party (an address, a keeper service, an embedded protocol record) while keeping the funds, the ability to raise or lower the budget at any time, and a one-call kill switch.

--- a/contracts/allowance/README.md
+++ b/contracts/allowance/README.md
@@ -2,8 +2,8 @@
 
 > This release has been professionally audited. See the security audit report in
 `audits/`.
-
-> It is available as open source code in this repository but is **not published to the Move Registry (MVR)** by OpenZeppelin. To use it, add this repository as a Move dependency directly in `Move.toml` (or vendor the source) rather than resolving it via `mvr add`. If you'd like to consume it via MVR, you can publish and register this package to the registry yourself under your own namespace.
+>
+> It is available as open-source code in this repository but is **not published to the Move Registry (MVR)** by OpenZeppelin. To use it, add this repository as a Move dependency directly in `Move.toml` (or vendor the source) rather than resolving it via `mvr add`. If you'd like to consume it via MVR, you can publish and register this package to the registry yourself under your own namespace.
 
 Capability-keyed, multi-coin spending allowances for Sui: an owner funds a shared vault and grants bounded, optionally expiring, revocable spend authority that delegates draw on demand, without giving up custody and without signing each spend.
 

--- a/contracts/allowance/README.md
+++ b/contracts/allowance/README.md
@@ -1,5 +1,7 @@
 # `openzeppelin_allowance`
 
+> This package is open-source and not actively maintained.
+>
 > This release has been professionally audited. See the security audit report in
 `audits/`.
 >

--- a/contracts/finance/README.md
+++ b/contracts/finance/README.md
@@ -1,5 +1,10 @@
 # `openzeppelin_finance`
 
+> This release has been professionally audited. See the security audit report in
+`audits/`.
+
+> It is available as open source code in this repository but is **not published to the Move Registry (MVR)** by OpenZeppelin. To use it, add this repository as a Move dependency directly in `Move.toml` (or vendor the source) rather than resolving it via `mvr add`. If you'd like to consume it via MVR, you can publish and register this package to the registry yourself under your own namespace.
+
 Vesting primitives for releasing a locked coin to a beneficiary over time.
 
 The `openzeppelin_finance` package locks a `Balance<C>` for a single beneficiary

--- a/contracts/finance/README.md
+++ b/contracts/finance/README.md
@@ -1,5 +1,7 @@
 # `openzeppelin_finance`
 
+> This package is open-source and not actively maintained.
+>
 > This release has been professionally audited. See the security audit report in
 `audits/`.
 >

--- a/contracts/finance/README.md
+++ b/contracts/finance/README.md
@@ -2,8 +2,8 @@
 
 > This release has been professionally audited. See the security audit report in
 `audits/`.
-
-> It is available as open source code in this repository but is **not published to the Move Registry (MVR)** by OpenZeppelin. To use it, add this repository as a Move dependency directly in `Move.toml` (or vendor the source) rather than resolving it via `mvr add`. If you'd like to consume it via MVR, you can publish and register this package to the registry yourself under your own namespace.
+>
+> It is available as open-source code in this repository but is **not published to the Move Registry (MVR)** by OpenZeppelin. To use it, add this repository as a Move dependency directly in `Move.toml` (or vendor the source) rather than resolving it via `mvr add`. If you'd like to consume it via MVR, you can publish and register this package to the registry yourself under your own namespace.
 
 Vesting primitives for releasing a locked coin to a beneficiary over time.
 

--- a/contracts/sale/README.md
+++ b/contracts/sale/README.md
@@ -1,5 +1,7 @@
 # `openzeppelin_sale`
 
+> This package is open-source and not actively maintained.
+>
 > This release has been professionally audited. See the security audit report in
 `audits/`.
 >

--- a/contracts/sale/README.md
+++ b/contracts/sale/README.md
@@ -2,8 +2,8 @@
 
 > This release has been professionally audited. See the security audit report in
 `audits/`.
-
-> It is available as open source code in this repository but is **not published to the Move Registry (MVR)** by OpenZeppelin. To use it, add this repository as a Move dependency directly in `Move.toml` (or vendor the source) rather than resolving it via `mvr add`. If you'd like to consume it via MVR, you can publish and register this package to the registry yourself under your own namespace.
+>
+> It is available as open-source code in this repository but is **not published to the Move Registry (MVR)** by OpenZeppelin. To use it, add this repository as a Move dependency directly in `Move.toml` (or vendor the source) rather than resolving it via `mvr add`. If you'd like to consume it via MVR, you can publish and register this package to the registry yourself under your own namespace.
 
 Fixed-price, pre-funded token sales (presale / IDO) for Sui.
 

--- a/contracts/sale/README.md
+++ b/contracts/sale/README.md
@@ -1,5 +1,10 @@
 # `openzeppelin_sale`
 
+> This release has been professionally audited. See the security audit report in
+`audits/`.
+
+> It is available as open source code in this repository but is **not published to the Move Registry (MVR)** by OpenZeppelin. To use it, add this repository as a Move dependency directly in `Move.toml` (or vendor the source) rather than resolving it via `mvr add`. If you'd like to consume it via MVR, you can publish and register this package to the registry yourself under your own namespace.
+
 Fixed-price, pre-funded token sales (presale / IDO) for Sui.
 
 The `openzeppelin_sale` package runs a token sale against a **fixed, pre-deposited

--- a/contracts/timelock/README.md
+++ b/contracts/timelock/README.md
@@ -2,8 +2,8 @@
 
 > This release has been professionally audited. See the security audit report in
 `audits/`.
-
-> It is available as open source code in this repository but is **not published to the Move Registry (MVR)** by OpenZeppelin. To use it, add this repository as a Move dependency directly in `Move.toml` (or vendor the source) rather than resolving it via `mvr add`. If you'd like to consume it via MVR, you can publish and register this package to the registry yourself under your own namespace.
+>
+> It is available as open-source code in this repository but is **not published to the Move Registry (MVR)** by OpenZeppelin. To use it, add this repository as a Move dependency directly in `Move.toml` (or vendor the source) rather than resolving it via `mvr add`. If you'd like to consume it via MVR, you can publish and register this package to the registry yourself under your own namespace.
 
 A delayed-operation controller for Sui - a Sui-native take on OpenZeppelin's `TimelockController`. It enforces a minimum on-chain delay between *scheduling* a privileged operation and *executing* it, giving users a window to react before the change takes effect.
 

--- a/contracts/timelock/README.md
+++ b/contracts/timelock/README.md
@@ -1,5 +1,10 @@
 # `openzeppelin_timelock`
 
+> This release has been professionally audited. See the security audit report in
+`audits/`.
+
+> It is available as open source code in this repository but is **not published to the Move Registry (MVR)** by OpenZeppelin. To use it, add this repository as a Move dependency directly in `Move.toml` (or vendor the source) rather than resolving it via `mvr add`. If you'd like to consume it via MVR, you can publish and register this package to the registry yourself under your own namespace.
+
 A delayed-operation controller for Sui - a Sui-native take on OpenZeppelin's `TimelockController`. It enforces a minimum on-chain delay between *scheduling* a privileged operation and *executing* it, giving users a window to react before the change takes effect.
 
 Operations carry typed parameters stored on-chain, and an integration binds to a specific timelock through a stored `OperationCap`, so the canonical-timelock check is enforced by the library rather than by hand-written asserts. Execution returns the typed params through a no-ability `ExecutionTicket<Action, Params>` hot potato that the consumer redeems in the same transaction. Roles come from a hard dependency on `openzeppelin_access`.

--- a/contracts/timelock/README.md
+++ b/contracts/timelock/README.md
@@ -13,7 +13,7 @@ Operations carry typed parameters stored on-chain, and an integration binds to a
 
 ```toml
 [dependencies]
-openzeppelin_timelock = { r.mvr = "@openzeppelin-move/timelock" }
+openzeppelin_sale = { git = "https://github.com/OpenZeppelin/contracts-sui.git", subdir = "contracts/timelock", rev = "v1.5.1" }
 ```
 
 ## Module Snapshot

--- a/contracts/timelock/README.md
+++ b/contracts/timelock/README.md
@@ -1,5 +1,7 @@
 # `openzeppelin_timelock`
 
+> This package is open-source and not actively maintained.
+>
 > This release has been professionally audited. See the security audit report in
 `audits/`.
 >

--- a/contracts/utils/README.md
+++ b/contracts/utils/README.md
@@ -1,5 +1,9 @@
 # `openzeppelin_utils`
 
+> This package is open-source and not actively maintained.
+
+> The `UpgradeCap` for packages published to the Move Registry under `@openzeppelin-move/*` has been made immutable, so these packages can no longer be upgraded by OpenZeppelin or anyone else.
+
 Embeddable primitives for Sui smart contract development.
 
 ## Install

--- a/contracts/utils/README.md
+++ b/contracts/utils/README.md
@@ -1,7 +1,7 @@
 # `openzeppelin_utils`
 
 > This package is open-source and not actively maintained.
-
+>
 > The `UpgradeCap` for packages published to the Move Registry under `@openzeppelin-move/*` has been made immutable, so these packages can no longer be upgraded by OpenZeppelin or anyone else.
 
 Embeddable primitives for Sui smart contract development.

--- a/math/core/README.md
+++ b/math/core/README.md
@@ -1,5 +1,9 @@
 # `openzeppelin_math`
 
+> This package is open-source and not actively maintained.
+
+> The `UpgradeCap` for packages published to the Move Registry under `@openzeppelin-move/*` has been made immutable, so these packages can no longer be upgraded by OpenZeppelin or anyone else.
+
 Overflow-safe arithmetic helpers for unsigned integers with configurable rounding.
 
 ## Install

--- a/math/core/README.md
+++ b/math/core/README.md
@@ -1,7 +1,7 @@
 # `openzeppelin_math`
 
 > This package is open-source and not actively maintained.
-
+>
 > The `UpgradeCap` for packages published to the Move Registry under `@openzeppelin-move/*` has been made immutable, so these packages can no longer be upgraded by OpenZeppelin or anyone else.
 
 Overflow-safe arithmetic helpers for unsigned integers with configurable rounding.

--- a/math/fixed_point/README.md
+++ b/math/fixed_point/README.md
@@ -1,7 +1,7 @@
 # `openzeppelin_fp_math`
 
 > This package is open-source and not actively maintained.
-
+>
 > The `UpgradeCap` for packages published to the Move Registry under `@openzeppelin-move/*` has been made immutable, so these packages can no longer be upgraded by OpenZeppelin or anyone else.
 
 Fixed-point decimal types with 9 decimals (10^9), matching Sui coin precision.

--- a/math/fixed_point/README.md
+++ b/math/fixed_point/README.md
@@ -1,5 +1,9 @@
 # `openzeppelin_fp_math`
 
+> This package is open-source and not actively maintained.
+
+> The `UpgradeCap` for packages published to the Move Registry under `@openzeppelin-move/*` has been made immutable, so these packages can no longer be upgraded by OpenZeppelin or anyone else.
+
 Fixed-point decimal types with 9 decimals (10^9), matching Sui coin precision.
 
 ## Install


### PR DESCRIPTION
Adds a maintenance-status disclaimer to the root README and each package README.

The disclaimer notes that this library is open source and available to use, but is no longer under active maintenance, and that the `UpgradeCap` for packages published to the Move Registry under `@openzeppelin-move/*` has been made immutable, so these packages can no longer be upgraded by OpenZeppelin or anyone else.

Packages that ship a professional audit report (`allowance`, `finance`, `timelock`) instead note that they are not published to MVR by OpenZeppelin, and should be added as a direct Move dependency (or vendored) rather than resolved via `mvr add`.

#### PR Checklist

- [ ] Tests — N/A, README-only change
- [x] Documentation
- [ ] Changelog — N/A, status notice rather than a library behavior change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added “Project Status” and introductory notices that the libraries are open source but not actively maintained.
  * Clarified package governance: upgrade capabilities for registry-published `@openzeppelin-move/*` packages are immutable.
  * Reframed the security/maintenance messaging to a more explicit risk-management tone.
  * Documented professional audits and added links/pointers to audit materials.
  * For select packages, clarified they aren’t published via the Move Registry and provided direct dependency/vendoring guidance (and namespace notes for publishing/registration).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->