### PR TITLE
docs: add maintenance status disclaimer to collections + make all disclaimers into warnings

### DIFF
--- a/collections/README.md
+++ b/collections/README.md
@@ -20,10 +20,6 @@ The ordered-collections family for Sui Move: two modules for ordered key/value a
 openzeppelin_collections = { git = "https://github.com/OpenZeppelin/contracts-sui.git", subdir = "contracts/collections", rev = "v1.5.1" }
 ```
 
-> [!NOTE]
-> `openzeppelin_collections` is **not yet published** to the Move Registry. The handle above
-> is the intended install form once released; until then, vendor the package from source.
-
 ## Modules
 
 | Module | Summary |

--- a/collections/README.md
+++ b/collections/README.md
@@ -17,10 +17,12 @@ The ordered-collections family for Sui Move: two modules for ordered key/value a
 
 ```toml
 [dependencies]
-openzeppelin_collections = { r.mvr = "@openzeppelin-move/collections" }
+openzeppelin_collections = { git = "https://github.com/OpenZeppelin/contracts-sui.git", subdir = "contracts/collections", rev = "v1.5.1" }
 ```
 
-Consumers write `use openzeppelin_collections::sorted_map;` (or `::sorted_set`) and install this one package.
+> [!NOTE]
+> `openzeppelin_collections` is **not yet published** to the Move Registry. The handle above
+> is the intended install form once released; until then, vendor the package from source.
 
 ## Modules
 

--- a/collections/README.md
+++ b/collections/README.md
@@ -1,5 +1,12 @@
 # `openzeppelin_collections`
 
+> This package is open-source and not actively maintained.
+>
+> This release has been professionally audited. See the security audit report in
+`audits/`.
+>
+> It is available as open-source code in this repository but is **not published to the Move Registry (MVR)** by OpenZeppelin. To use it, add this repository as a Move dependency directly in `Move.toml` (or vendor the source) rather than resolving it via `mvr add`. If you'd like to consume it via MVR, you can publish and register this package to the registry yourself under your own namespace.
+
 The ordered-collections family for Sui Move: two modules for ordered key/value and set data that share one comparator model and a parallel API. Reach for the single-object `sorted_map` (an ordered `SortedMap<K, V>` over one sorted vector) for key/value data, or its set counterpart `sorted_set` for ordered membership. Both read in key order - head/tail, floor/ceiling, next key, sorted pages - not just point lookups.
 
 > [!WARNING]

--- a/collections/README.md
+++ b/collections/README.md
@@ -1,5 +1,6 @@
 # `openzeppelin_collections`
 
+> [!WARNING]
 > This package is open-source and not actively maintained.
 >
 > This release has been professionally audited. See the security audit report in

--- a/contracts/access/README.md
+++ b/contracts/access/README.md
@@ -1,5 +1,6 @@
 # `openzeppelin_access`
 
+> [!WARNING]
 > This package is open-source and not actively maintained.
 >
 > The `UpgradeCap` for packages published to the Move Registry under `@openzeppelin-move/*` has been made immutable, so these packages can no longer be upgraded by OpenZeppelin or anyone else.

--- a/contracts/allowance/README.md
+++ b/contracts/allowance/README.md
@@ -1,5 +1,6 @@
 # `openzeppelin_allowance`
 
+> [!WARNING]
 > This package is open-source and not actively maintained.
 >
 > This release has been professionally audited. See the security audit report in

--- a/contracts/allowance/README.md
+++ b/contracts/allowance/README.md
@@ -15,7 +15,18 @@ The `openzeppelin_allowance` package lets a treasury, protocol, or wallet delega
 > [!WARNING]
 > A `SpenderCap` is a **bearer instrument**: whoever can present it to `spend` exercises the full authority of every budget it keys, up to each budget's limit. The library never checks who holds or presents a cap. Any protocol that custodies a cap MUST sender-gate the function that borrows it, and MUST validate the cap's vault binding before accepting it. See [Security Notes](#security-notes).
 
-## Module Snapshot
+## Install
+
+```toml
+[dependencies]
+openzeppelin_allowance = { git = "https://github.com/OpenZeppelin/contracts-sui.git", subdir = "contracts/allowance", rev = "v1.5.1" }
+```
+
+> [!NOTE]
+> `openzeppelin_allowance` is **not yet published** to the Move Registry. The handle above
+> is the intended install form once released; until then, vendor the package from source.
+
+## Modules
 
 | Module | Summary |
 |--------|---------|

--- a/contracts/allowance/README.md
+++ b/contracts/allowance/README.md
@@ -22,10 +22,6 @@ The `openzeppelin_allowance` package lets a treasury, protocol, or wallet delega
 openzeppelin_allowance = { git = "https://github.com/OpenZeppelin/contracts-sui.git", subdir = "contracts/allowance", rev = "v1.5.1" }
 ```
 
-> [!NOTE]
-> `openzeppelin_allowance` is **not yet published** to the Move Registry. The handle above
-> is the intended install form once released; until then, vendor the package from source.
-
 ## Modules
 
 | Module | Summary |

--- a/contracts/finance/README.md
+++ b/contracts/finance/README.md
@@ -24,9 +24,8 @@ openzeppelin_finance = { git = "https://github.com/OpenZeppelin/contracts-sui.gi
 ```
 
 > [!NOTE]
-> `openzeppelin_finance` is **not yet published** to the Move Registry. The handle above
-> is the intended install form once released; until then, vendor the package from
-> source. It depends on [`openzeppelin_math`](../../math/core) for the linear vesting calculation.
+> `openzeppelin_finance` depends on [`openzeppelin_math`](../../math/core) for the
+> linear vesting calculation.
 
 ## Modules
 

--- a/contracts/finance/README.md
+++ b/contracts/finance/README.md
@@ -16,6 +16,18 @@ conservation of funds; the curve - linear, stepped, cliff, or a custom shape you
 write - is a separate, swappable concern. Use it for token grants, team and investor
 vesting, payroll streams, and emission schedules.
 
+## Install
+
+```toml
+[dependencies]
+openzeppelin_finance = { git = "https://github.com/OpenZeppelin/contracts-sui.git", subdir = "contracts/finance", rev = "v1.5.1" }
+```
+
+> [!NOTE]
+> `openzeppelin_finance` is **not yet published** to the Move Registry. The handle above
+> is the intended install form once released; until then, vendor the package from
+> source. It depends on [`openzeppelin_math`](../../math/core) for the linear vesting calculation.
+
 ## Modules
 
 | Module | Use it when |

--- a/contracts/finance/README.md
+++ b/contracts/finance/README.md
@@ -1,5 +1,6 @@
 # `openzeppelin_finance`
 
+> [!WARNING]
 > This package is open-source and not actively maintained.
 >
 > This release has been professionally audited. See the security audit report in

--- a/contracts/sale/README.md
+++ b/contracts/sale/README.md
@@ -38,9 +38,8 @@ openzeppelin_sale = { git = "https://github.com/OpenZeppelin/contracts-sui.git",
 ```
 
 > [!NOTE]
-> `openzeppelin_sale` is **not yet published** to the Move Registry. The handle above
-> is the intended install form once released; until then, vendor the package from
-> source. It depends on [`openzeppelin_finance`](../finance) for the vesting path.
+> `openzeppelin_sale` depends on [`openzeppelin_finance`](../finance) for the vesting
+> path.
 
 ## Modules
 

--- a/contracts/sale/README.md
+++ b/contracts/sale/README.md
@@ -1,5 +1,6 @@
 # `openzeppelin_sale`
 
+> [!WARNING]
 > This package is open-source and not actively maintained.
 >
 > This release has been professionally audited. See the security audit report in

--- a/contracts/timelock/README.md
+++ b/contracts/timelock/README.md
@@ -16,10 +16,14 @@ Operations carry typed parameters stored on-chain, and an integration binds to a
 
 ```toml
 [dependencies]
-openzeppelin_sale = { git = "https://github.com/OpenZeppelin/contracts-sui.git", subdir = "contracts/timelock", rev = "v1.5.1" }
+openzeppelin_timelock = { git = "https://github.com/OpenZeppelin/contracts-sui.git", subdir = "contracts/timelock", rev = "v1.5.1" }
 ```
 
-## Module Snapshot
+> [!NOTE]
+> `openzeppelin_timelock` depends on [`openzeppelin_access`](../access) for role-based
+> authorization.
+
+## Modules
 
 | Module | Summary |
 |--------|---------|

--- a/contracts/timelock/README.md
+++ b/contracts/timelock/README.md
@@ -1,5 +1,6 @@
 # `openzeppelin_timelock`
 
+> [!WARNING]
 > This package is open-source and not actively maintained.
 >
 > This release has been professionally audited. See the security audit report in

--- a/contracts/utils/README.md
+++ b/contracts/utils/README.md
@@ -14,7 +14,7 @@ Embeddable primitives for Sui smart contract development.
 openzeppelin_utils = { r.mvr = "@openzeppelin-move/utils" }
 ```
 
-## Module Snapshot
+## Modules
 
 | Module | Summary |
 |--------|---------|

--- a/contracts/utils/README.md
+++ b/contracts/utils/README.md
@@ -1,5 +1,6 @@
 # `openzeppelin_utils`
 
+> [!WARNING]
 > This package is open-source and not actively maintained.
 >
 > The `UpgradeCap` for packages published to the Move Registry under `@openzeppelin-move/*` has been made immutable, so these packages can no longer be upgraded by OpenZeppelin or anyone else.

--- a/math/core/README.md
+++ b/math/core/README.md
@@ -1,5 +1,6 @@
 # `openzeppelin_math`
 
+> [!WARNING]
 > This package is open-source and not actively maintained.
 >
 > The `UpgradeCap` for packages published to the Move Registry under `@openzeppelin-move/*` has been made immutable, so these packages can no longer be upgraded by OpenZeppelin or anyone else.

--- a/math/fixed_point/README.md
+++ b/math/fixed_point/README.md
@@ -1,5 +1,6 @@
 # `openzeppelin_fp_math`
 
+> [!WARNING]
 > This package is open-source and not actively maintained.
 >
 > The `UpgradeCap` for packages published to the Move Registry under `@openzeppelin-move/*` has been made immutable, so these packages can no longer be upgraded by OpenZeppelin or anyone else.

--- a/math/fixed_point/README.md
+++ b/math/fixed_point/README.md
@@ -15,7 +15,7 @@ openzeppelin_fp_math = { r.mvr = "@openzeppelin-move/fixed-point-math" }
 ```
 
 > [!NOTE]
-> `openzeppelin_fp_math` depends on [`@openzeppelin-move/integer-math`](https://www.moveregistry.com/package/@openzeppelin-move/integer-math) for rounding modes
+> `openzeppelin_fp_math` depends on [`openzeppelin_math`](../core) for rounding modes
 > and widened integer arithmetic.
 
 ## Types

--- a/math/fixed_point/README.md
+++ b/math/fixed_point/README.md
@@ -14,6 +14,10 @@ Fixed-point decimal types with 9 decimals (10^9), matching Sui coin precision.
 openzeppelin_fp_math = { r.mvr = "@openzeppelin-move/fixed-point-math" }
 ```
 
+> [!NOTE]
+> `openzeppelin_fp_math` depends on [`@openzeppelin-move/integer-math`](https://www.moveregistry.com/package/@openzeppelin-move/integer-math) for rounding modes
+> and widened integer arithmetic.
+
 ## Types
 
 - `UD30x9`: Unsigned decimal fixed-point (internal: 0 to 2^128 - 1; decimal: 0 to ~3.4e29)


### PR DESCRIPTION
Related #520 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added prominent warning callouts at the top of multiple package READMEs to clarify open-source status and maintenance expectations.
  * Expanded installation guidance with clearer `Move.toml` snippets, including updated notes about registry usage and direct git-based installation where applicable.
  * Added/updated notes describing dependency relationships between related packages (e.g., vesting/math/tooling links).
  * Refreshed README section headings to better match module/install structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->